### PR TITLE
feat(backend): implement construct insn codegen with typed container validation

### DIFF
--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
@@ -9,7 +9,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import static dev.superice.gdcc.util.StringUtil.escapeStringLiteral;
 
@@ -20,6 +22,7 @@ import static dev.superice.gdcc.util.StringUtil.escapeStringLiteral;
 @SuppressWarnings("UnusedReturnValue")
 public final class CBodyBuilder {
     private static final String RETURN_SLOT_NAME = "_return_val";
+    private static final @NotNull Pattern NON_TEMP_PREFIX_CHAR_PATTERN = Pattern.compile("[^a-z0-9_]");
 
     private final @NotNull CGenHelper helper;
     private final @NotNull LirClassDef clazz;
@@ -705,7 +708,7 @@ public final class CBodyBuilder {
         if (!copyFunc.isEmpty()) {
             // Need to copy: godot_new_<Type>_with_<Type>(source_ptr)
             var sourcePtr = renderValueAddress(value);
-            var temp = newTempVariable(type.getTypeName().toLowerCase(), type, copyFunc + "(" + sourcePtr.code() + ")");
+            var temp = newTempVariable(renderSafeTempPrefix(type), type, copyFunc + "(" + sourcePtr.code() + ")");
             var temps = new ArrayList<>(sourcePtr.temps());
             temps.add(temp);
             return new RenderResult(temp.name(), temps);
@@ -780,10 +783,22 @@ public final class CBodyBuilder {
             return new RenderResult("&" + code, List.of());
         }
         if (value instanceof ExprValue exprValue) {
-            var temp = newTempVariable(exprValue.type().getTypeName().toLowerCase(), exprValue.type(), exprValue.generateCode());
+            var temp = newTempVariable(renderSafeTempPrefix(exprValue.type()), exprValue.type(), exprValue.generateCode());
             return new RenderResult("&" + temp.name(), List.of(temp));
         }
         return new RenderResult("&" + value.generateCode(), List.of());
+    }
+
+    private @NotNull String renderSafeTempPrefix(@NotNull GdType type) {
+        var normalizedTypeName = helper.renderGdTypeName(type).toLowerCase(Locale.ROOT);
+        var safePrefix = NON_TEMP_PREFIX_CHAR_PATTERN.matcher(normalizedTypeName).replaceAll("_");
+        if (safePrefix.isBlank()) {
+            return "tmp";
+        }
+        if (Character.isDigit(safePrefix.charAt(0))) {
+            return "tmp_" + safePrefix;
+        }
+        return safePrefix;
     }
 
     private void emitDestroy(@NotNull String varCode, @NotNull GdType type) {

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
@@ -40,6 +40,7 @@ public class CCodegen implements Codegen {
         registerInsnGen(new DestructInsnGen());
         registerInsnGen(new PackUnpackVariantInsnGen());
         registerInsnGen(new CallGlobalInsnGen());
+        registerInsnGen(new ConstructInsnGen());
     }
 
     public CodegenContext ctx;

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
@@ -269,7 +269,7 @@ public final class CGenHelper {
                 return "(godot_" + objectType.getTypeName() + "*)godot_new_Object_with_Variant";
             }
         } else {
-            return "godot_new_" + type.getTypeName() + "_with_Variant";
+            return "godot_new_" + renderGdTypeName(type) + "_with_Variant";
         }
     }
 
@@ -281,7 +281,7 @@ public final class CGenHelper {
                 return "godot_new_Variant_with_Object";
             }
         } else {
-            return "godot_new_Variant_with_" + type.getTypeName();
+            return "godot_new_Variant_with_" + renderGdTypeName(type);
         }
     }
 
