### PR TITLE
refactor(backend): unify property access resolution and setter self-store lifecycle

### DIFF
--- a/doc/gdcc_c_backend.md
+++ b/doc/gdcc_c_backend.md
@@ -64,7 +64,7 @@
 ### Slot Write Consolidation
 
 - Keep object and non-object slot writes separated by semantics: 
-  - Objects follow ownership rules (`release old -> assign(convert ptr if needed) -> own only for BORROWED`).
+  - Objects follow ownership rules (`capture old -> assign(convert ptr if needed) -> own only for BORROWED -> release captured old`).
   - Non-objects follow value-lifecycle rules (`prepare/copy rhs -> destroy old (if needed) -> assign`).
 - For non-object writes, prefer a single Builder helper (for example `emitNonObjectSlotWrite`) used by both `assignVar` and `callAssign` result assignment paths.
 - The consolidation above is a maintenance refactor only:

--- a/doc/gdcc_ownership_lifecycle_spec.md
+++ b/doc/gdcc_ownership_lifecycle_spec.md
@@ -53,12 +53,13 @@ A writable storage location, including but not limited to:
 
 Writing any object value into a slot must follow this order:
 
-1. If the slot is initialized and has an old value, release the old value first (`release` or `try_release` variant).
+1. If the slot is initialized and has an old value, capture the old value into a temporary slot.
 2. Write the new value (including pointer representation conversion if needed).
 3. Decide whether to `own` based on RHS ownership:
    - RHS is `BORROWED`: must `own` the new value.
    - RHS is `OWNED`: must not `own` again; consume ownership directly.
-4. Mark the slot as initialized.
+4. Release the captured old value (`release` or `try_release` variant).
+5. Mark the slot as initialized.
 
 Implementation note:
 

--- a/doc/module_impl/cbodybuilder_implemention.md
+++ b/doc/module_impl/cbodybuilder_implemention.md
@@ -8,7 +8,7 @@
 >
 > 目标：仅保留当前代码库已落地且可验证的实现语义、长期风险和工程反思。
 >
-> 校对基线：2026-02-24（代码与单测已交叉检查）
+> 校对基线：2026-02-25（代码与单测已交叉检查）
 
 ## 1. 范围与对齐关系
 
@@ -26,10 +26,11 @@
 ### 2.1 统一槽位写入模型
 
 - 对象类型写入统一走 `emitObjectSlotWrite(...)`，顺序固定：
-  1. 可覆盖时先 release old（`release_object` / `try_release_object` / no-op）
+  1. 可覆盖时先 capture old 到对象 temp（`__gdcc_tmp_old_obj_*`）
   2. 必要时做指针表示转换
   3. 赋值
   4. RHS 为 `BORROWED` 时 own new；RHS 为 `OWNED` 时消费所有权，不重复 own
+  5. release captured old（`release_object` / `try_release_object` / no-op）
 - 非对象类型写入统一走 `emitNonObjectSlotWrite(...)`：
   1. 满足条件时 destroy old（`destroyOldValue && !__prepare__ && type.isDestroyable()`）
   2. 赋值
@@ -105,11 +106,13 @@
 
 ### 7.1 `StorePropertyInsnGen` 的 setter-self 直写路径
 
-- 现状：在 setter-self 分支中直接生成 `$self->field = rhs;`，绕过 Builder 槽位写入入口。
-- 影响：
-  - 生命周期正确性依赖外部 IR 是否补充配套指令。
-  - 对可析构非对象字段（如 String）存在旧值清理风险，需要额外审计。
-- 建议：将该分支收敛到 Builder 统一槽位写入语义，或在 IR 生成阶段强约束配套指令与顺序。
+- 现状：setter-self 分支已收敛到 `assignVar(targetOfExpr(...), valueOfVar(...))`，
+  通过 Builder 统一槽位写入语义处理生命周期和指针转换。
+- 收敛收益：
+  - 不再需要在生成器里手工拼接 own/release。
+  - 对象写槽顺序与 `assignVar` / `callAssign` / `_return_val` 保持一致。
+- 仍需关注：
+  - 模板层和 Java 层双轨演进时，需持续做语义对齐回归。
 
 ### 7.2 FTL 与 Java 路径演进偏差风险
 