@@ -290,7 +290,10 @@ public final class CGenHelper {
             case GdObjectType _, GdPrimitiveType _ -> "";
             case GdVoidType _, GdNilType _ ->
                     throw new IllegalArgumentException("Type " + type.getTypeName() + " does not support copy assignment");
-            default -> "godot_new_" + type.getTypeName() + "_with_" + type.getTypeName();
+            default -> {
+                var symbolTypeName = renderGdTypeName(type);
+                yield "godot_new_" + symbolTypeName + "_with_" + symbolTypeName;
+            }
         };
     }
 

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java
@@ -1,0 +1,181 @@
+package dev.superice.gdcc.backend.c.gen.insn;
+
+import dev.superice.gdcc.backend.c.gen.CBodyBuilder;
+import dev.superice.gdcc.backend.c.gen.CInsnGen;
+import dev.superice.gdcc.enums.GdInstruction;
+import dev.superice.gdcc.lir.LirInstruction;
+import dev.superice.gdcc.lir.LirVariable;
+import dev.superice.gdcc.lir.insn.ConstructArrayInsn;
+import dev.superice.gdcc.lir.insn.ConstructBuiltinInsn;
+import dev.superice.gdcc.lir.insn.ConstructDictionaryInsn;
+import dev.superice.gdcc.lir.insn.ConstructionInstruction;
+import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdType;
+import dev.superice.gdcc.type.GdVariantType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+/// C code generator for construct instructions:
+/// - construct_builtin
+/// - construct_array
+/// - construct_dictionary
+public final class ConstructInsnGen implements CInsnGen<ConstructionInstruction> {
+    @Override
+    public @NotNull EnumSet<GdInstruction> getInsnOpcodes() {
+        return EnumSet.of(
+                GdInstruction.CONSTRUCT_BUILTIN,
+                GdInstruction.CONSTRUCT_ARRAY,
+                GdInstruction.CONSTRUCT_DICTIONARY
+        );
+    }
+
+    @Override
+    public void generateCCode(@NotNull CBodyBuilder bodyBuilder) {
+        var instruction = bodyBuilder.getCurrentInsn(this);
+        var resultVar = resolveResultVariable(bodyBuilder, instruction);
+        var target = bodyBuilder.targetOfVar(resultVar);
+
+        try {
+            switch (instruction) {
+                case ConstructBuiltinInsn(_, var args) -> {
+                    var ctorArgs = resolveConstructorArguments(bodyBuilder, args);
+                    bodyBuilder.helper().builtinBuilder().constructBuiltin(bodyBuilder, target, ctorArgs);
+                }
+                case ConstructArrayInsn(_, var className) -> {
+                    if (!(resultVar.type() instanceof GdArrayType arrayType)) {
+                        throw bodyBuilder.invalidInsn("Result variable ID '" + resultVar.id() + "' must be Array type");
+                    }
+                    validateArrayTypeHint(bodyBuilder, className, arrayType);
+                    bodyBuilder.helper().builtinBuilder().constructBuiltin(bodyBuilder, target, List.of());
+                }
+                case ConstructDictionaryInsn(_, var keyClassName, var valueClassName) -> {
+                    if (!(resultVar.type() instanceof GdDictionaryType dictionaryType)) {
+                        throw bodyBuilder.invalidInsn("Result variable ID '" + resultVar.id() + "' must be Dictionary type");
+                    }
+                    validateDictionaryTypeHint(bodyBuilder, keyClassName, valueClassName, dictionaryType);
+                    bodyBuilder.helper().builtinBuilder().constructBuiltin(bodyBuilder, target, List.of());
+                }
+                default -> throw bodyBuilder.invalidInsn(
+                        "Unsupported construction instruction: " + instruction.opcode().opcode()
+                );
+            }
+        } catch (IllegalArgumentException ex) {
+            throw bodyBuilder.invalidInsn(ex.getMessage());
+        }
+    }
+
+    private @NotNull LirVariable resolveResultVariable(@NotNull CBodyBuilder bodyBuilder,
+                                                       @NotNull ConstructionInstruction instruction) {
+        var resultId = instruction.resultId();
+        if (resultId == null) {
+            throw bodyBuilder.invalidInsn("Construction instruction missing result variable ID");
+        }
+        var resultVar = bodyBuilder.func().getVariableById(resultId);
+        if (resultVar == null) {
+            throw bodyBuilder.invalidInsn("Result variable ID '" + resultId + "' does not exist");
+        }
+        if (resultVar.ref()) {
+            throw bodyBuilder.invalidInsn("Result variable ID '" + resultId + "' cannot be a reference");
+        }
+        return resultVar;
+    }
+
+    private @NotNull List<CBodyBuilder.ValueRef> resolveConstructorArguments(@NotNull CBodyBuilder bodyBuilder,
+                                                                             @NotNull List<LirInstruction.Operand> operands) {
+        var args = new ArrayList<CBodyBuilder.ValueRef>(operands.size());
+        for (var i = 0; i < operands.size(); i++) {
+            var operand = operands.get(i);
+            if (!(operand instanceof LirInstruction.VariableOperand(var variableId))) {
+                throw bodyBuilder.invalidInsn("construct_builtin argument #" + (i + 1) + " must be a variable operand");
+            }
+            var variable = bodyBuilder.func().getVariableById(variableId);
+            if (variable == null) {
+                throw bodyBuilder.invalidInsn("construct_builtin argument variable ID '" + variableId + "' not found");
+            }
+            args.add(bodyBuilder.valueOfVar(variable));
+        }
+        return args;
+    }
+
+    private void validateArrayTypeHint(@NotNull CBodyBuilder bodyBuilder,
+                                       String className,
+                                       @NotNull GdArrayType resultType) {
+        var expectedElementType = resolveContainerTypeHint(
+                bodyBuilder,
+                className,
+                "construct_array"
+        );
+        var actualElementType = resultType.getValueType();
+        if (!hasSameRenderedTypeName(bodyBuilder, expectedElementType, actualElementType)) {
+            throw bodyBuilder.invalidInsn(
+                    "construct_array type mismatch: operand element type '" +
+                            renderTypeName(bodyBuilder, expectedElementType) +
+                            "' does not match result variable element type '" +
+                            renderTypeName(bodyBuilder, actualElementType) + "'"
+            );
+        }
+    }
+
+    private void validateDictionaryTypeHint(@NotNull CBodyBuilder bodyBuilder,
+                                            String keyClassName,
+                                            String valueClassName,
+                                            @NotNull GdDictionaryType resultType) {
+        var expectedKeyType = resolveContainerTypeHint(
+                bodyBuilder,
+                keyClassName,
+                "construct_dictionary key"
+        );
+        var expectedValueType = resolveContainerTypeHint(
+                bodyBuilder,
+                valueClassName,
+                "construct_dictionary value"
+        );
+        if (!hasSameRenderedTypeName(bodyBuilder, expectedKeyType, resultType.getKeyType())) {
+            throw bodyBuilder.invalidInsn(
+                    "construct_dictionary key type mismatch: operand key type '" +
+                            renderTypeName(bodyBuilder, expectedKeyType) +
+                            "' does not match result variable key type '" +
+                            renderTypeName(bodyBuilder, resultType.getKeyType()) + "'"
+            );
+        }
+        if (!hasSameRenderedTypeName(bodyBuilder, expectedValueType, resultType.getValueType())) {
+            throw bodyBuilder.invalidInsn(
+                    "construct_dictionary value type mismatch: operand value type '" +
+                            renderTypeName(bodyBuilder, expectedValueType) +
+                            "' does not match result variable value type '" +
+                            renderTypeName(bodyBuilder, resultType.getValueType()) + "'"
+            );
+        }
+    }
+
+    private @NotNull GdType resolveContainerTypeHint(@NotNull CBodyBuilder bodyBuilder,
+                                                     String textType,
+                                                     @NotNull String hintLabel) {
+        if (textType == null) {
+            return GdVariantType.VARIANT;
+        }
+        if (textType.isBlank()) {
+            throw bodyBuilder.invalidInsn(hintLabel + " must not be blank");
+        }
+        var parsedType = ClassRegistry.tryParseTextType(textType);
+        if (parsedType == null) {
+            throw bodyBuilder.invalidInsn(hintLabel + " '" + textType + "' is not a valid type");
+        }
+        return parsedType;
+    }
+
+    private boolean hasSameRenderedTypeName(@NotNull CBodyBuilder bodyBuilder,
+                                            @NotNull GdType expectedType,
+                                            @NotNull GdType actualType) {
+        return renderTypeName(bodyBuilder, expectedType).equals(renderTypeName(bodyBuilder, actualType));
+    }
+
+    private @NotNull String renderTypeName(@NotNull CBodyBuilder bodyBuilder, @NotNull GdType type) {
+        return bodyBuilder.helper().renderGdTypeName(type);
+    }
+}

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java
@@ -358,6 +358,24 @@ public class CBodyBuilderPhaseCTest {
         }
 
         @Test
+        @DisplayName("Typed Array assignment should use normalized copy symbol and safe temp prefix")
+        void testTypedArrayAssignmentUsesNormalizedSymbolAndSafeTempPrefix() {
+            var arrayType = new GdArrayType(GdStringNameType.STRING_NAME);
+            var target = new LirVariable("arr", arrayType, lirFunctionDef);
+            var source = new LirVariable("src", arrayType, lirFunctionDef);
+
+            builder.assignVar(builder.targetOfVar(target), builder.valueOfVar(source));
+
+            var result = builder.build();
+            assertTrue(result.contains("godot_new_Array_with_Array(&$src);"),
+                    "Typed Array copy should use normalized Array constructor symbol");
+            assertTrue(result.contains("__gdcc_tmp_array_0"),
+                    "Typed Array temp variable should use safe normalized prefix");
+            assertFalse(result.contains("__gdcc_tmp_array["),
+                    "Temp variable name must not contain generic suffix characters");
+        }
+
+        @Test
         @DisplayName("__prepare__ non-object assignment should not destroy old value")
         void testPrepareBlockNonObjectAssignSkipsDestroy() {
             var prepareBlock = new LirBasicBlock("__prepare__");
@@ -500,6 +518,25 @@ public class CBodyBuilderPhaseCTest {
 
             var result = stringBuilder.build();
             assertTrue(result.contains("godot_new_String_with_String(&$s)"), "Should copy String on return");
+        }
+
+        @Test
+        @DisplayName("Returning typed Dictionary expression should use normalized copy symbol and safe temp prefix")
+        void testReturnTypedDictionaryExprUsesNormalizedSymbolAndSafeTempPrefix() {
+            var dictionaryType = new GdDictionaryType(GdStringNameType.STRING_NAME, GdVariantType.VARIANT);
+            var dictionaryBuilder = createBuilderWithReturnType(dictionaryType);
+            setFinallyBlockContext(dictionaryBuilder);
+            var value = dictionaryBuilder.valueOfExpr("some_dict_expr", dictionaryType);
+
+            dictionaryBuilder.returnValue(value);
+
+            var result = dictionaryBuilder.build();
+            assertTrue(result.contains("godot_new_Dictionary_with_Dictionary(&__gdcc_tmp_dictionary_0);"),
+                    "Typed Dictionary return copy should use normalized Dictionary symbol");
+            assertTrue(result.contains("__gdcc_tmp_dictionary_0"),
+                    "Typed Dictionary expression temp should use safe normalized prefix");
+            assertFalse(result.contains("__gdcc_tmp_dictionary["),
+                    "Expression temp name must not contain generic suffix characters");
         }
 
         @Test

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java
@@ -24,7 +24,9 @@ import dev.superice.gdcc.scope.ClassRegistry;
 import dev.superice.gdcc.type.GdArrayType;
 import dev.superice.gdcc.type.GdDictionaryType;
 import dev.superice.gdcc.type.GdFloatType;
+import dev.superice.gdcc.type.GdIntType;
 import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdStringNameType;
 import dev.superice.gdcc.type.GdTransform2DType;
 import dev.superice.gdcc.type.GdVariantType;
 import org.junit.jupiter.api.Assumptions;
@@ -71,6 +73,17 @@ class CConstructInsnGenEngineTest {
         var buildResult = builder.buildProject(projectInfo, codegen);
         assertTrue(buildResult.success(), "Compilation should succeed. Build log:\n" + buildResult.buildLog());
         assertFalse(buildResult.artifacts().isEmpty(), "Compilation should produce extension artifacts.");
+        var entrySource = Files.readString(tempDir.resolve("entry.c"));
+        assertTrue(entrySource.contains("make_typed_array_explicit"), "Typed array method should be emitted into C source.");
+        assertTrue(entrySource.contains("make_typed_dictionary_explicit"), "Typed dictionary method should be emitted into C source.");
+        assertTrue(
+                entrySource.contains("godot_new_Array_with_Array_int_StringName_Variant"),
+                "Typed array constructor call should be generated in C source."
+        );
+        assertTrue(
+                entrySource.contains("godot_new_Dictionary_with_Dictionary_int_StringName_Variant_int_StringName_Variant"),
+                "Typed dictionary constructor call should be generated in C source."
+        );
 
         var runner = new GodotGdextensionTestRunner(Path.of("test_project"));
         runner.prepareProject(new GodotGdextensionTestRunner.ProjectSetup(
@@ -112,6 +125,10 @@ class CConstructInsnGenEngineTest {
         clazz.addFunction(newPrepareGenericArrayFunction(selfType));
         clazz.addFunction(newExplicitGenericDictionaryFunction(selfType));
         clazz.addFunction(newPrepareGenericDictionaryFunction(selfType));
+        clazz.addFunction(newExplicitTypedArrayFunction(selfType));
+        clazz.addFunction(newPrepareTypedArrayFunction(selfType));
+        clazz.addFunction(newExplicitTypedDictionaryFunction(selfType));
+        clazz.addFunction(newPrepareTypedDictionaryFunction(selfType));
         return clazz;
     }
 
@@ -188,12 +205,52 @@ class CConstructInsnGenEngineTest {
         return func;
     }
 
+    private static LirFunctionDef newExplicitTypedArrayFunction(GdObjectType selfType) {
+        var arrayType = new GdArrayType(new GdObjectType("Node"));
+        var func = newMethodWithMarker("make_typed_array_explicit", arrayType, selfType);
+        func.createAndAddVariable("arr", arrayType);
+        entry(func).instructions().add(new ConstructArrayInsn("arr", "Node"));
+        entry(func).instructions().add(new ReturnInsn("arr"));
+        return func;
+    }
+
+    private static LirFunctionDef newPrepareTypedArrayFunction(GdObjectType selfType) {
+        var arrayType = new GdArrayType(new GdObjectType("Node"));
+        var func = newMethodWithMarker("make_typed_array_prepare", arrayType, selfType);
+        func.createAndAddVariable("arr", arrayType);
+        entry(func).instructions().add(new ReturnInsn("arr"));
+        return func;
+    }
+
+    private static LirFunctionDef newExplicitTypedDictionaryFunction(GdObjectType selfType) {
+        var dictionaryType = new GdDictionaryType(GdStringNameType.STRING_NAME, new GdObjectType("Node"));
+        var func = newMethodWithMarker("make_typed_dictionary_explicit", dictionaryType, selfType);
+        func.createAndAddVariable("dict", dictionaryType);
+        entry(func).instructions().add(new ConstructDictionaryInsn("dict", "StringName", "Node"));
+        entry(func).instructions().add(new ReturnInsn("dict"));
+        return func;
+    }
+
+    private static LirFunctionDef newPrepareTypedDictionaryFunction(GdObjectType selfType) {
+        var dictionaryType = new GdDictionaryType(GdStringNameType.STRING_NAME, new GdObjectType("Node"));
+        var func = newMethodWithMarker("make_typed_dictionary_prepare", dictionaryType, selfType);
+        func.createAndAddVariable("dict", dictionaryType);
+        entry(func).instructions().add(new ReturnInsn("dict"));
+        return func;
+    }
+
     private static LirFunctionDef newMethod(String name, dev.superice.gdcc.type.GdType returnType, GdObjectType selfType) {
         var func = new LirFunctionDef(name);
         func.setReturnType(returnType);
         func.addParameter(new LirParameterDef("self", selfType, null, func));
         func.addBasicBlock(new LirBasicBlock("entry"));
         func.setEntryBlockId("entry");
+        return func;
+    }
+
+    private static LirFunctionDef newMethodWithMarker(String name, dev.superice.gdcc.type.GdType returnType, GdObjectType selfType) {
+        var func = newMethod(name, returnType, selfType);
+        func.addParameter(new LirParameterDef("marker", GdIntType.INT, null, func));
         return func;
     }
 

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java
@@ -1,0 +1,281 @@
+package dev.superice.gdcc.backend.c.gen;
+
+import dev.superice.gdcc.backend.CodegenContext;
+import dev.superice.gdcc.backend.c.build.COptimizationLevel;
+import dev.superice.gdcc.backend.c.build.CProjectBuilder;
+import dev.superice.gdcc.backend.c.build.CProjectInfo;
+import dev.superice.gdcc.backend.c.build.GodotGdextensionTestRunner;
+import dev.superice.gdcc.backend.c.build.TargetPlatform;
+import dev.superice.gdcc.backend.c.build.ZigUtil;
+import dev.superice.gdcc.enums.GodotVersion;
+import dev.superice.gdcc.gdextension.ExtensionApiLoader;
+import dev.superice.gdcc.lir.LirBasicBlock;
+import dev.superice.gdcc.lir.LirClassDef;
+import dev.superice.gdcc.lir.LirFunctionDef;
+import dev.superice.gdcc.lir.LirInstruction;
+import dev.superice.gdcc.lir.LirModule;
+import dev.superice.gdcc.lir.LirParameterDef;
+import dev.superice.gdcc.lir.insn.ConstructArrayInsn;
+import dev.superice.gdcc.lir.insn.ConstructBuiltinInsn;
+import dev.superice.gdcc.lir.insn.ConstructDictionaryInsn;
+import dev.superice.gdcc.lir.insn.LiteralFloatInsn;
+import dev.superice.gdcc.lir.insn.ReturnInsn;
+import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdFloatType;
+import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdTransform2DType;
+import dev.superice.gdcc.type.GdVariantType;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CConstructInsnGenEngineTest {
+    @Test
+    @DisplayName("construct insns should generate runnable typed container and builtin constructors in real engine")
+    void constructInsnsShouldRunInRealGodot() throws IOException, InterruptedException {
+        if (!hasZig()) {
+            Assumptions.abort("Zig not found; skipping integration test");
+            return;
+        }
+
+        var tempDir = Path.of("tmp/test/construct_engine");
+        Files.createDirectories(tempDir);
+
+        var projectInfo = new CProjectInfo(
+                "construct_engine",
+                GodotVersion.V451,
+                tempDir,
+                COptimizationLevel.DEBUG,
+                TargetPlatform.WINDOWS_X86_64
+        );
+        var builder = new CProjectBuilder();
+        builder.initProject(projectInfo);
+
+        var constructClass = newConstructEngineClass();
+        var module = new LirModule("construct_engine_module", List.of(constructClass));
+        var api = ExtensionApiLoader.loadVersion(GodotVersion.V451);
+        var codegen = new CCodegen();
+        codegen.prepare(new CodegenContext(projectInfo, new ClassRegistry(api)), module);
+
+        var buildResult = builder.buildProject(projectInfo, codegen);
+        assertTrue(buildResult.success(), "Compilation should succeed. Build log:\n" + buildResult.buildLog());
+        assertFalse(buildResult.artifacts().isEmpty(), "Compilation should produce extension artifacts.");
+
+        var runner = new GodotGdextensionTestRunner(Path.of("test_project"));
+        runner.prepareProject(new GodotGdextensionTestRunner.ProjectSetup(
+                buildResult.artifacts(),
+                List.of(new GodotGdextensionTestRunner.SceneNodeSpec(
+                        "ConstructNode",
+                        constructClass.getName(),
+                        ".",
+                        Map.of()
+                )),
+                new GodotGdextensionTestRunner.TestScriptSpec(testScript())
+        ));
+
+        var runResult = runner.run(true);
+        var combinedOutput = runResult.combinedOutput();
+
+        assertTrue(runResult.stopSignalSeen(), "Godot run should emit stop signal.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("explicit transform check passed."), "explicit transform should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("prepare transform check passed."), "prepare transform should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("explicit generic array check passed."), "explicit generic array should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("prepare generic array check passed."), "prepare generic array should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("explicit generic dictionary check passed."), "explicit generic dictionary should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("prepare generic dictionary check passed."), "prepare generic dictionary should pass.\nOutput:\n" + combinedOutput);
+        assertFalse(combinedOutput.contains("check failed"), "No check should fail.\nOutput:\n" + combinedOutput);
+    }
+
+    private static boolean hasZig() {
+        return ZigUtil.findZig() != null;
+    }
+
+    private static LirClassDef newConstructEngineClass() {
+        var clazz = new LirClassDef("GDConstructEngineNode", "Node");
+        clazz.setSourceFile("construct_engine.gd");
+
+        var selfType = new GdObjectType(clazz.getName());
+        clazz.addFunction(newExplicitTransformFunction(selfType));
+        clazz.addFunction(newPrepareTransformFunction(selfType));
+        clazz.addFunction(newExplicitGenericArrayFunction(selfType));
+        clazz.addFunction(newPrepareGenericArrayFunction(selfType));
+        clazz.addFunction(newExplicitGenericDictionaryFunction(selfType));
+        clazz.addFunction(newPrepareGenericDictionaryFunction(selfType));
+        return clazz;
+    }
+
+    private static LirFunctionDef newExplicitTransformFunction(GdObjectType selfType) {
+        var func = newMethod("make_transform2d_explicit", GdTransform2DType.TRANSFORM2D, selfType);
+        func.createAndAddVariable("xx", GdFloatType.FLOAT);
+        func.createAndAddVariable("xy", GdFloatType.FLOAT);
+        func.createAndAddVariable("yx", GdFloatType.FLOAT);
+        func.createAndAddVariable("yy", GdFloatType.FLOAT);
+        func.createAndAddVariable("tx", GdFloatType.FLOAT);
+        func.createAndAddVariable("ty", GdFloatType.FLOAT);
+        func.createAndAddVariable("t", GdTransform2DType.TRANSFORM2D);
+
+        var block = entry(func);
+        block.instructions().add(new LiteralFloatInsn("xx", 1.0));
+        block.instructions().add(new LiteralFloatInsn("xy", 0.0));
+        block.instructions().add(new LiteralFloatInsn("yx", 0.0));
+        block.instructions().add(new LiteralFloatInsn("yy", 1.0));
+        block.instructions().add(new LiteralFloatInsn("tx", 2.0));
+        block.instructions().add(new LiteralFloatInsn("ty", 3.0));
+        block.instructions().add(new ConstructBuiltinInsn(
+                "t",
+                List.of(
+                        varRef("xx"),
+                        varRef("xy"),
+                        varRef("yx"),
+                        varRef("yy"),
+                        varRef("tx"),
+                        varRef("ty")
+                )
+        ));
+        block.instructions().add(new ReturnInsn("t"));
+        return func;
+    }
+
+    private static LirFunctionDef newPrepareTransformFunction(GdObjectType selfType) {
+        var func = newMethod("make_transform2d_prepare", GdTransform2DType.TRANSFORM2D, selfType);
+        func.createAndAddVariable("t", GdTransform2DType.TRANSFORM2D);
+        entry(func).instructions().add(new ReturnInsn("t"));
+        return func;
+    }
+
+    private static LirFunctionDef newExplicitGenericArrayFunction(GdObjectType selfType) {
+        var arrayType = new GdArrayType(GdVariantType.VARIANT);
+        var func = newMethod("make_generic_array_explicit", arrayType, selfType);
+        func.createAndAddVariable("arr", arrayType);
+        entry(func).instructions().add(new ConstructArrayInsn("arr", null));
+        entry(func).instructions().add(new ReturnInsn("arr"));
+        return func;
+    }
+
+    private static LirFunctionDef newPrepareGenericArrayFunction(GdObjectType selfType) {
+        var arrayType = new GdArrayType(GdVariantType.VARIANT);
+        var func = newMethod("make_generic_array_prepare", arrayType, selfType);
+        func.createAndAddVariable("arr", arrayType);
+        entry(func).instructions().add(new ReturnInsn("arr"));
+        return func;
+    }
+
+    private static LirFunctionDef newExplicitGenericDictionaryFunction(GdObjectType selfType) {
+        var dictionaryType = new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT);
+        var func = newMethod("make_generic_dictionary_explicit", dictionaryType, selfType);
+        func.createAndAddVariable("dict", dictionaryType);
+        entry(func).instructions().add(new ConstructDictionaryInsn("dict", null, null));
+        entry(func).instructions().add(new ReturnInsn("dict"));
+        return func;
+    }
+
+    private static LirFunctionDef newPrepareGenericDictionaryFunction(GdObjectType selfType) {
+        var dictionaryType = new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT);
+        var func = newMethod("make_generic_dictionary_prepare", dictionaryType, selfType);
+        func.createAndAddVariable("dict", dictionaryType);
+        entry(func).instructions().add(new ReturnInsn("dict"));
+        return func;
+    }
+
+    private static LirFunctionDef newMethod(String name, dev.superice.gdcc.type.GdType returnType, GdObjectType selfType) {
+        var func = new LirFunctionDef(name);
+        func.setReturnType(returnType);
+        func.addParameter(new LirParameterDef("self", selfType, null, func));
+        func.addBasicBlock(new LirBasicBlock("entry"));
+        func.setEntryBlockId("entry");
+        return func;
+    }
+
+    private static LirBasicBlock entry(LirFunctionDef functionDef) {
+        return functionDef.getBasicBlock("entry");
+    }
+
+    private static LirInstruction.VariableOperand varRef(String id) {
+        return new LirInstruction.VariableOperand(id);
+    }
+
+    private static String testScript() {
+        return """
+                extends Node
+
+                const TARGET_NODE_NAME = "ConstructNode"
+                const EPSILON = 0.001
+
+                func _ready() -> void:
+                    var target = get_parent().get_node_or_null(TARGET_NODE_NAME)
+                    if target == null:
+                        push_error("Target node missing.")
+                        return
+
+                    var transform_explicit = target.call("make_transform2d_explicit")
+                    if _check_transform2d(transform_explicit, 2.0, 3.0):
+                        print("explicit transform check passed.")
+                    else:
+                        push_error("explicit transform check failed.")
+
+                    var transform_prepare = target.call("make_transform2d_prepare")
+                    if _check_transform2d(transform_prepare, 0.0, 0.0):
+                        print("prepare transform check passed.")
+                    else:
+                        push_error("prepare transform check failed.")
+
+                    var arr_explicit = target.call("make_generic_array_explicit")
+                    if _check_generic_array(arr_explicit):
+                        print("explicit generic array check passed.")
+                    else:
+                        push_error("explicit generic array check failed.")
+
+                    var arr_prepare = target.call("make_generic_array_prepare")
+                    if _check_generic_array(arr_prepare):
+                        print("prepare generic array check passed.")
+                    else:
+                        push_error("prepare generic array check failed.")
+
+                    var dict_explicit = target.call("make_generic_dictionary_explicit")
+                    if _check_generic_dictionary(dict_explicit):
+                        print("explicit generic dictionary check passed.")
+                    else:
+                        push_error("explicit generic dictionary check failed.")
+
+                    var dict_prepare = target.call("make_generic_dictionary_prepare")
+                    if _check_generic_dictionary(dict_prepare):
+                        print("prepare generic dictionary check passed.")
+                    else:
+                        push_error("prepare generic dictionary check failed.")
+
+                func _check_transform2d(value: Variant, tx: float, ty: float) -> bool:
+                    if typeof(value) != TYPE_TRANSFORM2D:
+                        return false
+                    var t: Transform2D = value
+                    return absf(t.x.x - 1.0) <= EPSILON \
+                            and absf(t.x.y - 0.0) <= EPSILON \
+                            and absf(t.y.x - 0.0) <= EPSILON \
+                            and absf(t.y.y - 1.0) <= EPSILON \
+                            and absf(t.origin.x - tx) <= EPSILON \
+                            and absf(t.origin.y - ty) <= EPSILON
+
+                func _check_generic_array(value: Variant) -> bool:
+                    if typeof(value) != TYPE_ARRAY:
+                        return false
+                    var arr: Array = value
+                    return not arr.is_typed() and arr.size() == 0
+
+                func _check_generic_dictionary(value: Variant) -> bool:
+                    if typeof(value) != TYPE_DICTIONARY:
+                        return false
+                    var dict: Dictionary = value
+                    return not dict.is_typed() and dict.is_empty()
+                """;
+    }
+}

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
@@ -1,0 +1,310 @@
+package dev.superice.gdcc.backend.c.gen;
+
+import dev.superice.gdcc.backend.CodegenContext;
+import dev.superice.gdcc.backend.ProjectInfo;
+import dev.superice.gdcc.enums.GodotVersion;
+import dev.superice.gdcc.exception.InvalidInsnException;
+import dev.superice.gdcc.gdextension.ExtensionAPI;
+import dev.superice.gdcc.lir.LirBasicBlock;
+import dev.superice.gdcc.lir.LirClassDef;
+import dev.superice.gdcc.lir.LirFunctionDef;
+import dev.superice.gdcc.lir.LirInstruction;
+import dev.superice.gdcc.lir.LirModule;
+import dev.superice.gdcc.lir.insn.ConstructArrayInsn;
+import dev.superice.gdcc.lir.insn.ConstructBuiltinInsn;
+import dev.superice.gdcc.lir.insn.ConstructDictionaryInsn;
+import dev.superice.gdcc.lir.insn.ReturnInsn;
+import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdFloatType;
+import dev.superice.gdcc.type.GdStringNameType;
+import dev.superice.gdcc.type.GdStringType;
+import dev.superice.gdcc.type.GdTransform2DType;
+import dev.superice.gdcc.type.GdVariantType;
+import dev.superice.gdcc.type.GdVoidType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CConstructInsnGenTest {
+    @Test
+    @DisplayName("construct_builtin should emit helper-shim constructor call for Transform2D with 6 float args")
+    void constructBuiltinShouldEmitTransform2DHelperCtor() {
+        var clazz = newTestClass();
+        var func = newFunction("construct_transform2d");
+        func.createAndAddVariable("a", GdFloatType.FLOAT);
+        func.createAndAddVariable("b", GdFloatType.FLOAT);
+        func.createAndAddVariable("c", GdFloatType.FLOAT);
+        func.createAndAddVariable("d", GdFloatType.FLOAT);
+        func.createAndAddVariable("e", GdFloatType.FLOAT);
+        func.createAndAddVariable("f", GdFloatType.FLOAT);
+        func.createAndAddVariable("t", GdTransform2DType.TRANSFORM2D);
+
+        entry(func).instructions().add(new ConstructBuiltinInsn(
+                "t",
+                List.of(
+                        new LirInstruction.VariableOperand("a"),
+                        new LirInstruction.VariableOperand("b"),
+                        new LirInstruction.VariableOperand("c"),
+                        new LirInstruction.VariableOperand("d"),
+                        new LirInstruction.VariableOperand("e"),
+                        new LirInstruction.VariableOperand("f")
+                )
+        ));
+        clazz.addFunction(func);
+
+        var body = generateBody(clazz, func);
+        assertTrue(body.contains("godot_new_Transform2D_with_float_float_float_float_float_float"));
+    }
+
+    @Test
+    @DisplayName("construct_builtin should reject non-variable operands")
+    void constructBuiltinShouldRejectNonVariableOperand() {
+        var clazz = newTestClass();
+        var func = newFunction("construct_builtin_non_var_operand");
+        func.createAndAddVariable("t", GdTransform2DType.TRANSFORM2D);
+
+        entry(func).instructions().add(new ConstructBuiltinInsn(
+                "t",
+                List.of(new LirInstruction.StringOperand("not_var"))
+        ));
+        clazz.addFunction(func);
+
+        var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("must be a variable operand"));
+    }
+
+    @Test
+    @DisplayName("construct_array should emit typed Array constructor when operand type matches result type")
+    void constructArrayShouldEmitTypedCtor() {
+        var clazz = newTestClass();
+        var func = newFunction("construct_typed_array");
+        func.createAndAddVariable("arr", new GdArrayType(GdStringNameType.STRING_NAME));
+
+        entry(func).instructions().add(new ConstructArrayInsn("arr", "StringName"));
+        clazz.addFunction(func);
+
+        var body = generateBody(clazz, func);
+        assertTrue(body.contains("godot_new_Array_with_Array_int_StringName_Variant"));
+        assertTrue(body.contains("GDEXTENSION_VARIANT_TYPE_STRING_NAME"));
+    }
+
+    @Test
+    @DisplayName("construct_array should fail when provided class_name does not match result element type")
+    void constructArrayShouldRejectTypeMismatch() {
+        var clazz = newTestClass();
+        var func = newFunction("construct_array_mismatch");
+        func.createAndAddVariable("arr", new GdArrayType(GdStringNameType.STRING_NAME));
+
+        entry(func).instructions().add(new ConstructArrayInsn("arr", "String"));
+        clazz.addFunction(func);
+
+        var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("construct_array type mismatch"));
+    }
+
+    @Test
+    @DisplayName("construct_dictionary should emit typed Dictionary constructor when key/value operands match result types")
+    void constructDictionaryShouldEmitTypedCtor() {
+        var clazz = newTestClass();
+        var func = newFunction("construct_typed_dictionary");
+        func.createAndAddVariable("dict", new GdDictionaryType(GdStringNameType.STRING_NAME, GdVariantType.VARIANT));
+
+        entry(func).instructions().add(new ConstructDictionaryInsn("dict", "StringName", "Variant"));
+        clazz.addFunction(func);
+
+        var body = generateBody(clazz, func);
+        assertTrue(body.contains("godot_new_Dictionary_with_Dictionary_int_StringName_Variant_int_StringName_Variant"));
+        assertTrue(body.contains("GDEXTENSION_VARIANT_TYPE_STRING_NAME"));
+        assertTrue(body.contains("GDEXTENSION_VARIANT_TYPE_NIL"));
+    }
+
+    @Test
+    @DisplayName("construct_dictionary should fail when provided key/value types do not match result types")
+    void constructDictionaryShouldRejectTypeMismatch() {
+        var clazz = newTestClass();
+        var func = newFunction("construct_dictionary_mismatch");
+        func.createAndAddVariable("dict", new GdDictionaryType(GdStringNameType.STRING_NAME, GdVariantType.VARIANT));
+
+        entry(func).instructions().add(new ConstructDictionaryInsn("dict", "String", "Variant"));
+        clazz.addFunction(func);
+
+        var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("construct_dictionary key type mismatch"));
+    }
+
+    @Test
+    @DisplayName("construct_dictionary should fail when one-side typed operand implies Variant but result value type is non-Variant")
+    void constructDictionaryShouldRejectImplicitVariantValueMismatch() {
+        var clazz = newTestClass();
+        var func = newFunction("construct_dictionary_partial_operand_mismatch");
+        func.createAndAddVariable("dict", new GdDictionaryType(GdStringNameType.STRING_NAME, GdStringType.STRING));
+
+        entry(func).instructions().add(new ConstructDictionaryInsn("dict", "StringName", null));
+        clazz.addFunction(func);
+
+        var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("construct_dictionary value type mismatch"));
+    }
+
+    @Test
+    @DisplayName("generate should inject typed construct instructions into __prepare__ for Array and Dictionary variables")
+    void generateShouldInjectConstructInstructionsIntoPrepareBlock() {
+        var clazz = newTestClass();
+        var func = newFunction("prepare_inject_constructs");
+        func.createAndAddVariable("arr", new GdArrayType(GdStringNameType.STRING_NAME));
+        func.createAndAddVariable("dict", new GdDictionaryType(GdStringNameType.STRING_NAME, GdVariantType.VARIANT));
+        entry(func).instructions().add(new ReturnInsn(null));
+        clazz.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(clazz));
+        var codegen = newCodegen(module, List.of(clazz));
+        codegen.generate();
+
+        var prepare = func.getBasicBlock("__prepare__");
+        assertNotNull(prepare);
+        assertEquals("__prepare__", func.getEntryBlockId());
+
+        var hasArrayInsn = prepare.instructions().stream()
+                .filter(ConstructArrayInsn.class::isInstance)
+                .map(ConstructArrayInsn.class::cast)
+                .anyMatch(insn -> "arr".equals(insn.resultId()) && "StringName".equals(insn.className()));
+        assertTrue(hasArrayInsn);
+
+        var hasDictionaryInsn = prepare.instructions().stream()
+                .filter(ConstructDictionaryInsn.class::isInstance)
+                .map(ConstructDictionaryInsn.class::cast)
+                .anyMatch(insn ->
+                        "dict".equals(insn.resultId()) &&
+                                "StringName".equals(insn.keyClassName()) &&
+                                "Variant".equals(insn.valueClassName())
+                );
+        assertTrue(hasDictionaryInsn);
+    }
+
+    @Test
+    @DisplayName("__prepare__ generated typed construct instructions should emit typed constructor C calls")
+    void generatedPrepareConstructsShouldEmitTypedConstructorCalls() {
+        var clazz = newTestClass();
+        var func = newFunction("prepare_emit_typed_ctor_calls");
+        func.createAndAddVariable("arr", new GdArrayType(GdStringNameType.STRING_NAME));
+        func.createAndAddVariable("dict", new GdDictionaryType(GdStringNameType.STRING_NAME, GdVariantType.VARIANT));
+        entry(func).instructions().add(new ReturnInsn(null));
+        clazz.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(clazz));
+        var codegen = newCodegen(module, List.of(clazz));
+        codegen.generate();
+
+        var body = codegen.generateFuncBody(clazz, func);
+        assertTrue(body.contains("__prepare__: // __prepare__"));
+        assertTrue(body.contains("godot_new_Array_with_Array_int_StringName_Variant"));
+        assertTrue(body.contains("godot_new_Dictionary_with_Dictionary_int_StringName_Variant_int_StringName_Variant"));
+    }
+
+    @Test
+    @DisplayName("__prepare__ construct_array should fail fast on type mismatch")
+    void prepareConstructArrayTypeMismatchShouldFailFast() {
+        var clazz = newTestClass();
+        var func = new LirFunctionDef("prepare_array_mismatch");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("arr", new GdArrayType(GdStringNameType.STRING_NAME));
+
+        var prepare = new LirBasicBlock("__prepare__");
+        prepare.instructions().add(new ConstructArrayInsn("arr", "String"));
+        func.addBasicBlock(prepare);
+        func.setEntryBlockId("__prepare__");
+        clazz.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(clazz));
+        var codegen = newCodegen(module, List.of(clazz));
+        var ex = assertThrows(InvalidInsnException.class, () -> codegen.generateFuncBody(clazz, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("construct_array type mismatch"));
+    }
+
+    @Test
+    @DisplayName("__prepare__ construct_dictionary should fail fast on type mismatch")
+    void prepareConstructDictionaryTypeMismatchShouldFailFast() {
+        var clazz = newTestClass();
+        var func = new LirFunctionDef("prepare_dictionary_mismatch");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dict", new GdDictionaryType(GdStringNameType.STRING_NAME, GdVariantType.VARIANT));
+
+        var prepare = new LirBasicBlock("__prepare__");
+        prepare.instructions().add(new ConstructDictionaryInsn("dict", "String", "Variant"));
+        func.addBasicBlock(prepare);
+        func.setEntryBlockId("__prepare__");
+        clazz.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(clazz));
+        var codegen = newCodegen(module, List.of(clazz));
+        var ex = assertThrows(InvalidInsnException.class, () -> codegen.generateFuncBody(clazz, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("construct_dictionary key type mismatch"));
+    }
+
+    private LirClassDef newTestClass() {
+        return new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+    }
+
+    private LirFunctionDef newFunction(String name) {
+        var func = new LirFunctionDef(name);
+        func.setReturnType(GdVoidType.VOID);
+        var entry = new LirBasicBlock("entry");
+        func.addBasicBlock(entry);
+        func.setEntryBlockId("entry");
+        return func;
+    }
+
+    private LirBasicBlock entry(LirFunctionDef functionDef) {
+        return functionDef.getBasicBlock("entry");
+    }
+
+    private String generateBody(LirClassDef clazz, LirFunctionDef func) {
+        var module = new LirModule("test_module", List.of(clazz));
+        var codegen = newCodegen(module, List.of(clazz));
+        return codegen.generateFuncBody(clazz, func);
+    }
+
+    private CCodegen newCodegen(LirModule module, List<LirClassDef> gdccClasses) {
+        var classRegistry = new ClassRegistry(emptyApi());
+        for (var gdccClass : gdccClasses) {
+            classRegistry.addGdccClass(gdccClass);
+        }
+        ProjectInfo projectInfo = new ProjectInfo("TestProject", GodotVersion.V451, Path.of(".")) {
+        };
+        var ctx = new CodegenContext(projectInfo, classRegistry);
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+        return codegen;
+    }
+
+    private ExtensionAPI emptyApi() {
+        return new ExtensionAPI(
+                null,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+        );
+    }
+}

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -81,7 +80,6 @@ class CConstructInsnGenTest {
         clazz.addFunction(func);
 
         var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
-        assertInstanceOf(InvalidInsnException.class, ex);
         assertTrue(ex.getMessage().contains("must be a variable operand"));
     }
 