@@ -131,9 +134,14 @@
 ./gradlew.bat classes --no-daemon --info --console=plain
 ```
 
+关键顺序断言（对象写槽）已按以下语义更新：
+
+- `capture old -> assign(convert if needed) -> own(BORROWED only) -> release captured old`
+
 ## 9. 工程反思（保留可复用教训）
 
 1. 指针转换规则分散在调用点时，最容易出现 `NULL->_object`、遗漏转换、断言漂移等问题；必须集中到单点 helper + Builder 自动转换。
 2. 迁移文档混合“待办清单”和“已完成记录”会快速失真；实现文档应只保留当前事实，历史过程归档到提交记录。
 3. 生命周期规则若在模板和 Java 两侧同时手写，长期一定发生语义偏差；应尽可能由单一入口承载。
-4. 单元测试不应只断言“有某个函数名”，还要断言关键顺序（release -> assign -> own）与负向约束（不重复 own、不错误转换）。
+4. 单元测试不应只断言“有某个函数名”，还要断言关键顺序
+   （capture old -> assign -> own -> release old）与负向约束（不重复 own、不错误转换）。

--- a/doc/module_impl/cbodybuilder_implemention.md
+++ b/doc/module_impl/cbodybuilder_implemention.md
@@ -98,6 +98,8 @@
 - 指令生成器负责 IR 校验与错误定位，不直接复制生命周期策略。
 - 应优先通过 `assignVar` / `assignExpr` / `callAssign` / `callVoid` 交给 Builder 处理生命周期与转换。
 - 对对象类型，避免在生成器中手工拼 own/release 与指针转换逻辑。
+- `ExprTargetRef` / `targetOfExpr(...)` is assignment-only by design.
+  Use it only with `assignVar` / `assignExpr`, not as a generic target for `callAssign` or return/discard paths.
 
 ## 7. 已知风险与后续关注点
 

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
@@ -249,6 +249,14 @@ public final class CBodyBuilder {
         return new VarTargetRef(variable);
     }
 
+    /// Creates an assignment-only target reference from a raw C lvalue expression.
+    ///
+    /// This target is intentionally limited to assignment paths (`assignVar` / `assignExpr`).
+    /// Do not use it for result targets of `callAssign`, return-slot flow, or discard flow.
+    public @NotNull TargetRef targetOfExpr(@NotNull String code, @NotNull GdType type) {
+        return new ExprTargetRef(code, type);
+    }
+
     /// Creates a special target reference that discards call return values.
     public @NotNull DiscardRef discardRef() {
         return DiscardRef.INSTANCE;
@@ -1067,7 +1075,7 @@ public final class CBodyBuilder {
         }
     }
 
-    public sealed interface TargetRef permits VarTargetRef, TempVar, DiscardRef {
+    public sealed interface TargetRef permits VarTargetRef, ExprTargetRef, TempVar, DiscardRef {
         @NotNull GdType type();
 
         @NotNull String generateCode();
@@ -1093,6 +1101,32 @@ public final class CBodyBuilder {
         @Override
         public boolean isRef() {
             return variable.ref();
+        }
+    }
+
+    /// Assignment-only raw lvalue target.
+    ///
+    /// Keep usage scoped to assignment writes so lifecycle and ownership semantics remain
+    /// centralized in assignment APIs, instead of spreading to generic call/return paths.
+    public record ExprTargetRef(@NotNull String code, @NotNull GdType type) implements TargetRef {
+        public ExprTargetRef {
+            Objects.requireNonNull(code);
+            Objects.requireNonNull(type);
+        }
+
+        @Override
+        public @NotNull GdType type() {
+            return type;
+        }
+
+        @Override
+        public @NotNull String generateCode() {
+            return code;
+        }
+
+        @Override
+        public boolean isRef() {
+            return false;
         }
     }
 

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
@@ -406,7 +406,7 @@ public final class CBodyBuilder {
     }
 
     /// Common logic for writing a call expression result into a target variable.
-    /// Handles: old-value destroy/release → ptr conversion → assignment → ownership consume/own → mark initialized.
+    /// Handles: capture old slot value → ptr conversion + assignment → ownership consume/own → release captured old → mark initialized.
     private void emitCallResultAssignment(@NotNull TargetRef target,
                                           @NotNull String cFuncName,
                                           @NotNull GdType returnType,
@@ -795,21 +795,27 @@ public final class CBodyBuilder {
     }
 
     /// Writes an object value into a storage slot with ownership-aware semantics:
-    /// release old (if initialized) → assign converted rhs → own new only for BORROWED rhs.
+    /// capture old (if initialized) → assign converted rhs → own new only for BORROWED rhs → release captured old.
     private void emitObjectSlotWrite(@NotNull String targetCode,
                                      @NotNull GdObjectType targetType,
                                      boolean releaseOldValue,
                                      @NotNull String rhsCode,
                                      @NotNull PtrKind rhsPtrKind,
                                      @NotNull OwnershipKind ownership) {
+        TempVar oldValueTemp = null;
         if (releaseOldValue) {
-            emitReleaseObject(targetCode, targetType);
+            // Capture old value before overwriting slot to keep alias/self-assignment safe.
+            oldValueTemp = newTempVariable("old_obj", targetType, targetCode);
+            declareTempVar(oldValueTemp);
         }
         var assignCode = convertPtrIfNeeded(rhsCode, rhsPtrKind, targetType);
         out.append(targetCode).append(" = ").append(assignCode).append(";\n");
         if (ownership == OwnershipKind.BORROWED) {
             // BORROWED rhs must be retained by the slot after assignment.
             emitOwnObject(targetCode, targetType);
+        }
+        if (oldValueTemp != null) {
+            emitReleaseObject(oldValueTemp.name(), targetType);
         }
     }
 

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
@@ -117,15 +117,7 @@ public class CCodegen implements Codegen {
 
                     var bb = new LirBasicBlock("entry");
                     func.addBasicBlock(bb);
-                    if (propertyDef.getType() instanceof GdObjectType) {
-                        var oldValueVar = func.createAndAddTmpVariable(propertyDef.getType());
-                        bb.instructions().add(new LoadPropertyInsn(oldValueVar.id(), propertyDef.getName(), "self"));
-                        bb.instructions().add(new StorePropertyInsn(propertyDef.getName(), "self", "value"));
-                        bb.instructions().add(new TryOwnObjectInsn("value"));
-                        bb.instructions().add(new TryReleaseObjectInsn(oldValueVar.id()));
-                    } else {
-                        bb.instructions().add(new StorePropertyInsn(propertyDef.getName(), "self", "value"));
-                    }
+                    bb.instructions().add(new StorePropertyInsn(propertyDef.getName(), "self", "value"));
                     bb.instructions().add(new ReturnInsn(null));
                     func.setEntryBlockId("entry");
                     classDef.addFunction(func);

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/LoadPropertyInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/LoadPropertyInsnGen.java
@@ -1,13 +1,9 @@
 package dev.superice.gdcc.backend.c.gen.insn;
 
 import dev.superice.gdcc.backend.c.gen.CBodyBuilder;
-import dev.superice.gdcc.backend.c.gen.CGenHelper;
 import dev.superice.gdcc.backend.c.gen.CInsnGen;
 import dev.superice.gdcc.enums.GdInstruction;
-import dev.superice.gdcc.gdextension.ExtensionBuiltinClass;
-import dev.superice.gdcc.lir.LirFunctionDef;
 import dev.superice.gdcc.lir.insn.LoadPropertyInsn;
-import dev.superice.gdcc.scope.ClassDef;
 import dev.superice.gdcc.scope.PropertyDef;
 import dev.superice.gdcc.type.GdNilType;
 import dev.superice.gdcc.type.GdObjectType;
@@ -51,16 +47,16 @@ public final class LoadPropertyInsnGen implements CInsnGen<LoadPropertyInsn> {
             throw bodyBuilder.invalidInsn("Object variable ID " + insn.objectId() + " is not a valid property target type, but " + objectVar.type().getTypeName());
         }
 
-        var registry = helper.context().classRegistry();
+        var registry = bodyBuilder.classRegistry();
         var propertyType = resolvePropertyType(bodyBuilder, objectVar.type(), resultVar.type(), insn.propertyName());
-        var genMode = getGenMode(helper, func, insn);
+        var genMode = PropertyAccessResolver.resolveGenMode(bodyBuilder, func, insn.objectId(), "LOAD_PROPERTY");
         var target = bodyBuilder.targetOfVar(resultVar);
 
         switch (genMode) {
-            case "gdcc" -> {
+            case GDCC -> {
                 var objectType = (GdObjectType) objectVar.type();
                 var classDef = Objects.requireNonNull(registry.getClassDef(objectType));
-                var propertyDef = Objects.requireNonNull(findPropertyDef(classDef, insn.propertyName()));
+                var propertyDef = Objects.requireNonNull(PropertyAccessResolver.findPropertyDef(classDef, insn.propertyName()));
                 var inGetterSelf = isLoadingInsideGetterSelf(bodyBuilder, insn, propertyDef);
                 if (inGetterSelf) {
                     var expr = "$" + objectVar.id() + "->" + insn.propertyName();
@@ -74,13 +70,13 @@ public final class LoadPropertyInsnGen implements CInsnGen<LoadPropertyInsn> {
                     bodyBuilder.callAssign(target, getterCall, propertyType, List.of(bodyBuilder.valueOfVar(objectVar)));
                 }
             }
-            case "engine" -> {
+            case ENGINE -> {
                 var objectType = (GdObjectType) objectVar.type();
                 var getterName = "godot_" + objectType.getTypeName() + "_get_" + insn.propertyName();
                 var objectValue = bodyBuilder.valueOfVar(objectVar);
                 bodyBuilder.callAssign(target, getterName, propertyType, List.of(objectValue));
             }
-            case "general" -> {
+            case GENERAL -> {
                 // Pass objectVar directly; renderArgument will auto-convert GDCC ptrs
                 // to Godot raw ptrs via godot_object_from_gdcc_object_ptr(...) since godot_Object_get requires Godot ptrs.
                 var objectValue = bodyBuilder.valueOfVar(objectVar);
@@ -93,7 +89,7 @@ public final class LoadPropertyInsnGen implements CInsnGen<LoadPropertyInsn> {
                 bodyBuilder.callAssign(target, unpackFunc, resultType, List.of(tempVar));
                 bodyBuilder.destroyTempVar(tempVar);
             }
-            case "builtin" -> {
+            case BUILTIN -> {
                 var objectType = objectVar.type();
                 var getterName = "godot_" + objectType.getTypeName() + "_get_" + insn.propertyName();
                 var objectValue = bodyBuilder.valueOfVar(objectVar);
@@ -114,7 +110,7 @@ public final class LoadPropertyInsnGen implements CInsnGen<LoadPropertyInsn> {
                 // Unknown object types are read through godot_Object_get and unpacked into the expected result type.
                 return resultType;
             }
-            var propertyFound = findPropertyDef(classDef, propertyName);
+            var propertyFound = PropertyAccessResolver.findPropertyDef(classDef, propertyName);
             if (propertyFound == null) {
                 throw bodyBuilder.invalidInsn("Property '" + propertyName + "' not found in class " + classDef.getName());
             }
@@ -126,47 +122,17 @@ public final class LoadPropertyInsnGen implements CInsnGen<LoadPropertyInsn> {
             return propertyType;
         }
 
-        var builtinClass = registry.findBuiltinClass(objectType.getTypeName());
-        if (builtinClass == null) {
-            throw bodyBuilder.invalidInsn("Builtin class not found for type " + objectType.getTypeName());
-        }
-        ExtensionBuiltinClass.PropertyInfo propertyFound = null;
-        for (var property : builtinClass.getProperties()) {
-            if (property.getName().equals(propertyName)) {
-                propertyFound = (ExtensionBuiltinClass.PropertyInfo) property;
-                break;
-            }
-        }
-        if (propertyFound == null) {
-            throw bodyBuilder.invalidInsn("Property '" + propertyName + "' not found in builtin class " + builtinClass.getName());
-        }
-        if (!propertyFound.isReadable()) {
+        var lookup = PropertyAccessResolver.resolveBuiltinProperty(bodyBuilder, objectType, propertyName);
+        var builtinClass = lookup.builtinClass();
+        if (!lookup.property().isReadable()) {
             throw bodyBuilder.invalidInsn("Property '" + propertyName + "' in builtin class " + builtinClass.getName() + " is not readable");
         }
-        var propertyType = propertyFound.getType();
+        var propertyType = lookup.property().getType();
         if (!registry.checkAssignable(propertyType, resultType)) {
             throw bodyBuilder.invalidInsn("Result type " + resultType.getTypeName() +
                     " is not assignable from property '" + propertyName + "' of type " + propertyType.getTypeName());
         }
         return propertyType;
-    }
-
-    private @NotNull String getGenMode(@NotNull CGenHelper helper,
-                                       @NotNull LirFunctionDef func,
-                                       @NotNull LoadPropertyInsn insn) {
-        var objectVar = Objects.requireNonNull(func.getVariableById(insn.objectId()));
-        if (objectVar.type() instanceof GdObjectType gdObjectType) {
-            if (gdObjectType.checkGdccType(helper.context().classRegistry())) {
-                return "gdcc";
-            } else if (gdObjectType.checkEngineType(helper.context().classRegistry())) {
-                return "engine";
-            } else {
-                return "general";
-            }
-        } else if (objectVar.type() instanceof GdVoidType || objectVar.type() instanceof GdNilType) {
-            throw new IllegalStateException("Invalid object variable type for LOAD_PROPERTY instruction");
-        }
-        return "builtin";
     }
 
     private boolean isLoadingInsideGetterSelf(@NotNull CBodyBuilder bodyBuilder,
@@ -195,12 +161,4 @@ public final class LoadPropertyInsnGen implements CInsnGen<LoadPropertyInsn> {
         return false;
     }
 
-    private PropertyDef findPropertyDef(@NotNull ClassDef classDef, @NotNull String propertyName) {
-        for (var property : classDef.getProperties()) {
-            if (property.getName().equals(propertyName)) {
-                return property;
-            }
-        }
-        return null;
-    }
 }

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/PropertyAccessResolver.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/PropertyAccessResolver.java
@@ -1,0 +1,87 @@
+package dev.superice.gdcc.backend.c.gen.insn;
+
+import dev.superice.gdcc.backend.c.gen.CBodyBuilder;
+import dev.superice.gdcc.gdextension.ExtensionBuiltinClass;
+import dev.superice.gdcc.lir.LirFunctionDef;
+import dev.superice.gdcc.scope.ClassDef;
+import dev.superice.gdcc.scope.PropertyDef;
+import dev.superice.gdcc.type.GdNilType;
+import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdType;
+import dev.superice.gdcc.type.GdVoidType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/// Shared resolver for load/store property codegen.
+///
+/// Responsibilities:
+/// - Resolve property access generation mode for a receiver variable.
+/// - Resolve GDCC/engine property definitions from class metadata.
+/// - Resolve builtin property metadata from extension API metadata.
+final class PropertyAccessResolver {
+    private PropertyAccessResolver() {
+    }
+
+    enum GenMode {
+        GDCC,
+        ENGINE,
+        GENERAL,
+        BUILTIN
+    }
+
+    record BuiltinPropertyLookup(@NotNull ExtensionBuiltinClass builtinClass,
+                                 @NotNull ExtensionBuiltinClass.PropertyInfo property) {
+        BuiltinPropertyLookup {
+            Objects.requireNonNull(builtinClass);
+            Objects.requireNonNull(property);
+        }
+    }
+
+    static @NotNull GenMode resolveGenMode(@NotNull CBodyBuilder bodyBuilder,
+                                           @NotNull LirFunctionDef func,
+                                           @NotNull String objectId,
+                                           @NotNull String insnName) {
+        var objectVar = Objects.requireNonNull(func.getVariableById(objectId));
+        if (objectVar.type() instanceof GdObjectType gdObjectType) {
+            if (gdObjectType.checkGdccType(bodyBuilder.classRegistry())) {
+                return GenMode.GDCC;
+            }
+            if (gdObjectType.checkEngineType(bodyBuilder.classRegistry())) {
+                return GenMode.ENGINE;
+            }
+            return GenMode.GENERAL;
+        }
+        if (objectVar.type() instanceof GdVoidType || objectVar.type() instanceof GdNilType) {
+            throw new IllegalStateException("Invalid object variable type for " + insnName + " instruction");
+        }
+        return GenMode.BUILTIN;
+    }
+
+    static @Nullable PropertyDef findPropertyDef(@NotNull ClassDef classDef, @NotNull String propertyName) {
+        for (var property : classDef.getProperties()) {
+            if (property.getName().equals(propertyName)) {
+                return property;
+            }
+        }
+        return null;
+    }
+
+    static @NotNull BuiltinPropertyLookup resolveBuiltinProperty(@NotNull CBodyBuilder bodyBuilder,
+                                                                 @NotNull GdType objectType,
+                                                                 @NotNull String propertyName) {
+        var builtinClass = bodyBuilder.classRegistry().findBuiltinClass(objectType.getTypeName());
+        if (builtinClass == null) {
+            throw bodyBuilder.invalidInsn("Builtin class not found for type " + objectType.getTypeName());
+        }
+        for (var property : builtinClass.getProperties()) {
+            if (property.getName().equals(propertyName)) {
+                return new BuiltinPropertyLookup(builtinClass, (ExtensionBuiltinClass.PropertyInfo) property);
+            }
+        }
+        throw bodyBuilder.invalidInsn("Property '" + propertyName + "' not found in builtin class " +
+                builtinClass.getName());
+    }
+}
+

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/StorePropertyInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/StorePropertyInsnGen.java
@@ -1,14 +1,10 @@
 package dev.superice.gdcc.backend.c.gen.insn;
 
 import dev.superice.gdcc.backend.c.gen.CBodyBuilder;
-import dev.superice.gdcc.backend.c.gen.CGenHelper;
 import dev.superice.gdcc.backend.c.gen.CInsnGen;
 import dev.superice.gdcc.enums.GdInstruction;
-import dev.superice.gdcc.gdextension.ExtensionBuiltinClass;
 import dev.superice.gdcc.gdextension.ExtensionGdClass;
-import dev.superice.gdcc.lir.LirFunctionDef;
 import dev.superice.gdcc.lir.insn.StorePropertyInsn;
-import dev.superice.gdcc.scope.ClassDef;
 import dev.superice.gdcc.scope.PropertyDef;
 import dev.superice.gdcc.type.GdNilType;
 import dev.superice.gdcc.type.GdObjectType;
@@ -48,13 +44,13 @@ public final class StorePropertyInsnGen implements CInsnGen<StorePropertyInsn> {
 
         // Validate property existence/writability and assignment compatibility first.
         validatePropertyWrite(bodyBuilder, objectVar.type(), valueVar.type(), insn.propertyName());
-        var genMode = getGenMode(helper, func, insn);
+        var genMode = PropertyAccessResolver.resolveGenMode(bodyBuilder, func, insn.objectId(), "STORE_PROPERTY");
 
         switch (genMode) {
-            case "gdcc" -> {
+            case GDCC -> {
                 var objectType = (GdObjectType) objectVar.type();
                 var classDef = Objects.requireNonNull(bodyBuilder.classRegistry().getClassDef(objectType));
-                var propertyDef = Objects.requireNonNull(findPropertyDef(classDef, insn.propertyName()));
+                var propertyDef = Objects.requireNonNull(PropertyAccessResolver.findPropertyDef(classDef, insn.propertyName()));
                 if (isStoringInsideSetterSelf(bodyBuilder, insn, propertyDef)) {
                     var fieldTarget = bodyBuilder.targetOfExpr(
                             "$" + objectVar.id() + "->" + insn.propertyName(),
@@ -72,13 +68,13 @@ public final class StorePropertyInsnGen implements CInsnGen<StorePropertyInsn> {
                             List.of(bodyBuilder.valueOfVar(objectVar), bodyBuilder.valueOfVar(valueVar)));
                 }
             }
-            case "engine", "builtin" -> {
+            case ENGINE, BUILTIN -> {
                 var objectType = objectVar.type();
                 var setterName = "godot_" + objectType.getTypeName() + "_set_" + insn.propertyName();
                 bodyBuilder.callVoid(setterName,
                         List.of(bodyBuilder.valueOfVar(objectVar), bodyBuilder.valueOfVar(valueVar)));
             }
-            case "general" -> {
+            case GENERAL -> {
                 var packFunc = helper.renderPackFunctionName(valueVar.type());
                 var tempVariant = bodyBuilder.newTempVariable("variant", GdVariantType.VARIANT);
                 bodyBuilder.declareTempVar(tempVariant);
@@ -108,7 +104,7 @@ public final class StorePropertyInsnGen implements CInsnGen<StorePropertyInsn> {
                 // Unknown object types are written through godot_Object_set and resolved at runtime.
                 return;
             }
-            var propertyFound = findPropertyDef(classDef, propertyName);
+            var propertyFound = PropertyAccessResolver.findPropertyDef(classDef, propertyName);
             if (propertyFound == null) {
                 throw bodyBuilder.invalidInsn("Property '" + propertyName + "' not found in class " + classDef.getName());
             }
@@ -125,49 +121,18 @@ public final class StorePropertyInsnGen implements CInsnGen<StorePropertyInsn> {
             return;
         }
 
-        var builtinClass = registry.findBuiltinClass(objectType.getTypeName());
-        if (builtinClass == null) {
-            throw bodyBuilder.invalidInsn("Builtin class not found for type " + objectType.getTypeName());
-        }
-        ExtensionBuiltinClass.PropertyInfo propertyFound = null;
-        for (var property : builtinClass.getProperties()) {
-            if (property.getName().equals(propertyName)) {
-                propertyFound = (ExtensionBuiltinClass.PropertyInfo) property;
-                break;
-            }
-        }
-        if (propertyFound == null) {
-            throw bodyBuilder.invalidInsn("Property '" + propertyName + "' not found in builtin class " +
-                    builtinClass.getName());
-        }
-        if (!propertyFound.isWritable()) {
+        var lookup = PropertyAccessResolver.resolveBuiltinProperty(bodyBuilder, objectType, propertyName);
+        var builtinClass = lookup.builtinClass();
+        if (!lookup.property().isWritable()) {
             throw bodyBuilder.invalidInsn("Property '" + propertyName + "' in builtin class " +
                     builtinClass.getName() + " is not writable");
         }
-        var propertyType = propertyFound.getType();
+        var propertyType = lookup.property().getType();
         if (!registry.checkAssignable(valueType, propertyType)) {
             throw bodyBuilder.invalidInsn("Value type " + valueType.getTypeName() +
                     " is not assignable to property '" + propertyName +
                     "' of type " + propertyType.getTypeName());
         }
-    }
-
-    private @NotNull String getGenMode(@NotNull CGenHelper helper,
-                                       @NotNull LirFunctionDef func,
-                                       @NotNull StorePropertyInsn insn) {
-        var objectVar = Objects.requireNonNull(func.getVariableById(insn.objectId()));
-        if (objectVar.type() instanceof GdObjectType gdObjectType) {
-            if (gdObjectType.checkGdccType(helper.context().classRegistry())) {
-                return "gdcc";
-            } else if (gdObjectType.checkEngineType(helper.context().classRegistry())) {
-                return "engine";
-            } else {
-                return "general";
-            }
-        } else if (objectVar.type() instanceof GdVoidType || objectVar.type() instanceof GdNilType) {
-            throw new IllegalStateException("Invalid object variable type for STORE_PROPERTY instruction");
-        }
-        return "builtin";
     }
 
     private boolean isStoringInsideSetterSelf(@NotNull CBodyBuilder bodyBuilder,
@@ -197,12 +162,4 @@ public final class StorePropertyInsnGen implements CInsnGen<StorePropertyInsn> {
         return false;
     }
 
-    private PropertyDef findPropertyDef(@NotNull ClassDef classDef, @NotNull String propertyName) {
-        for (var property : classDef.getProperties()) {
-            if (property.getName().equals(propertyName)) {
-                return property;
-            }
-        }
-        return null;
-    }
 }

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/StorePropertyInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/StorePropertyInsnGen.java
@@ -56,8 +56,11 @@ public final class StorePropertyInsnGen implements CInsnGen<StorePropertyInsn> {
                 var classDef = Objects.requireNonNull(bodyBuilder.classRegistry().getClassDef(objectType));
                 var propertyDef = Objects.requireNonNull(findPropertyDef(classDef, insn.propertyName()));
                 if (isStoringInsideSetterSelf(bodyBuilder, insn, propertyDef)) {
-                    var rhs = renderDirectFieldAssignRhs(helper, func, valueVar.id(), valueVar.type());
-                    bodyBuilder.appendLine("$" + objectVar.id() + "->" + insn.propertyName() + " = " + rhs + ";");
+                    var fieldTarget = bodyBuilder.targetOfExpr(
+                            "$" + objectVar.id() + "->" + insn.propertyName(),
+                            propertyDef.getType()
+                    );
+                    bodyBuilder.assignVar(fieldTarget, bodyBuilder.valueOfVar(valueVar));
                 } else {
                     var setterName = propertyDef.getSetterFunc();
                     if (setterName == null || setterName.isEmpty()) {
@@ -192,18 +195,6 @@ public final class StorePropertyInsnGen implements CInsnGen<StorePropertyInsn> {
             return setter != null && setter.equals(func.getName());
         }
         return false;
-    }
-
-    private @NotNull String renderDirectFieldAssignRhs(@NotNull CGenHelper helper,
-                                                       @NotNull LirFunctionDef func,
-                                                       @NotNull String valueId,
-                                                       @NotNull GdType valueType) {
-        var valueRef = helper.renderVarRef(func, valueId);
-        var copyAssignFunc = helper.renderCopyAssignFunctionName(valueType);
-        if (copyAssignFunc.isEmpty()) {
-            return valueRef;
-        }
-        return copyAssignFunc + "(" + valueRef + ")";
     }
 
     private PropertyDef findPropertyDef(@NotNull ClassDef classDef, @NotNull String propertyName) {

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java
@@ -376,7 +376,7 @@ public class CBodyBuilderPhaseCTest {
         }
 
         @Test
-        @DisplayName("RefCounted object assignment should release old and own new")
+        @DisplayName("RefCounted object assignment should capture old, own new, then release captured old")
         void testRefCountedObjectAssignment() {
             var target = new LirVariable("obj", new GdObjectType("RefCounted"), lirFunctionDef);
             var source = new LirVariable("src", new GdObjectType("RefCounted"), lirFunctionDef);
@@ -387,7 +387,10 @@ public class CBodyBuilderPhaseCTest {
 
             var result = builder.build();
             // RefCounted: should use release_object and own_object (not try_ versions)
-            assertTrue(result.contains("release_object($obj)"), "Should release old RefCounted object");
+            assertTrue(result.contains("godot_RefCounted* __gdcc_tmp_old_obj_0 = $obj;"),
+                    "Should capture old RefCounted object");
+            assertTrue(result.contains("release_object(__gdcc_tmp_old_obj_0);"),
+                    "Should release captured old RefCounted object");
             assertTrue(result.contains("own_object($obj)"), "Should own new RefCounted object");
         }
 
@@ -556,7 +559,7 @@ public class CBodyBuilderPhaseCTest {
 
             var result = objectBuilder.build();
             assertTrue(result.contains("godot_RefCounted* _return_val = NULL;"), "Prepare block should init return slot");
-            assertTrue(result.contains("release_object(_return_val);"), "Writing return slot should release old value first");
+            assertTrue(result.contains("release_object(__gdcc_tmp_old_obj_0);"), "Writing return slot should release captured old value");
             assertTrue(result.contains("_return_val = $obj;"), "Should write returned object into slot");
             assertTrue(result.contains("own_object(_return_val);"), "Borrowed object source should be retained for return slot");
             assertTrue(result.contains("goto __finally__;"), "Non-finally return should jump to __finally__");
@@ -576,7 +579,7 @@ public class CBodyBuilderPhaseCTest {
             objectBuilder.returnValue(ownedValue);
 
             var result = objectBuilder.build();
-            assertTrue(result.contains("release_object(_return_val);"), "Should still release previous return slot value");
+            assertTrue(result.contains("release_object(__gdcc_tmp_old_obj_0);"), "Should still release previous return slot value");
             assertTrue(result.contains("_return_val = create_object();"), "Should assign owned return expression");
             assertFalse(result.contains("own_object(_return_val);"), "Owned return value must not be owned again");
             assertTrue(result.contains("goto __finally__;"), "Non-finally return should jump to __finally__");
@@ -634,7 +637,7 @@ public class CBodyBuilderPhaseCTest {
         }
 
         @Test
-        @DisplayName("callAssign with RefCounted target should release old and consume owned return")
+        @DisplayName("callAssign with RefCounted target should release captured old and consume owned return")
         void testCallAssignRefCountedTarget() {
             var target = new LirVariable("obj", new GdObjectType("RefCounted"), lirFunctionDef);
             var targetRef = builder.targetOfVar(target);
@@ -642,7 +645,7 @@ public class CBodyBuilderPhaseCTest {
             builder.callAssign(targetRef, "create_object", new GdObjectType("RefCounted"), List.of());
 
             var result = builder.build();
-            assertTrue(result.contains("release_object($obj)"), "Should release old object before assignment");
+            assertTrue(result.contains("release_object(__gdcc_tmp_old_obj_0);"), "Should release captured old object");
             assertFalse(result.contains("own_object($obj)"), "Owned call result should not be owned again");
         }
 
@@ -773,7 +776,9 @@ public class CBodyBuilderPhaseCTest {
             builder.assignVar(targetRef, value);
 
             var result = builder.build();
-            assertTrue(result.contains("try_release_object($obj)"), "Should try_release unknown object");
+            assertTrue(result.contains("GDExtensionObjectPtr __gdcc_tmp_old_obj_0 = $obj;"),
+                    "Should capture old unknown object");
+            assertTrue(result.contains("try_release_object(__gdcc_tmp_old_obj_0)"), "Should try_release unknown object");
             assertTrue(result.contains("try_own_object($obj)"), "Should try_own unknown object");
         }
     }
@@ -953,7 +958,7 @@ public class CBodyBuilderPhaseCTest {
         }
 
         @Test
-        @DisplayName("callAssign with GDCC target from godot_ func should release old and consume owned return")
+        @DisplayName("callAssign with GDCC target from godot_ func should release captured old and consume owned return")
         void testCallAssignGdccTargetOwnRelease() {
             var target = new LirVariable("myObj", new GdObjectType("MyGdccClass"), lirFunctionDef);
             var targetRef = builder.targetOfVar(target);
@@ -962,8 +967,8 @@ public class CBodyBuilderPhaseCTest {
 
             var result = builder.build();
             // MyGdccClass extends RefCounted; owned call results should not be owned again.
-            assertTrue(result.contains("release_object(godot_object_from_gdcc_object_ptr($myObj))"),
-                    "Should release old GDCC object. Actual:\n" + result);
+            assertTrue(result.contains("release_object(godot_object_from_gdcc_object_ptr(__gdcc_tmp_old_obj_0))"),
+                    "Should release captured old GDCC object. Actual:\n" + result);
             assertFalse(result.contains("own_object(godot_object_from_gdcc_object_ptr($myObj))"),
                     "Should consume owned call result without own. Actual:\n" + result);
         }
@@ -1062,7 +1067,7 @@ public class CBodyBuilderPhaseCTest {
         }
 
         @Test
-        @DisplayName("GODOT_PTR to GDCC target should still do own/release with helper conversion")
+        @DisplayName("GODOT_PTR to GDCC target should still do own/release with helper conversion using old-temp flow")
         void testGodotPtrToGdccTargetOwnRelease() {
             var target = new LirVariable("myObj", new GdObjectType("MyGdccClass"), lirFunctionDef);
             var targetRef = builder.targetOfVar(target);
@@ -1072,8 +1077,8 @@ public class CBodyBuilderPhaseCTest {
 
             var result = builder.build();
             // MyGdccClass extends RefCounted, should have own/release with helper conversion
-            assertTrue(result.contains("release_object(godot_object_from_gdcc_object_ptr($myObj))"),
-                    "Should release old GDCC object via helper conversion. Actual:\n" + result);
+            assertTrue(result.contains("release_object(godot_object_from_gdcc_object_ptr(__gdcc_tmp_old_obj_0))"),
+                    "Should release captured old GDCC object via helper conversion. Actual:\n" + result);
             assertTrue(result.contains("own_object(godot_object_from_gdcc_object_ptr($myObj))"),
                     "Should own new GDCC object via helper conversion. Actual:\n" + result);
             // Should also convert the assignment value
@@ -1128,7 +1133,7 @@ public class CBodyBuilderPhaseCTest {
         }
 
         @Test
-        @DisplayName("GODOT_PTR to GDCC target full ordering: release → assign with conversion → own")
+        @DisplayName("GODOT_PTR to GDCC target full ordering: capture old → assign with conversion → own → release old")
         void testGodotPtrToGdccTargetFullOrdering() {
             var target = new LirVariable("myObj", new GdObjectType("MyGdccClass"), lirFunctionDef);
             var targetRef = builder.targetOfVar(target);
@@ -1137,15 +1142,18 @@ public class CBodyBuilderPhaseCTest {
             builder.assignVar(targetRef, value);
 
             var result = builder.build();
-            var releaseIndex = result.indexOf("release_object(godot_object_from_gdcc_object_ptr($myObj))");
+            var captureIndex = result.indexOf("MyGdccClass* __gdcc_tmp_old_obj_0 = $myObj;");
             var assignIndex = result.indexOf("$myObj = (MyGdccClass*)gdcc_object_from_godot_object_ptr(godot_result);");
             var ownIndex = result.indexOf("own_object(godot_object_from_gdcc_object_ptr($myObj))");
+            var releaseOldIndex = result.indexOf("release_object(godot_object_from_gdcc_object_ptr(__gdcc_tmp_old_obj_0));");
 
-            assertTrue(releaseIndex >= 0, "Should have release. Actual:\n" + result);
+            assertTrue(captureIndex >= 0, "Should capture old slot value. Actual:\n" + result);
             assertTrue(assignIndex >= 0, "Should have converted assignment. Actual:\n" + result);
             assertTrue(ownIndex >= 0, "Should have own. Actual:\n" + result);
-            assertTrue(releaseIndex < assignIndex, "Release should come before assignment");
+            assertTrue(releaseOldIndex >= 0, "Should release captured old value. Actual:\n" + result);
+            assertTrue(captureIndex < assignIndex, "Old capture should come before assignment");
             assertTrue(assignIndex < ownIndex, "Assignment should come before own");
+            assertTrue(ownIndex < releaseOldIndex, "Release of captured old value should happen last");
         }
     }
 }

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CStorePropertyInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CStorePropertyInsnGenTest.java
@@ -13,6 +13,7 @@ import dev.superice.gdcc.lir.LirFunctionDef;
 import dev.superice.gdcc.lir.LirModule;
 import dev.superice.gdcc.lir.LirParameterDef;
 import dev.superice.gdcc.lir.LirPropertyDef;
+import dev.superice.gdcc.lir.insn.LoadPropertyInsn;
 import dev.superice.gdcc.lir.insn.ReturnInsn;
 import dev.superice.gdcc.lir.insn.StorePropertyInsn;
 import dev.superice.gdcc.scope.ClassRegistry;
@@ -87,10 +88,70 @@ public class CStorePropertyInsnGenTest {
         codegen.prepare(ctx, module);
 
         var body = codegen.generateFuncBody(gdccClass, func);
-        assertTrue(body.contains("try_release_object($self->target);"));
+        assertTrue(body.contains("__gdcc_tmp_old_obj_"), "Should capture old target object in temp.");
+        assertTrue(body.contains(" = $self->target;"), "Captured old temp should be initialized from target slot.");
+        assertTrue(body.contains("try_release_object(__gdcc_tmp_old_obj_"), "Should release captured old target object.");
         assertTrue(body.contains("$self->target = $value;"));
         assertTrue(body.contains("try_own_object($self->target);"));
         assertFalse(body.contains("try_own_object($value);"));
+    }
+
+    @Test
+    @DisplayName("GDCC setter self.obj = self.obj should keep RefCounted lifecycle ordering on backing field writes")
+    void gdccSetterSelfPropertyReassignForRefCountedKeepsFieldLifecycleOrdering() {
+        var refCountedClass = new ExtensionGdClass(
+                "RefCounted", true, true, "Object", "core",
+                List.of(), List.of(), List.of(), List.of(), List.of()
+        );
+        var api = new ExtensionAPI(null, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(refCountedClass), List.of(), List.of());
+
+        var gdccClass = new LirClassDef("MyClass", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        gdccClass.addProperty(new LirPropertyDef(
+                "obj",
+                new GdObjectType("RefCounted"),
+                false,
+                null,
+                "_field_getter_obj",
+                "_field_setter_obj",
+                Map.of()
+        ));
+
+        var setter = new LirFunctionDef("_field_setter_obj");
+        setter.setReturnType(GdVoidType.VOID);
+        setter.addParameter(new LirParameterDef("self", new GdObjectType("MyClass"), null, setter));
+        setter.addParameter(new LirParameterDef("value", new GdObjectType("RefCounted"), null, setter));
+        setter.createAndAddVariable("rhs", new GdObjectType("RefCounted"));
+
+        var entry = new LirBasicBlock("entry");
+        entry.instructions().add(new LoadPropertyInsn("rhs", "obj", "self"));
+        entry.instructions().add(new StorePropertyInsn("obj", "self", "rhs"));
+        entry.instructions().add(new ReturnInsn(null));
+        setter.addBasicBlock(entry);
+        setter.setEntryBlockId("entry");
+        gdccClass.addFunction(setter);
+
+        var module = new LirModule("test_module", List.of(gdccClass));
+        var ctx = newContext(api, List.of(gdccClass));
+
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+
+        var body = codegen.generateFuncBody(gdccClass, setter);
+        assertTrue(body.contains("MyClass__field_getter_obj($self);"));
+        assertFalse(body.contains("MyClass__field_setter_obj($self, $rhs);"));
+        assertTrue(body.contains("__gdcc_tmp_old_obj_"), "Setter-self field write should capture old value temp.");
+        assertTrue(body.contains(" = $self->obj;"), "Captured temp should copy field old value.");
+
+        var assignIndex = body.indexOf("$self->obj = $rhs;");
+        var ownIndex = body.indexOf("own_object($self->obj);");
+        assertTrue(assignIndex >= 0, "Setter-self field write should assign RHS value.");
+        assertTrue(ownIndex >= 0, "Setter-self field write should own BORROWED RHS value.");
+        assertTrue(body.substring(0, assignIndex).contains(" = $self->obj;"),
+                "Setter-self field write should capture old value before assignment.");
+        assertTrue(assignIndex < ownIndex, "Assignment should happen before own.");
+        var releaseOldIndex = body.indexOf("release_object(__gdcc_tmp_old_obj_", ownIndex);
+        assertTrue(releaseOldIndex >= 0, "Setter-self field write should release captured old value after own.");
+        assertTrue(ownIndex < releaseOldIndex, "Release of captured old value should happen last.");
     }
 
     @Test

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CStorePropertyInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CStorePropertyInsnGenTest.java
@@ -54,8 +54,43 @@ public class CStorePropertyInsnGenTest {
         codegen.prepare(ctx, module);
 
         var body = codegen.generateFuncBody(gdccClass, func);
-        assertTrue(body.contains("$self->value = godot_new_String_with_String($value);"));
+        assertTrue(body.contains("godot_String_destroy(&$self->value);"));
+        assertTrue(body.contains("__gdcc_tmp_string_0 = godot_new_String_with_String($value);"));
+        assertTrue(body.contains("$self->value = __gdcc_tmp_string_0;"));
+        assertTrue(body.contains("godot_String_destroy(&__gdcc_tmp_string_0);"));
         assertFalse(body.contains("MyClass__field_setter_value("));
+    }
+
+    @Test
+    @DisplayName("GDCC object setter should rely on store_property lifecycle path without extra own/release instructions")
+    void gdccObjectSetterUsesUnifiedLifecyclePath() {
+        var nodeClass = new ExtensionGdClass(
+                "Node", false, true, "Object", "core",
+                List.of(), List.of(), List.of(), List.of(), List.of()
+        );
+        var api = new ExtensionAPI(null, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(nodeClass), List.of(), List.of());
+
+        var gdccClass = new LirClassDef("MyClass", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        gdccClass.addProperty(new LirPropertyDef("target", new GdObjectType("Object"), false, null, null, "_field_setter_target", Map.of()));
+
+        var func = new LirFunctionDef("_field_setter_target");
+        func.setReturnType(GdVoidType.VOID);
+        func.addParameter(new LirParameterDef("self", new GdObjectType("MyClass"), null, func));
+        func.addParameter(new LirParameterDef("value", new GdObjectType("Node"), null, func));
+        addEntryStoreAndReturn(func, new StorePropertyInsn("target", "self", "value"));
+        gdccClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(gdccClass));
+        var ctx = newContext(api, List.of(gdccClass));
+
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+
+        var body = codegen.generateFuncBody(gdccClass, func);
+        assertTrue(body.contains("try_release_object($self->target);"));
+        assertTrue(body.contains("$self->target = $value;"));
+        assertTrue(body.contains("try_own_object($self->target);"));
+        assertFalse(body.contains("try_own_object($value);"));
     }
 
     @Test


### PR DESCRIPTION
## What changed
- Added `PropertyAccessResolver` to centralize property access mode detection (GDCC/engine/general/builtin), GDCC property lookup, and builtin property lookup for both load/store generators.
- Refactored `LoadPropertyInsnGen` and `StorePropertyInsnGen` to use the shared resolver, removing duplicated mode/property lookup code.
- Added assignment-only expression target support in `CBodyBuilder` via `ExprTargetRef` and `targetOfExpr(...)`.
- Updated auto-generated GDCC field setter construction in `CCodegen` to emit only `StorePropertyInsn`, delegating lifecycle behavior to store-property codegen path.
- Expanded store-property tests to verify string/object lifecycle behavior in GDCC setter self-assignment path.
- Documented assignment-only contract for `ExprTargetRef` in module implementation notes.

## Why
- Keep property resolution behavior consistent between load/store generators.
- Ensure GDCC setter self writes follow the same lifecycle/ownership rules as normal assignment APIs.
- Reduce duplicated logic and make future property access changes safer.

## Affected areas
- `dev.superice.gdcc.backend.c.gen`
- `dev.superice.gdcc.backend.c.gen.insn`
- `src/test/java/dev/superice/gdcc/backend/c/gen`
- `doc/module_impl`

## Validation
- `./gradlew.bat test --tests CStorePropertyInsnGenTest --tests CLoadPropertyInsnGenTest --no-daemon --info --console=plain`