@@ -111,7 +109,6 @@ class CConstructInsnGenTest {
         clazz.addFunction(func);
 
         var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
-        assertInstanceOf(InvalidInsnException.class, ex);
         assertTrue(ex.getMessage().contains("construct_array type mismatch"));
     }
 
@@ -142,7 +139,6 @@ class CConstructInsnGenTest {
         clazz.addFunction(func);
 
         var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
-        assertInstanceOf(InvalidInsnException.class, ex);
         assertTrue(ex.getMessage().contains("construct_dictionary key type mismatch"));
     }
 
@@ -157,7 +153,6 @@ class CConstructInsnGenTest {
         clazz.addFunction(func);
 
         var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
-        assertInstanceOf(InvalidInsnException.class, ex);
         assertTrue(ex.getMessage().contains("construct_dictionary value type mismatch"));
     }
 
@@ -233,7 +228,6 @@ class CConstructInsnGenTest {
         var module = new LirModule("test_module", List.of(clazz));
         var codegen = newCodegen(module, List.of(clazz));
         var ex = assertThrows(InvalidInsnException.class, () -> codegen.generateFuncBody(clazz, func));
-        assertInstanceOf(InvalidInsnException.class, ex);
         assertTrue(ex.getMessage().contains("construct_array type mismatch"));
     }
 
@@ -254,7 +248,6 @@ class CConstructInsnGenTest {
         var module = new LirModule("test_module", List.of(clazz));
         var codegen = newCodegen(module, List.of(clazz));
         var ex = assertThrows(InvalidInsnException.class, () -> codegen.generateFuncBody(clazz, func));
-        assertInstanceOf(InvalidInsnException.class, ex);
         assertTrue(ex.getMessage().contains("construct_dictionary key type mismatch"));
     }
 

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CLoadPropertyInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CLoadPropertyInsnGenTest.java
@@ -16,9 +16,11 @@ import dev.superice.gdcc.lir.LirPropertyDef;
 import dev.superice.gdcc.lir.insn.LoadPropertyInsn;
 import dev.superice.gdcc.lir.insn.ReturnInsn;
 import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
 import dev.superice.gdcc.type.GdFloatType;
 import dev.superice.gdcc.type.GdFloatVectorType;
 import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdStringNameType;
 import dev.superice.gdcc.type.GdStringType;
 import dev.superice.gdcc.type.GdVoidType;
 import org.junit.jupiter.api.DisplayName;
@@ -220,6 +222,34 @@ public class CLoadPropertyInsnGenTest {
         assertTrue(body.contains("__gdcc_tmp_variant_0 = godot_Object_get($obj, GD_STATIC_SN(u8\"target\"));"));
         assertTrue(body.contains("$tmp = (TargetClass*)godot_new_gdcc_Object_with_Variant(&__gdcc_tmp_variant_0);"));
         assertFalse(body.contains("godot_UnknownType_get_target("));
+    }
+
+    @Test
+    @DisplayName("Unknown object type should unpack typed Array using normalized symbol name")
+    void unknownObjectTypeShouldUnpackTypedArrayWithNormalizedSymbol() {
+        var gdccClass = new LirClassDef("TestClass", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("get_unknown_array_prop");
+        func.setReturnType(GdVoidType.VOID);
+        func.addParameter(new LirParameterDef("obj", new GdObjectType("UnknownType"), null, func));
+        func.createAndAddVariable("tmp", new GdArrayType(GdStringNameType.STRING_NAME));
+
+        var entry = new LirBasicBlock("entry");
+        entry.instructions().add(new LoadPropertyInsn("tmp", "items", "obj"));
+        entry.instructions().add(new ReturnInsn(null));
+        func.addBasicBlock(entry);
+        func.setEntryBlockId("entry");
+        gdccClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(gdccClass));
+        var ctx = newContext(new ExtensionAPI(null, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of()),
+                List.of(gdccClass));
+
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+
+        var body = codegen.generateFuncBody(gdccClass, func);
+        assertTrue(body.contains("$tmp = godot_new_Array_with_Variant(&__gdcc_tmp_variant_0);"));
+        assertFalse(body.contains("godot_new_Array["));
     }
 
     @Test

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CPackUnpackVariantInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CPackUnpackVariantInsnGenTest.java
@@ -13,7 +13,10 @@ import dev.superice.gdcc.lir.insn.PackVariantInsn;
 import dev.superice.gdcc.lir.insn.ReturnInsn;
 import dev.superice.gdcc.lir.insn.UnpackVariantInsn;
 import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdDictionaryType;
 import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdStringNameType;
 import dev.superice.gdcc.type.GdStringType;
 import dev.superice.gdcc.type.GdVariantType;
 import dev.superice.gdcc.type.GdVoidType;
@@ -120,6 +123,54 @@ public class CPackUnpackVariantInsnGenTest {
         assertTrue(body.contains("godot_Variant_destroy(&$result);"));
         assertTrue(body.contains("$result = godot_new_Variant_with_gdcc_Object($value);"));
         assertFalse(body.contains("godot_new_Variant_with_gdcc_Object(godot_object_from_gdcc_object_ptr($value));"));
+    }
+
+    @Test
+    @DisplayName("pack_variant from typed Array should use normalized Array symbol without generic suffix")
+    void packVariantFromTypedArrayShouldUseNormalizedArraySymbol() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("pack_typed_array");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("result", GdVariantType.VARIANT);
+        func.createAndAddVariable("value", new GdArrayType(GdStringNameType.STRING_NAME));
+
+        var entry = new LirBasicBlock("entry");
+        entry.instructions().add(new PackVariantInsn("result", "value"));
+        entry.instructions().add(new ReturnInsn(null));
+        func.addBasicBlock(entry);
+        func.setEntryBlockId("entry");
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("$result = godot_new_Variant_with_Array(&$value);"));
+        assertFalse(body.contains("godot_new_Variant_with_Array["));
+    }
+
+    @Test
+    @DisplayName("unpack_variant to typed Dictionary should use normalized Dictionary symbol without generic suffix")
+    void unpackVariantToTypedDictionaryShouldUseNormalizedDictionarySymbol() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("unpack_typed_dictionary");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("result", new GdDictionaryType(GdStringNameType.STRING_NAME, GdVariantType.VARIANT));
+        func.createAndAddVariable("variant", GdVariantType.VARIANT);
+
+        var entry = new LirBasicBlock("entry");
+        entry.instructions().add(new UnpackVariantInsn("result", "variant"));
+        entry.instructions().add(new ReturnInsn(null));
+        func.addBasicBlock(entry);
+        func.setEntryBlockId("entry");
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("$result = godot_new_Dictionary_with_Variant(&$variant);"));
+        assertFalse(body.contains("godot_new_Dictionary["));
     }
 
     private ExtensionAPI emptyApi() {

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CStorePropertyInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CStorePropertyInsnGenTest.java
@@ -17,10 +17,13 @@ import dev.superice.gdcc.lir.insn.LoadPropertyInsn;
 import dev.superice.gdcc.lir.insn.ReturnInsn;
 import dev.superice.gdcc.lir.insn.StorePropertyInsn;
 import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdDictionaryType;
 import dev.superice.gdcc.type.GdFloatType;
 import dev.superice.gdcc.type.GdFloatVectorType;
 import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdStringNameType;
 import dev.superice.gdcc.type.GdStringType;
+import dev.superice.gdcc.type.GdVariantType;
 import dev.superice.gdcc.type.GdVoidType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -227,6 +230,30 @@ public class CStorePropertyInsnGenTest {
         assertTrue(body.contains("__gdcc_tmp_variant_0 = godot_new_Variant_with_String("));
         assertTrue(body.contains("godot_Object_set($obj, GD_STATIC_SN(u8\"name\"), &__gdcc_tmp_variant_0);"));
         assertFalse(body.contains("godot_UnknownType_set_name("));
+    }
+
+    @Test
+    @DisplayName("Unknown object type should pack typed Dictionary using normalized symbol name")
+    void unknownObjectTypeShouldPackTypedDictionaryWithNormalizedSymbol() {
+        var gdccClass = new LirClassDef("TestClass", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("set_unknown_typed_dict");
+        func.setReturnType(GdVoidType.VOID);
+        func.addParameter(new LirParameterDef("obj", new GdObjectType("UnknownType"), null, func));
+        func.addParameter(
+                new LirParameterDef("value", new GdDictionaryType(GdStringNameType.STRING_NAME, GdVariantType.VARIANT), null, func)
+        );
+        addEntryStoreAndReturn(func, new StorePropertyInsn("meta", "obj", "value"));
+        gdccClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(gdccClass));
+        var ctx = newContext(emptyApi(), List.of(gdccClass));
+
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+
+        var body = codegen.generateFuncBody(gdccClass, func);
+        assertTrue(body.contains("__gdcc_tmp_variant_0 = godot_new_Variant_with_Dictionary("));
+        assertFalse(body.contains("godot_new_Variant_with_Dictionary["));
     }
 
     @Test


### PR DESCRIPTION
## What changed
- Added C backend code generation support for `construct_builtin`, `construct_array`, and `construct_dictionary` in `ConstructInsnGen`.
- Enforced strict type-hint validation for typed container construction:
  - `construct_array` verifies provided element type matches result variable element type.
  - `construct_dictionary` verifies provided key/value types match result variable key/value types.
- Wired construct paths through `CBuiltinBuilder` typed constructor generation for Array/Dictionary.
- Normalized generated C symbol names for container-related pack/unpack/copy paths to prevent invalid identifiers from generic type text.
- Added safe temp-prefix normalization in `CBodyBuilder` and precompiled the regex used by `renderSafeTempPrefix` for lower overhead.
- Expanded tests:
  - unit tests for construct insns (including `__prepare__` validation/fail-fast)
  - unit tests for pack/unpack and property GENERAL fallback with typed containers
  - phase-C tests for typed container copy/return temp naming
  - engine test updates to verify typed container construct code emission and runtime stability for existing construct scenarios.

## Why
This closes gaps in construct instruction support and prevents invalid generated C identifiers like `godot_new_Variant_with_Array[StringName]`, while preserving compatibility and lifecycle behavior in existing paths.

## Affected packages
- `dev.superice.gdcc.backend.c.gen`
- `dev.superice.gdcc.backend.c.gen.insn`
- `dev.superice.gdcc.backend.c.gen` tests

## Test commands run
- `./gradlew.bat test --tests dev.superice.gdcc.backend.c.gen.CConstructInsnGenTest --no-daemon --info --console=plain`
- `./gradlew.bat test --tests dev.superice.gdcc.backend.c.gen.CConstructInsnGenEngineTest --no-daemon --info --console=plain`
- `./gradlew.bat test --tests dev.superice.gdcc.backend.c.gen.CPackUnpackVariantInsnGenTest --no-daemon --info --console=plain`

