### PR TITLE
fix(backend): enforce helper-only GDCC object conversion and inheritance-safe dispatch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,79 @@
+## Summary
+<!--
+1-3 sentences.
+State the main feature/fix and subsystem (frontend / HIR / LIR / backend).
+-->
+
+## What changed
+<!--
+List concrete changes grouped by responsibility.
+Prefer specific components/classes/files.
+-->
+- 
+
+## Why
+<!--
+Explain root problem or missing capability.
+Include design rationale when trade-offs exist.
+-->
+- 
+
+## Affected packages/files
+<!--
+List impacted packages and key files.
+For large PRs, keep this review-relevant.
+-->
+- 
+
+## Validation
+<!--
+Provide exact commands that were run.
+Prefer targeted tests during iteration.
+Use required flags: --no-daemon --info --console=plain
+-->
+- `./gradlew test --tests <TestClassOrMethod> --no-daemon --info --console=plain`
+- `./gradlew classes --no-daemon --info --console=plain`
+
+Result: `BUILD SUCCESSFUL`
+
+## Risks / Notes
+<!--
+List intentional limitations/non-goals and follow-up work.
+If behavior contracts changed (IR validation, ownership lifecycle, type compatibility, codegen semantics), state explicitly.
+-->
+- 
+
+## Key behaviors covered (Optional)
+<!--
+For compiler/codegen semantics, e.g. dispatch rules, type checks, lifecycle handling, vararg/default argument contracts.
+-->
+- 
+
+## Diff stats (Optional)
+<!--
+Useful for large PRs.
+Example: 12 files changed, 520 insertions, 74 deletions.
+-->
+- 
+
+## Breaking changes (Optional)
+<!--
+Required when API/behavior compatibility changes.
+-->
+- None
+
+## Related docs (Optional)
+<!--
+Link updated docs under doc/.
+-->
+- `doc/pr_message_guideline.md`
+
+---
+
+## Checklist
+- [ ] PR title follows Conventional Commits format: `<type>(<scope>): <imperative summary>`
+- [ ] PR body is in English
+- [ ] Required sections are complete (`Summary`, `What changed`, `Why`, `Affected packages/files`, `Validation`, `Risks / Notes`)
+- [ ] Validation commands are exact and reproducible
+- [ ] Semantics/ownership/type-contract impacts are clearly described when applicable
+- [ ] Scope and non-goals are explicit

--- a/doc/gdcc_c_backend.md
+++ b/doc/gdcc_c_backend.md
@@ -52,6 +52,14 @@
   - Do not mix with parent helper unless the value has already been upcast safely.
 - Any touched legacy path that still depends on the deprecated macro must be migrated in the same change or explicitly tracked as migration debt.
 
+### Stage 4 Alignment (2026-02-27)
+
+- `CBodyBuilder` 已对齐到专用 helper 转换基线：
+  - GDCC -> Godot 统一生成 `gdcc_object_to_godot_object_ptr(value, Type_object_ptr)`。
+  - `CALL_METHOD` receiver 为 GDCC 且 owner 为 ENGINE 时，先 helper 转换，再执行 engine 指针 cast。
+  - GDCC 子类 -> GDCC 父类上行由 `_super` 链表达式承载，不走裸 C cast。
+- `CallMethodInsnGen`/`CBodyBuilder` 回归测试文本断言已切到 helper 入口，相关链路不再回退到 `godot_object_from_gdcc_object_ptr(...)`。
+
 ### Implementing a New Instruction Generator
 
 - Each instruction generator implements `CInsnGen`, for those who wants to use FreeMarker templates, they can extend `TemplateInsnGen`.

--- a/doc/gdcc_c_backend.md
+++ b/doc/gdcc_c_backend.md
@@ -6,6 +6,9 @@
 
 - GDCC types cannot be used directly as a `godot_Object*` or `GDExtensionObjectPtr`, they need to be converted first.
   - Convert into Godot object pointer using generated per-class helper functions.
+  - Preferred conversion macro: `gdcc_object_to_godot_object_ptr(obj, Class_object_ptr)`.
+    - `obj` must be a GDCC wrapper pointer value.
+    - `Class_object_ptr` must be the generated helper for the static type of `obj`.
   - `godot_object_from_gdcc_object_ptr` is deprecated and must not be used in new or migrated code paths.
   - Convert from Godot object pointer using `gdcc_object_from_godot_object_ptr(GDExtensionObjectPtr ptr)`.
   - `Variant` can be converted to/from GDCC types using `godot_new_Variant_with_gdcc_Object` and `godot_new_gdcc_Object_with_Variant`.
@@ -42,6 +45,11 @@
 - This baseline is effective immediately and must be treated as a gate for follow-up implementation.
 - `godot_object_from_gdcc_object_ptr` is deprecated and must not appear in newly modified code.
 - All GDCC -> Godot pointer conversions must use generated, class-specific helper functions.
+- Standard form for conversion in generated C code:
+  - `gdcc_object_to_godot_object_ptr($value, MyGdccType_object_ptr)`
+- Keep static type and helper matched:
+  - If the value static type is `MyChild*`, use `MyChild_object_ptr`.
+  - Do not mix with parent helper unless the value has already been upcast safely.
 - Any touched legacy path that still depends on the deprecated macro must be migrated in the same change or explicitly tracked as migration debt.
 
 ### Implementing a New Instruction Generator

--- a/doc/gdcc_c_backend.md
+++ b/doc/gdcc_c_backend.md
@@ -5,7 +5,8 @@
 ### Use GDCC Class Types
 
 - GDCC types cannot be used directly as a `godot_Object*` or `GDExtensionObjectPtr`, they need to be converted first.
-  - Convert into Godot object pointer using `godot_object_from_gdcc_object_ptr(gdcc_object)`.
+  - Convert into Godot object pointer using generated per-class helper functions.
+  - `godot_object_from_gdcc_object_ptr` is deprecated and must not be used in new or migrated code paths.
   - Convert from Godot object pointer using `gdcc_object_from_godot_object_ptr(GDExtensionObjectPtr ptr)`.
   - `Variant` can be converted to/from GDCC types using `godot_new_Variant_with_gdcc_Object` and `godot_new_gdcc_Object_with_Variant`.
 - `godot_float` is usually a typedef for `double`, but it should always be used as `godot_float` for compatibility.
@@ -33,8 +34,15 @@
 - For type mapping between compiler types and C types:
   - GDCC types are directly used as C types, e.g., `MyCustomGdClass` is used as `MyCustomGdClass*`.
   - Other types are mapped with a `godot_` prefix, e.g., `int` is mapped to `godot_int`, `String` is mapped to `godot_String`.
-- Always remember GDExtension API does not receive GDCC object ptrs, convert them to `godot_Object*` using `godot_object_from_gdcc_object_ptr(gdcc_object)` first.
+- Always remember GDExtension API does not receive GDCC object ptrs, convert them to `godot_Object*` using generated per-class helper functions first.
 - When receiving `godot_Object*` from GDExtension API that is actually a GDCC object, convert it to the correct GDCC type using `gdcc_object_from_godot_object_ptr(GDExtensionObjectPtr ptr)` if necessary.
+
+### Pointer Conversion Baseline (Mandatory)
+
+- This baseline is effective immediately and must be treated as a gate for follow-up implementation.
+- `godot_object_from_gdcc_object_ptr` is deprecated and must not appear in newly modified code.
+- All GDCC -> Godot pointer conversions must use generated, class-specific helper functions.
+- Any touched legacy path that still depends on the deprecated macro must be migrated in the same change or explicitly tracked as migration debt.
 
 ### Implementing a New Instruction Generator
 
@@ -57,7 +65,7 @@
 - `gdcc_object_from_godot_object_ptr` does not own the object, you still need to call `try_own_object` or `own_object` to retain the object if you want to keep it.
 - When construct a `Variant` from an object, the new `Variant` owns the object, so you do not need to call `try_own_object` or `own_object` again.
 - `try_own_object`, `try_release_object` are safe to use on non-ref-counted objects, they will do nothing in that case, but always use non-try version if you are 100% sure the object is ref-counted for better performance.
-- `try_own_object`, `try_release_object`, `own_object` and `release_object` receives only Godot object ptr but not GDCC object ptr, so remember to pass `godot_object_from_gdcc_object_ptr(gdcc_object)` instead of `gdcc_object`.
+- `try_own_object`, `try_release_object`, `own_object` and `release_object` receives only Godot object ptr but not GDCC object ptr, so remember to pass helper-converted Godot object ptr instead of raw `gdcc_object`.
 - `try_destroy_object` is used to destroy an object that we own, if an object is ref-counted it is the same as `try_release_object`, if it is not ref-counted, it will be actually destroyed, so always remember to check the type and use it properly.
 - Call lifecycle functions on `NULL` is safe, they will do nothing in that case, so you do not need to check if the pointer is `NULL` before calling lifecycle functions.
 

--- a/doc/gdcc_ownership_lifecycle_spec.md
+++ b/doc/gdcc_ownership_lifecycle_spec.md
@@ -36,7 +36,7 @@ A writable storage location, including but not limited to:
 ### 2.3 Representation Conversion
 
 - Conversion between GDCC object pointers (`<Type*>`) and Godot raw object pointers
-- For example: `gdcc_object_from_godot_object_ptr(...)`, `godot_object_from_gdcc_object_ptr(...)`
+- For example: `gdcc_object_from_godot_object_ptr(...)`, `gdcc_object_to_godot_object_ptr(obj, Class_object_ptr)`
 
 **Representation conversion does not change ownership category.**
 

--- a/doc/module_impl/call_method_implementation.md
+++ b/doc/module_impl/call_method_implementation.md
@@ -87,6 +87,7 @@
 
 ### 4. 指针转换安全约束
 
+- GDCC -> Godot 对象指针转换必须使用“按类生成的专用 helper”；`godot_object_from_gdcc_object_ptr` 视为废弃，不得用于新增或迁移后的路径。
 - 当 receiver 是 GDCC wrapper，但目标 owner 为 ENGINE 时，必须先做 GDCC -> Godot raw ptr 转换，再按需要 cast 到 `godot_<Owner>*`。
 - 禁止仅通过 C cast 把 GDCC wrapper 指针伪装成 engine 指针。
 - `CBodyBuilder.renderArgument(...)` 的 ptr kind/type fail-fast 防线属于不可回退约束。

--- a/doc/module_impl/call_method_implementation.md
+++ b/doc/module_impl/call_method_implementation.md
@@ -94,6 +94,16 @@
 - 禁止仅通过 C cast 把 GDCC wrapper 指针伪装成 engine 指针。
 - `CBodyBuilder.renderArgument(...)` 的 ptr kind/type fail-fast 防线属于不可回退约束。
 
+#### 阶段 4 对齐结论（2026-02-27）
+
+- `CALL_METHOD` 相关 receiver 转换已与基线一致：
+  - GDCC receiver -> ENGINE owner：生成 `gdcc_object_to_godot_object_ptr(receiver, ReceiverType_object_ptr)`，随后再 cast 到 `godot_<Owner>*`。
+  - GDCC 子类 receiver -> GDCC 父类 owner：生成 `_super` 链安全上行表达式（例如 `&($child->_super)`），无裸 cast。
+- 回归覆盖已同步到以下测试，且断言与当前实现一致：
+  - `CallMethodInsnGenTest`
+  - `CallMethodInsnGenEngineTest`
+  - `CBodyBuilderPhaseCTest`
+
 ### 5. `VARIANT_DYNAMIC` 诊断定位约束
 
 - `file_name` 优先使用 `LirClassDef.sourceFile`，缺失时回退类名。

--- a/doc/module_impl/call_method_implementation.md
+++ b/doc/module_impl/call_method_implementation.md
@@ -88,6 +88,8 @@
 ### 4. 指针转换安全约束
 
 - GDCC -> Godot 对象指针转换必须使用“按类生成的专用 helper”；`godot_object_from_gdcc_object_ptr` 视为废弃，不得用于新增或迁移后的路径。
+- 推荐统一写法：`gdcc_object_to_godot_object_ptr(value, Type_object_ptr)`。
+- `value` 的静态类型与 `Type_object_ptr` 必须匹配；若已安全上行转换到父类类型，才允许切换为父类 helper。
 - 当 receiver 是 GDCC wrapper，但目标 owner 为 ENGINE 时，必须先做 GDCC -> Godot raw ptr 转换，再按需要 cast 到 `godot_<Owner>*`。
 - 禁止仅通过 C cast 把 GDCC wrapper 指针伪装成 engine 指针。
 - `CBodyBuilder.renderArgument(...)` 的 ptr kind/type fail-fast 防线属于不可回退约束。

--- a/doc/module_impl/cbodybuilder_implementation.md
+++ b/doc/module_impl/cbodybuilder_implementation.md
@@ -47,8 +47,7 @@
 
 - `PtrKind`：`GDCC_PTR` / `GODOT_PTR` / `NON_OBJECT`
 - GDCC -> Godot 统一使用 helper：
-  - 优先：`gdcc_object_to_godot_object_ptr(obj, Class_object_ptr)`
-  - 兼容：`godot_object_from_gdcc_object_ptr(...)`（deprecated，存量路径迁移中）
+  - `gdcc_object_to_godot_object_ptr(obj, Class_object_ptr)`（唯一基线）
 - Godot -> GDCC 统一使用：
   - `gdcc_object_from_godot_object_ptr(...)`
 - `convertPtrIfNeeded(...)` 仅做表示转换，不改变所有权类别。
@@ -63,13 +62,12 @@
 - 调用 GDExtension API（如 `godot_*`、`*own_object`、`*release_object`、`try_destroy_object`）时，若参数是 GDCC 对象指针，必须转换为 Godot raw ptr。
 - 代码生成侧禁止手写 `->_object` 来做“调用侧转换”；统一走：
   - `CBodyBuilder#toGodotObjectPtr(...)`
-  - `gdcc_object_to_godot_object_ptr(...)`（首选）
-  - `godot_object_from_gdcc_object_ptr(...)`（兼容）
+  - `gdcc_object_to_godot_object_ptr(...)`（唯一允许的 GDCC -> Godot 路径）
 
 ### 3.2 helper 宏语义
 
 - `gdcc_object_to_godot_object_ptr(obj, Class_object_ptr)` 是当前推荐路径，且 NULL-safe。
-- `godot_object_from_gdcc_object_ptr(obj)` 在 `gdcc_helper.h` 中仅保留为兼容路径，语义仍为 NULL-safe。
+- `godot_object_from_gdcc_object_ptr(obj)` 已废弃，不得用于新增或迁移后的路径。
 - `godot_new_Variant_with_gdcc_Object(obj)` 已复用上述 helper，因此打包 Variant 时不应额外手动转换。
 
 ### 3.3 明确不替换的场景
@@ -131,7 +129,7 @@
 
 ### 7.3 helper 宏可移植性
 
-- `gdcc_object_to_godot_object_ptr` 与 `godot_object_from_gdcc_object_ptr` 都使用 GNU 扩展（statement expression + `__typeof__`）。
+- `gdcc_object_to_godot_object_ptr` 使用 GNU 扩展（statement expression + `__typeof__`）。
 - 当前链路可用，但若未来切换到不支持 GNU 扩展的纯 MSVC 语义环境，需要替代实现方案。
 
 ## 8. 回归校验基线

--- a/doc/module_impl/cbodybuilder_implementation.md
+++ b/doc/module_impl/cbodybuilder_implementation.md
@@ -47,7 +47,8 @@
 
 - `PtrKind`：`GDCC_PTR` / `GODOT_PTR` / `NON_OBJECT`
 - GDCC -> Godot 统一使用 helper：
-  - `godot_object_from_gdcc_object_ptr(...)`
+  - 优先：`gdcc_object_to_godot_object_ptr(obj, Class_object_ptr)`
+  - 兼容：`godot_object_from_gdcc_object_ptr(...)`（deprecated，存量路径迁移中）
 - Godot -> GDCC 统一使用：
   - `gdcc_object_from_godot_object_ptr(...)`
 - `convertPtrIfNeeded(...)` 仅做表示转换，不改变所有权类别。
@@ -62,11 +63,13 @@
 - 调用 GDExtension API（如 `godot_*`、`*own_object`、`*release_object`、`try_destroy_object`）时，若参数是 GDCC 对象指针，必须转换为 Godot raw ptr。
 - 代码生成侧禁止手写 `->_object` 来做“调用侧转换”；统一走：
   - `CBodyBuilder#toGodotObjectPtr(...)`
-  - `godot_object_from_gdcc_object_ptr(...)`
+  - `gdcc_object_to_godot_object_ptr(...)`（首选）
+  - `godot_object_from_gdcc_object_ptr(...)`（兼容）
 
 ### 3.2 helper 宏语义
 
-- `godot_object_from_gdcc_object_ptr(obj)` 在 `gdcc_helper.h` 中已是 NULL-safe。
+- `gdcc_object_to_godot_object_ptr(obj, Class_object_ptr)` 是当前推荐路径，且 NULL-safe。
+- `godot_object_from_gdcc_object_ptr(obj)` 在 `gdcc_helper.h` 中仅保留为兼容路径，语义仍为 NULL-safe。
 - `godot_new_Variant_with_gdcc_Object(obj)` 已复用上述 helper，因此打包 Variant 时不应额外手动转换。
 
 ### 3.3 明确不替换的场景
@@ -128,7 +131,7 @@
 
 ### 7.3 helper 宏可移植性
 
-- `godot_object_from_gdcc_object_ptr` 使用 GNU 扩展（statement expression + `__typeof__`）。
+- `gdcc_object_to_godot_object_ptr` 与 `godot_object_from_gdcc_object_ptr` 都使用 GNU 扩展（statement expression + `__typeof__`）。
 - 当前链路可用，但若未来切换到不支持 GNU 扩展的纯 MSVC 语义环境，需要替代实现方案。
 
 ## 8. 回归校验基线

--- a/doc/module_impl/explicit_c_inheritance_layout_plan.md
+++ b/doc/module_impl/explicit_c_inheritance_layout_plan.md
@@ -2,7 +2,7 @@
 
 ## 文档状态
 
-- 状态：Planned / Pending Implementation
+- 状态：In Progress（阶段 2 已完成，阶段 3-4 待实施）
 - 更新时间：2026-02-27
 - 适用范围：`backend.c` 中 GDCC 类实例布局、实例创建链路、对象转换与调用生成
 - 关联文档：
@@ -87,6 +87,20 @@
 1. Java 侧辅助（如模板数据不足）
 - 文件：`src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`、`src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java`（按实际结构调整）
 - 为模板提供 `classDef` 对应的“最近 native ancestor”字段，避免模板内复杂推导。
+
+#### 阶段 2 实施同步（2026-02-27）
+
+- 已完成：`src/main/c/codegen/template_451/entry.c.ftl`
+  - `*_class_create_instance` 的 `godot_classdb_construct_object2(...)` 已切换为“最近 native ancestor”而非直接 `superName`。
+  - 具体模板表达式：`${helper.resolveNearestNativeAncestorName(classDef)}`。
+- 已完成：`src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java`
+  - 新增 `resolveNearestNativeAncestorName(ClassDef classDef)`，沿 GDCC 继承链上溯并返回首个非 GDCC 祖先。
+  - 包含防御性检查：继承环检测、缺失父类定义检测、空祖先 fail-fast。
+- 已完成：`src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java`
+  - 新增/增强断言，覆盖：
+    - GDCC 子类 `create_instance` 构造目标为最近 native ancestor（例如 `Node`）。
+    - 深层 GDCC 继承链（`Leaf -> Mid -> Root -> Node`）仍稳定构造 `Node`。
+    - `create_instance` 中 `godot_object_set_instance(...)` 与 `godot_object_set_instance_binding(...)` 在最派生创建函数内各出现一次。
 
 ### 阶段 3：收敛 GDCC 上行转换语义
 

--- a/doc/module_impl/explicit_c_inheritance_layout_plan.md
+++ b/doc/module_impl/explicit_c_inheritance_layout_plan.md
@@ -2,7 +2,7 @@
 
 ## 文档状态
 
-- 状态：In Progress（阶段 2 已完成，阶段 3-4 待实施）
+- 状态：Completed（阶段 0-4 已完成）
 - 更新时间：2026-02-27
 - 适用范围：`backend.c` 中 GDCC 类实例布局、实例创建链路、对象转换与调用生成
 - 关联文档：
@@ -114,6 +114,28 @@
 - 保持 `renderReceiverValue(...)` 的 `checkAssignable` 预校验。
 - 对 owner/receiver 为 GDCC 对象且存在继承关系时，依赖新的安全上行表达式。
 
+#### 阶段 3 实施同步（2026-02-27）
+
+- 已完成：`src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java`
+  - `valueOfCastedVar(...)` 新增 GDCC->GDCC 专用路径：
+    - 仅允许可证明的上行转换（`ClassRegistry#checkAssignable(from, to)` 必须为 true）。
+    - 上行表达式通过 `_super` 前缀链生成（例如 `&($child->_super)`、`&($child->_super._super)`）。
+    - 不再使用 `(<Parent*>)$child` 裸 cast 表达 GDCC 子类->父类转换。
+  - 对非上行/不可证明路径 fail-fast，抛出 `InvalidInsnException`。
+  - 对继承链异常（循环、缺失定义、路径断裂）增加防御性 fail-fast。
+
+- 已完成：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/CallMethodInsnGen.java`
+  - `renderReceiverValue(...)` 继续保留 `checkAssignable` 预校验。
+  - 当静态分派 owner 为 GDCC 父类、receiver 为 GDCC 子类时，已通过 `valueOfCastedVar(...)` 生成 `_super` 链上行表达式参与调用。
+
+- 已完成：测试同步
+  - `src/test/java/dev/superice/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java`
+    - 新增 GDCC 多级上行转换 `_super` 链生成断言。
+    - 新增 GDCC 非上行转换 fail-fast 断言。
+  - `src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenTest.java`
+    - 新增 `CALL_METHOD` 子类 receiver 调父类 owner 静态分派时的 `_super` 链上行断言。
+    - 断言不存在裸 cast 回退路径。
+
 ### 阶段 4：文档复核与收敛
 
 1. 文件：`doc/gdcc_c_backend.md`
@@ -122,6 +144,27 @@
 
 1. 文件：`doc/module_impl/call_method_implementation.md`
 - 复核 `CALL_METHOD` receiver 上行转换文档与实现保持一致，无宏回退路径。
+
+#### 阶段 4 实施同步（2026-02-27）
+
+- 已完成：`doc/gdcc_c_backend.md`
+  - 复核并固化 “GDCC -> Godot 指针转换必须使用按类 helper（`gdcc_object_to_godot_object_ptr(value, Type_object_ptr)`）” 基线。
+  - 补充实现对齐说明，明确 `CBodyBuilder`/`CALL_METHOD` 相关路径已切换到专用 helper 入口。
+- 已完成：`doc/module_impl/call_method_implementation.md`
+  - `CALL_METHOD` receiver 的对象指针转换与上行转换描述已对齐实现：
+    - GDCC receiver -> ENGINE owner 先做 helper 转换再 cast。
+    - GDCC 子类 receiver -> GDCC 父类 owner 通过 `_super` 链安全上行，不允许裸 cast。
+  - 文档约束与回归测试断言一致，`CALL_METHOD` 路径无 `godot_object_from_gdcc_object_ptr(...)` 回退。
+- 已完成：代码与测试收敛（支撑阶段 4 文档结论）
+  - `src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java`
+    - GDCC->Godot 转换统一为 `gdcc_object_to_godot_object_ptr(value, <Type>_object_ptr)`。
+    - `convertPtrIfNeeded(...)` 增加源类型约束，缺失 GDCC 静态类型时 fail-fast。
+  - `src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java`
+    - 新增 `renderGdccObjectPtrHelperName(...)`，统一渲染按类 helper 符号名。
+  - 回归测试已同步并通过：
+    - `CBodyBuilderPhaseCTest`
+    - `CallMethodInsnGenTest`
+    - `CallMethodInsnGenEngineTest`
 
 ## 测试清单（必须完成）
 

--- a/doc/module_impl/explicit_c_inheritance_layout_plan.md
+++ b/doc/module_impl/explicit_c_inheritance_layout_plan.md
@@ -1,0 +1,159 @@
+# 显式 C 继承布局实施清单（GDCC C Backend）
+
+## 文档状态
+
+- 状态：Planned / Pending Implementation
+- 更新时间：2026-02-27
+- 适用范围：`backend.c` 中 GDCC 类实例布局、实例创建链路、对象转换与调用生成
+- 关联文档：
+  - `doc/gdcc_c_backend.md`
+  - `doc/module_impl/call_method_implementation.md`
+  - `doc/module_impl/cbodybuilder_implementation.md`
+
+## 背景与结论
+
+- GDScript 中显示的继承层级由 ClassDB 注册关系决定，而不是 C struct 布局本身。
+- 运行时“GDCC 子类对象调用父类方法”会把同一个 extension instance 作为回调实例传入；若子类/父类 C 布局不具备可证明的上行兼容性，存在未定义行为风险。
+- 当前实现中：
+  - GDCC 类 struct 为平铺布局（无显式 `_super` 链）。
+  - `create_instance` 直接 `construct_object2(superName)`，在 GDCC->GDCC 继承时存在绑定链路风险。
+  - `valueOfCastedVar` 对 GDCC 对象类型切换存在“裸 cast”路径，需要收敛到可证明安全的上行转换。
+
+## 目标与非目标
+
+### 目标
+
+- 建立 GDCC wrapper 的显式 C 继承布局，确保子类实例可安全上行解释为父类实例。
+- 修复实例创建链路，保证扩展实例绑定在创建阶段只走单次、可预期路径。
+- 将 GDCC 对象指针转换收敛为结构化 helper，避免依赖“所有类均有直接 `_object` 字段”的假设。
+- 为布局/转换/运行时行为建立回归测试矩阵，覆盖父类方法调用与继承可见性。
+
+### 非目标
+
+- 不改变 Godot ClassDB 注册语义（`class_name` / `parent_class_name` 保持现状）。
+- 不在本阶段重构全部指令生成器，只处理受影响的对象转换与 `CALL_METHOD` 路径。
+- 不修改 Gradle 配置与构建脚本。
+
+## 详细改动清单
+
+### 阶段 0：文档基线（必须先完成）
+
+1. 文件：`doc/gdcc_c_backend.md`
+- 明确新增“强制转换基线”并立刻生效：
+  - 废弃 `godot_object_from_gdcc_object_ptr`。
+  - 所有 GDCC -> Godot 对象指针转换必须通过“按类生成的专用 helper”完成。
+  - 禁止新增任何对该宏的依赖；存量用法纳入迁移清单并逐步清零。
+
+1. 文件：`doc/module_impl/call_method_implementation.md`
+- 将 `CALL_METHOD` 的 receiver 转换规范对齐到专用 helper 基线。
+- 明确“GDCC 子类 -> 父类 owner”必须走可证明安全的上行表达式，不得裸 cast。
+
+1. 文件：`doc/module_impl/explicit_c_inheritance_layout_plan.md`（本文档）
+- 将“文档先行”定义为后续代码改动的前置门禁：
+  - 未完成阶段 0，不进入模板与代码实现阶段。
+  - 后续评审以阶段 0 规则作为唯一规范基线。
+
+### 阶段 1：模板层建立显式继承布局
+
+1. 文件：`src/main/c/codegen/template_451/entry.h.ftl`
+- 为每个 GDCC 类生成 `struct` 时引入显式父类字段：
+  - 根 GDCC 类：保留 `GDExtensionObjectPtr _object;`
+  - 非根 GDCC 类：以父类为首字段，例如 `Parent _super;`
+- 保证父类子对象位于偏移 0，形成稳定前缀布局。
+- 为每个类额外生成对象访问 helper 声明：
+  - `static inline GDExtensionObjectPtr <Class>_object_ptr(<Class>* self);`
+
+1. 文件：`src/main/c/codegen/template_451/entry.c.ftl`
+- 实现 `<Class>_object_ptr(...)`：
+  - 根类直接返回 `self->_object`
+  - 子类沿 `_super` 链委托到父类 helper
+- 校正构造/析构中访问路径：
+  - 当前类字段继续使用 `self->field`
+  - 若需父类字段访问，统一通过 `_super` 链或父类 helper
+
+1. 文件：`src/main/c/codegen/include_451/gdcc/gdcc_helper.h`
+- 移除 `godot_object_from_gdcc_object_ptr` 在生成代码路径中的使用。
+- 提供/保留统一的 helper 调用入口（由模板生成的按类专用 helper 负责最终转换）。
+- 明确注释：GDCC 子类不保证存在直接 `_object` 字段，必须通过生成 helper 取对象指针。
+
+### 阶段 2：实例创建链路修正（避免绑定风险）
+
+1. 文件：`src/main/c/codegen/template_451/entry.c.ftl`
+- `*_class_create_instance` 不再无条件构造 `superName`。
+- 生成“最近可构造原生祖先”名称（最近 engine/native 祖先）并用于 `godot_classdb_construct_object2(...)`。
+- 保持 `godot_object_set_instance(...)` 与 `godot_object_set_instance_binding(...)` 仅在当前最派生扩展创建路径执行一次。
+
+1. Java 侧辅助（如模板数据不足）
+- 文件：`src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`、`src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java`（按实际结构调整）
+- 为模板提供 `classDef` 对应的“最近 native ancestor”字段，避免模板内复杂推导。
+
+### 阶段 3：收敛 GDCC 上行转换语义
+
+1. 文件：`src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java`
+- 调整 `valueOfCastedVar(...)`：
+  - GDCC->GDCC：仅允许“可证明上行”的转换，生成 `_super` 链表达式或调用已生成 helper。
+  - 禁止以裸 C cast 处理 GDCC 子类到父类转换。
+  - 对非上行或不可证明安全的转换 fail-fast。
+
+1. 文件：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/CallMethodInsnGen.java`
+- 保持 `renderReceiverValue(...)` 的 `checkAssignable` 预校验。
+- 对 owner/receiver 为 GDCC 对象且存在继承关系时，依赖新的安全上行表达式。
+
+### 阶段 4：文档复核与收敛
+
+1. 文件：`doc/gdcc_c_backend.md`
+- 对照实现复核阶段 0 规则无偏移、无回退。
+- 更新“显式 `_super` 布局 + 专用 helper 转换”的最终描述。
+
+1. 文件：`doc/module_impl/call_method_implementation.md`
+- 复核 `CALL_METHOD` receiver 上行转换文档与实现保持一致，无宏回退路径。
+
+## 测试清单（必须完成）
+
+### A. 代码生成单元测试（模板/文本）
+
+1. 文件：`src/test/java/dev/superice/gdcc/backend/c/gen/...`（按现有测试目录归档）
+- 断言子类 struct 包含父类前缀字段 `_super`。
+- 断言为每个类生成 `<Class>_object_ptr(...)` helper。
+- 断言 `create_instance` 构造目标为“最近 native ancestor”，而不是 GDCC 父类名。
+
+1. `CALL_METHOD` 相关回归
+- receiver 为子类、owner 为父类时，断言生成代码使用安全上行表达式，不出现裸 cast。
+- 非法转换路径保持 fail-fast（`InvalidInsnException`）。
+
+### B. 引擎行为集成测试（运行时）
+
+1. 新增引擎继承行为测试类（建议：`CallMethodInsnGenEngineInheritanceTest`）
+- 场景：`B extends A`，在 `A` 中定义访问 A 字段的方法，`B.new().a_method()` 返回值正确。
+- 验证 GDScript 侧继承关系可见：`B is A`、ClassDB parent 查询为 true。
+
+1. 环境策略
+- 依赖 Zig/引擎运行环境的测试需保留“不可用时跳过”策略，不得误报失败。
+
+## 验收标准（DoD）
+
+- 所有模板生成代码在多级继承下可编译通过。
+- `CALL_METHOD` 子类调用父类方法链路稳定，无裸 cast 造成的布局 UB 风险。
+- 目标测试集通过：
+  - `CallMethodInsnGenTest`
+  - `CallMethodInsnGenEngineTest`
+  - 新增继承行为测试类
+  - 必要的 `CBodyBuilderPhaseCTest` 子集
+- 文档同步完成，`doc/gdcc_c_backend.md` 与 `module_impl` 中无冲突性描述。
+
+## 风险与回滚策略
+
+- 风险 1：模板改动影响面大，可能破坏现有对象转换宏。
+  - 缓解：先引入并切换到 helper，再移除旧宏语义。
+- 风险 2：`create_instance` 祖先选择错误导致实例化失败。
+  - 缓解：新增“祖先选择”单测 + 引擎集成用例双重校验。
+- 风险 3：`valueOfCastedVar` 收紧后触发历史路径失败。
+  - 缓解：明确 fail-fast 文案并补齐测试，逐步修复调用点。
+
+## 执行顺序建议
+
+1. 完成阶段 0（文档基线）并在评审中冻结为强制标准。
+2. 完成阶段 1（布局 + helper）并补 A 类测试。
+3. 完成阶段 2（create_instance 修正）并补 create_instance 断言。
+4. 完成阶段 3（CBodyBuilder / CallMethod 对齐）并补 `CALL_METHOD` 回归。
+5. 完成阶段 4（文档复核）与引擎继承行为测试收尾。

--- a/doc/module_impl/explicit_c_inheritance_layout_plan.md
+++ b/doc/module_impl/explicit_c_inheritance_layout_plan.md
@@ -74,6 +74,7 @@
 1. 文件：`src/main/c/codegen/include_451/gdcc/gdcc_helper.h`
 - 移除 `godot_object_from_gdcc_object_ptr` 在生成代码路径中的使用。
 - 提供/保留统一的 helper 调用入口（由模板生成的按类专用 helper 负责最终转换）。
+- 统一入口宏为：`gdcc_object_to_godot_object_ptr(obj, Class_object_ptr)`。
 - 明确注释：GDCC 子类不保证存在直接 `_object` 字段，必须通过生成 helper 取对象指针。
 
 ### 阶段 2：实例创建链路修正（避免绑定风险）

--- a/doc/pr_message_guideline.md
+++ b/doc/pr_message_guideline.md
@@ -1,29 +1,15 @@
 # PR Message Guideline
 
-## 1. Purpose
-
-This guideline defines a consistent PR message format for `gdcc`, based on recent merged PRs:
-- `#7` `feat(backend): implement CALL_METHOD C codegen for static and dynamic dispatch`
-- `#6` `feat(backend): implement load_static codegen and tighten static literal handling`
-- `#1` `feat(backend): stabilize CALL_GLOBAL codegen and ownership semantics`
-
-Goal:
-- Make review scope obvious.
-- Make semantic/risk changes easy to audit.
-- Make validation reproducible with targeted Gradle commands.
-
-## 2. Mandatory Rules
+## Mandatory Rules
 
 1. PR title must use Conventional Commits style:
    - `<type>(<scope>): <imperative summary>`
    - Example: `feat(backend): implement CALL_METHOD C codegen`
 2. PR body must be written in English.
 3. Do not describe only "what"; include "why" and runtime/semantic impact.
-4. For tests, use targeted Gradle commands with required flags:
-   - `--no-daemon --info --console=plain`
-5. If behavior contracts changed (IR validation, ownership lifecycle, type compatibility, codegen semantics), explicitly state them.
+4. If behavior contracts changed, explicitly state them.
 
-## 3. Required Sections
+## Required Sections
 
 Use this section order unless there is a strong reason not to:
 
@@ -67,8 +53,6 @@ Use when applicable:
 
 - `## Key behaviors covered`
   - For compiler semantics (dispatch rules, type checks, lifecycle handling, vararg/default argument contracts).
-- `## Diff stats`
-  - Useful for large PRs to set review expectations.
 - `## Breaking changes`
   - Required when API/behavior compatibility changes.
 - `## Related docs`

--- a/doc/pr_message_guideline.md
+++ b/doc/pr_message_guideline.md
@@ -1,0 +1,140 @@
+# PR Message Guideline
+
+## 1. Purpose
+
+This guideline defines a consistent PR message format for `gdcc`, based on recent merged PRs:
+- `#7` `feat(backend): implement CALL_METHOD C codegen for static and dynamic dispatch`
+- `#6` `feat(backend): implement load_static codegen and tighten static literal handling`
+- `#1` `feat(backend): stabilize CALL_GLOBAL codegen and ownership semantics`
+
+Goal:
+- Make review scope obvious.
+- Make semantic/risk changes easy to audit.
+- Make validation reproducible with targeted Gradle commands.
+
+## 2. Mandatory Rules
+
+1. PR title must use Conventional Commits style:
+   - `<type>(<scope>): <imperative summary>`
+   - Example: `feat(backend): implement CALL_METHOD C codegen`
+2. PR body must be written in English.
+3. Do not describe only "what"; include "why" and runtime/semantic impact.
+4. For tests, use targeted Gradle commands with required flags:
+   - `--no-daemon --info --console=plain`
+5. If behavior contracts changed (IR validation, ownership lifecycle, type compatibility, codegen semantics), explicitly state them.
+
+## 3. Required Sections
+
+Use this section order unless there is a strong reason not to:
+
+1. `## Summary`
+2. `## What changed`
+3. `## Why`
+4. `## Affected packages/files`
+5. `## Validation`
+6. `## Risks / Notes`
+
+### Section Details
+
+`## Summary`
+- 1-3 sentences.
+- State feature/fix and subsystem (frontend / HIR / LIR / backend).
+
+`## What changed`
+- Bullet list grouped by responsibility.
+- Prefer concrete component names (for example `CBodyBuilder`, `CallMethodInsnGen`, `ExtensionApiLoader`).
+
+`## Why`
+- Explain root problem or missing capability.
+- Mention why this design is chosen over alternatives when trade-offs exist.
+
+`## Affected packages/files`
+- List package names and key files.
+- For large PRs, keep this to review-relevant paths only.
+
+`## Validation`
+- Provide exact commands that were run.
+- Include result summary (`BUILD SUCCESSFUL` or failure + follow-up).
+- Prefer targeted tests over full suite during iteration.
+
+`## Risks / Notes`
+- List intentional limitations/non-goals.
+- Mention follow-up work if the current PR is intentionally scoped.
+
+## 4. Recommended Optional Sections
+
+Use when applicable:
+
+- `## Key behaviors covered`
+  - For compiler semantics (dispatch rules, type checks, lifecycle handling, vararg/default argument contracts).
+- `## Diff stats`
+  - Useful for large PRs to set review expectations.
+- `## Breaking changes`
+  - Required when API/behavior compatibility changes.
+- `## Related docs`
+  - Link updated docs under `doc/`.
+
+## 5. Project-Specific Expectations (Compiler + C Backend)
+
+For backend/codegen PRs, prefer explicitly documenting:
+
+1. Instruction semantics and validation boundary
+   - What is validated in InsnGen vs builder/helper layers.
+2. Ownership/lifecycle implications
+   - `try_own_object`, `try_release_object`, destroy/copy behavior changes.
+3. Type compatibility contract
+   - How assignability is checked and enforced.
+4. Default value / vararg behavior
+   - Especially for utility calls and generated C argument conventions.
+5. Fail-fast behavior
+   - Which paths now throw `InvalidInsnException` and why.
+
+## 6. PR Body Template
+
+```md
+## Summary
+<One short paragraph describing the main change and subsystem.>
+
+## What changed
+- <change item 1>
+- <change item 2>
+- <change item 3>
+
+## Why
+- <problem statement>
+- <design rationale>
+
+## Affected packages/files
+- `dev.superice.gdcc.backend.c.gen`
+- `dev.superice.gdcc.backend.c.gen.insn`
+- `src/main/c/codegen/template_451/...`
+- `src/test/java/dev/superice/gdcc/backend/c/gen/...`
+- `doc/module_impl/...`
+
+## Validation
+- `./gradlew test --tests <TestClassOrMethod> --no-daemon --info --console=plain`
+- `./gradlew classes --no-daemon --info --console=plain`
+
+Result: `BUILD SUCCESSFUL`
+
+## Risks / Notes
+- <intentional limitation>
+- <follow-up item>
+```
+
+## 7. Anti-Patterns to Avoid
+
+1. Only a high-level description without concrete changed components.
+2. Listing changes but omitting `Why`.
+3. No reproducible validation commands.
+4. Mixing too many unrelated topics in one PR message.
+5. Using vague statements like "refactor" without semantic impact description.
+
+## 8. Quick Checklist (Before Opening PR)
+
+- [ ] Title follows Conventional Commits format.
+- [ ] Body is in English.
+- [ ] Required sections are complete.
+- [ ] Validation commands are exact and reproducible.
+- [ ] Semantics/ownership/type-contract impacts are clearly described.
+- [ ] Scope and non-goals are explicit.

--- a/src/main/c/codegen/include_451/gdcc/gdcc_helper.h
+++ b/src/main/c/codegen/include_451/gdcc/gdcc_helper.h
@@ -133,16 +133,10 @@ static GDExtensionClassInstancePtr gdcc_object_from_godot_object_ptr(GDExtension
 /// `object_ptr_helper` must be a generated per-class helper like `MyClass_object_ptr`.
 #define gdcc_object_to_godot_object_ptr(obj, object_ptr_helper) ({ __typeof__(obj) _o = (obj); _o ? object_ptr_helper(_o) : NULL; })
 
-/// Deprecated compatibility path.
-/// Kept temporarily for legacy generated code that has not migrated to per-class helpers yet.
-#define godot_object_from_gdcc_object_ptr(obj) ({ __typeof__(obj) _o = (obj); _o ? *((GDExtensionObjectPtr*)(void*)_o) : NULL; })
-
 static GDExtensionClassInstancePtr godot_new_gdcc_Object_with_Variant(const godot_Variant* value) {
     const GDExtensionObjectPtr obj = godot_new_Object_with_Variant(value);
     return gdcc_object_from_godot_object_ptr(obj);
 }
-
-#define godot_new_Variant_with_gdcc_Object(obj) godot_new_Variant_with_Object(godot_object_from_gdcc_object_ptr(obj))
 
 static godot_Transform2D godot_new_Transform2D_with_float_float_float_float_float_float(
     godot_float xx, godot_float xy, godot_float yx, godot_float yy, godot_float tx, godot_float ty

--- a/src/main/c/codegen/include_451/gdcc/gdcc_helper.h
+++ b/src/main/c/codegen/include_451/gdcc/gdcc_helper.h
@@ -129,7 +129,13 @@ static GDExtensionClassInstancePtr gdcc_object_from_godot_object_ptr(GDExtension
     return godot_object_get_instance_binding(ptr, class_library, &callbacks);
 }
 
-#define godot_object_from_gdcc_object_ptr(obj) ({ __typeof__(obj) _o = (obj); _o ? _o->_object : NULL; })
+/// Preferred conversion entry for GDCC -> Godot object pointers.
+/// `object_ptr_helper` must be a generated per-class helper like `MyClass_object_ptr`.
+#define gdcc_object_to_godot_object_ptr(obj, object_ptr_helper) ({ __typeof__(obj) _o = (obj); _o ? object_ptr_helper(_o) : NULL; })
+
+/// Deprecated compatibility path.
+/// Kept temporarily for legacy generated code that has not migrated to per-class helpers yet.
+#define godot_object_from_gdcc_object_ptr(obj) ({ __typeof__(obj) _o = (obj); _o ? *((GDExtensionObjectPtr*)(void*)_o) : NULL; })
 
 static GDExtensionClassInstancePtr godot_new_gdcc_Object_with_Variant(const godot_Variant* value) {
     const GDExtensionObjectPtr obj = godot_new_Object_with_Variant(value);

--- a/src/main/c/codegen/template_451/entry.c.ftl
+++ b/src/main/c/codegen/template_451/entry.c.ftl
@@ -93,12 +93,37 @@ void ${classDef.name}_class_bind_methods() {
 }
 </#list>
 
+// Object pointer helpers for GDCC wrapper layout
+<#list module.classDefs as classDef>
+static inline GDExtensionObjectPtr ${classDef.name}_object_ptr(${classDef.name}* self) {
+    if (self == NULL) {
+        return NULL;
+    }
+    <#if helper.checkGdccClassByName(classDef.superName)>
+        return ${classDef.superName}_object_ptr(&self->_super);
+    <#else>
+        return self->_object;
+    </#if>
+}
+
+static inline void ${classDef.name}_set_object_ptr(${classDef.name}* self, GDExtensionObjectPtr obj) {
+    if (self == NULL) {
+        return;
+    }
+    <#if helper.checkGdccClassByName(classDef.superName)>
+        ${classDef.superName}_set_object_ptr(&self->_super, obj);
+    <#else>
+        self->_object = obj;
+    </#if>
+}
+</#list>
+
 // GdExtension Methods for each class
 <#list module.classDefs as classDef>
 GDExtensionObjectPtr ${classDef.name}_class_create_instance(void* p_class_userdata, GDExtensionBool p_notify_postinitialize) {
     GDExtensionObjectPtr obj = godot_classdb_construct_object2(GD_STATIC_SN(u8"${classDef.superName}"));
     ${classDef.name}* self = godot_mem_alloc(sizeof(${classDef.name}));
-    self->_object = obj;
+    ${classDef.name}_set_object_ptr(self, obj);
     godot_object_set_instance(obj, GD_STATIC_SN(u8"${classDef.name}"), self);
     godot_object_set_instance_binding(obj, class_library, self, &${classDef.name}_class_binding_callbacks);
     if (p_notify_postinitialize) {
@@ -119,6 +144,9 @@ void ${classDef.name}_class_constructor(${classDef.name}* self) {
     if (self == NULL) {
         return;
     }
+    <#if helper.checkGdccClassByName(classDef.superName)>
+        ${classDef.superName}_class_constructor(&self->_super);
+    </#if>
     <#list classDef.properties as property>
         self->${property.name} = ${classDef.name}_${property.initFunc}(self);
     </#list>
@@ -135,7 +163,7 @@ void ${classDef.name}_class_destructor(${classDef.name}* self) {
         <#if property.type.destroyable>
             <#if property.type.gdExtensionType.name() == "OBJECT">
                 <#if helper.checkGdccType(property.type)>
-                    try_release_object(godot_object_from_gdcc_object_ptr(self->${property.name}));
+                    try_release_object(${helper.renderGdTypeName(property.type)}_object_ptr(self->${property.name}));
                 <#else>
                     try_release_object(self->${property.name});
                 </#if>
@@ -144,6 +172,9 @@ void ${classDef.name}_class_destructor(${classDef.name}* self) {
             </#if>
         </#if>
     </#list>
+    <#if helper.checkGdccClassByName(classDef.superName)>
+        ${classDef.superName}_class_destructor(&self->_super);
+    </#if>
 }
 
 void ${classDef.name}_class_notification(GDExtensionClassInstancePtr p_instance, int32_t p_what, GDExtensionBool p_reversed) {

--- a/src/main/c/codegen/template_451/entry.c.ftl
+++ b/src/main/c/codegen/template_451/entry.c.ftl
@@ -121,7 +121,7 @@ static inline void ${classDef.name}_set_object_ptr(${classDef.name}* self, GDExt
 // GdExtension Methods for each class
 <#list module.classDefs as classDef>
 GDExtensionObjectPtr ${classDef.name}_class_create_instance(void* p_class_userdata, GDExtensionBool p_notify_postinitialize) {
-    GDExtensionObjectPtr obj = godot_classdb_construct_object2(GD_STATIC_SN(u8"${classDef.superName}"));
+    GDExtensionObjectPtr obj = godot_classdb_construct_object2(GD_STATIC_SN(u8"${helper.resolveNearestNativeAncestorName(classDef)}"));
     ${classDef.name}* self = godot_mem_alloc(sizeof(${classDef.name}));
     ${classDef.name}_set_object_ptr(self, obj);
     godot_object_set_instance(obj, GD_STATIC_SN(u8"${classDef.name}"), self);

--- a/src/main/c/codegen/template_451/entry.h.ftl
+++ b/src/main/c/codegen/template_451/entry.h.ftl
@@ -28,13 +28,20 @@ typedef struct ${classDef.name} ${classDef.name};
 // Class definition for ${classDef.name}
 
 struct ${classDef.name} {
-    GDExtensionObjectPtr _object;
+    <#if helper.checkGdccClassByName(classDef.superName)>
+        ${classDef.superName} _super;
+    <#else>
+        GDExtensionObjectPtr _object;
+    </#if>
     <#list classDef.properties as property>
         <#if !property.static>
             ${helper.renderGdTypeInC(property.type)} ${property.name};
         </#if>
     </#list>
 };
+
+static inline GDExtensionObjectPtr ${classDef.name}_object_ptr(${classDef.name}* self);
+static inline void ${classDef.name}_set_object_ptr(${classDef.name}* self, GDExtensionObjectPtr obj);
 
 const GDExtensionInstanceBindingCallbacks ${classDef.name}_class_binding_callbacks = {
     .create_callback = NULL,

--- a/src/main/c/codegen/template_451/entry.h.ftl
+++ b/src/main/c/codegen/template_451/entry.h.ftl
@@ -82,6 +82,10 @@ typedef struct <@lambdaCaptureName classDef func/> {
 
 </#list>
 
+<#if module.classDefs?size gt 0>
+#define gdcc_new_Variant_with_gdcc_Object(obj) godot_new_Variant_with_Object(gdcc_object_to_godot_object_ptr((obj), _Generic((obj), <#list module.classDefs as classDef>${classDef.name}*: ${classDef.name}_object_ptr<#if classDef_has_next>, </#if></#list>)))
+</#if>
+
 // Method binding helpers
 
 <#list helper.bindingDataList as bindingData>

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
@@ -1061,7 +1061,7 @@ public final class CBodyBuilder {
     }
 
     private boolean checkGlobalFuncRequireGodotRawPtr(@NotNull String funcName) {
-        if (funcName.endsWith("_with_gdcc_Object")) {
+        if (funcName.equals("gdcc_new_Variant_with_gdcc_Object")) {
             return false;
         }
         if (funcName.startsWith("godot_")) {

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -141,7 +142,8 @@ public final class CBodyBuilder {
         checkAssignable(value.type(), temp.type());
         var initCode = value.generateCode();
         if (temp.type() instanceof GdObjectType targetObjType) {
-            initCode = convertPtrIfNeeded(initCode, value.ptrKind(), targetObjType);
+            var valueObjType = value.type() instanceof GdObjectType objectType ? objectType : null;
+            initCode = convertPtrIfNeeded(initCode, value.ptrKind(), valueObjType, targetObjType);
         }
         out.append(temp.name()).append(" = ").append(initCode).append(";\n");
         temp.setInitialized(true);
@@ -215,8 +217,12 @@ public final class CBodyBuilder {
             if (sourceObjectType.getTypeName().equals(targetObjectType.getTypeName()) && sourcePtrKind == targetPtrKind) {
                 return valueOfVar(variable);
             }
+            if (sourceObjectType.checkGdccType(classRegistry()) && targetObjectType.checkGdccType(classRegistry())) {
+                var upcastExpr = renderGdccUpcastExpr(variable, sourceObjectType, targetObjectType);
+                return valueOfExpr(upcastExpr, castType, targetPtrKind);
+            }
             var sourceCode = "$" + variable.id();
-            var convertedCode = convertPtrIfNeeded(sourceCode, sourcePtrKind, targetObjectType);
+            var convertedCode = convertPtrIfNeeded(sourceCode, sourcePtrKind, sourceObjectType, targetObjectType);
             if (sourcePtrKind == PtrKind.GODOT_PTR && targetPtrKind == PtrKind.GDCC_PTR) {
                 return valueOfExpr(convertedCode, castType, targetPtrKind);
             }
@@ -231,6 +237,49 @@ public final class CBodyBuilder {
         var castTypeCode = helper.renderGdTypeInC(castType);
         var castExpr = "(" + castTypeCode + ")$" + variable.id();
         return valueOfExpr(castExpr, castType);
+    }
+
+    /// Renders a GDCC -> GDCC upcast expression using `_super` prefix layout chain.
+    /// Fails fast for non-upcast or unverifiable inheritance paths.
+    private @NotNull String renderGdccUpcastExpr(@NotNull LirVariable variable,
+                                                 @NotNull GdObjectType sourceObjectType,
+                                                 @NotNull GdObjectType targetObjectType) {
+        var sourceName = sourceObjectType.getTypeName();
+        var targetName = targetObjectType.getTypeName();
+        if (sourceName.equals(targetName)) {
+            return "$" + variable.id();
+        }
+        if (!classRegistry().checkAssignable(sourceObjectType, targetObjectType)) {
+            throw invalidInsn("GDCC cast must be a safe upcast, but got '" +
+                    sourceName + "' -> '" + targetName + "'");
+        }
+
+        var visited = new HashSet<String>();
+        var currentName = sourceName;
+        var upcastDepth = 0;
+        while (!currentName.equals(targetName)) {
+            if (!visited.add(currentName)) {
+                throw invalidInsn("Detected GDCC inheritance cycle while casting '" +
+                        sourceName + "' -> '" + targetName + "'");
+            }
+            var currentClass = classRegistry().findGdccClass(currentName);
+            if (currentClass == null) {
+                throw invalidInsn("Cannot resolve GDCC class definition '" + currentName +
+                        "' while casting '" + sourceName + "' -> '" + targetName + "'");
+            }
+            var superName = currentClass.getSuperName();
+            if (!classRegistry().isGdccClass(superName)) {
+                throw invalidInsn("Cannot prove GDCC upcast path '" + sourceName + "' -> '" +
+                        targetName + "': parent '" + superName + "' is not a GDCC class");
+            }
+            currentName = superName;
+            upcastDepth++;
+        }
+
+        var sourceCode = "$" + variable.id();
+        return "&(" + sourceCode + "->_super" +
+                "._super".repeat(Math.max(0, upcastDepth - 1)) +
+                ")";
     }
 
     public @NotNull ValueRef valueOfVar(@NotNull String variableName) {
@@ -312,17 +361,18 @@ public final class CBodyBuilder {
 
         if (targetType instanceof GdObjectType objType) {
             // Route all object writes through one ownership-aware slot write path.
-            emitObjectSlotWrite(
-                    targetCode,
-                    objType,
-                    canDestroyOldValue && !checkInPrepareBlock(),
-                    rhsResult.code(),
-                    value.ptrKind(),
-                    value.ownership()
-            );
-        } else {
-            emitNonObjectSlotWrite(targetCode, targetType, canDestroyOldValue, rhsResult.code());
-        }
+                emitObjectSlotWrite(
+                        targetCode,
+                        objType,
+                        canDestroyOldValue && !checkInPrepareBlock(),
+                        rhsResult.code(),
+                        value.ptrKind(),
+                        value.type() instanceof GdObjectType objectType ? objectType : null,
+                        value.ownership()
+                );
+            } else {
+                emitNonObjectSlotWrite(targetCode, targetType, canDestroyOldValue, rhsResult.code());
+            }
 
         markTargetInitialized(target);
         emitTempDestroys(rhsResult.temps());
@@ -366,7 +416,7 @@ public final class CBodyBuilder {
     /// Caller is responsible for argument count/type checks.
     /// When `varargs == null`, vararg tail generation is skipped.
     /// When `varargs != null`, the vararg tail is always generated, including the empty case
-    /// (which emits `NULL, (godot_int)0`).
+    /// (which emits `NULL,(godot_int)0`).
     public @NotNull CBodyBuilder callVoid(@NotNull String funcName,
                                           @NotNull List<ValueRef> args,
                                           @Nullable List<ValueRef> varargs) {
@@ -398,7 +448,7 @@ public final class CBodyBuilder {
     /// Caller is responsible for argument count/type checks.
     /// When `varargs == null`, vararg tail generation is skipped.
     /// When `varargs != null`, the vararg tail is always generated, including the empty case
-    /// (which emits `NULL, (godot_int)0`).
+    /// (which emits `NULL,(godot_int)0`).
     public @NotNull CBodyBuilder callAssign(@NotNull TargetRef target,
                                             @NotNull String funcName,
                                             @NotNull GdType returnType,
@@ -465,6 +515,7 @@ public final class CBodyBuilder {
                     canDestroyOldValue && !checkInPrepareBlock(),
                     callExpr,
                     rhsPtrKind,
+                    returnObjType,
                     OwnershipKind.OWNED
             );
             markTargetInitialized(target);
@@ -534,6 +585,7 @@ public final class CBodyBuilder {
                         true,
                         returnCode,
                         value.ptrKind(),
+                        value.type() instanceof GdObjectType objectType ? objectType : null,
                         value.ownership()
                 );
             } else {
@@ -548,7 +600,8 @@ public final class CBodyBuilder {
         }
 
         if (returnType instanceof GdObjectType objType) {
-            returnCode = convertPtrIfNeeded(returnCode, value.ptrKind(), objType);
+            var sourceObjType = value.type() instanceof GdObjectType objectType ? objectType : null;
+            returnCode = convertPtrIfNeeded(returnCode, value.ptrKind(), sourceObjType, objType);
         }
 
         if (returnResult.temps().isEmpty()) {
@@ -656,11 +709,13 @@ public final class CBodyBuilder {
         return literal.length() >= 3 && literal.startsWith("$\"") && literal.endsWith("\"");
     }
 
-    @NotNull public static String renderStaticStringLiteral(@NotNull String value) {
+    @NotNull
+    public static String renderStaticStringLiteral(@NotNull String value) {
         return "GD_STATIC_S(u8\"" + escapeStringLiteral(value) + "\")";
     }
 
-    @NotNull public static String renderStaticStringNameLiteral(@NotNull String value) {
+    @NotNull
+    public static String renderStaticStringNameLiteral(@NotNull String value) {
         return "GD_STATIC_SN(u8\"" + escapeStringLiteral(value) + "\")";
     }
 
@@ -689,7 +744,7 @@ public final class CBodyBuilder {
     /// - Primitive types and object pointers: pass by value (no &)
     /// - Value-semantic types (String, StringName, Variant, etc.): pass by pointer (&)
     /// When requireGodotRawPtr is true, GDCC object pointers are auto-converted to Godot
-    /// object pointers via `godot_object_from_gdcc_object_ptr(...)`.
+    /// object pointers via `gdcc_object_to_godot_object_ptr(value, Type_object_ptr)`.
     private @NotNull RenderResult renderArgument(@NotNull ValueRef value, boolean requireGodotRawPtr) {
         var type = value.type();
 
@@ -857,6 +912,7 @@ public final class CBodyBuilder {
                                      boolean releaseOldValue,
                                      @NotNull String rhsCode,
                                      @NotNull PtrKind rhsPtrKind,
+                                     @Nullable GdObjectType rhsObjType,
                                      @NotNull OwnershipKind ownership) {
         TempVar oldValueTemp = null;
         if (releaseOldValue) {
@@ -864,7 +920,7 @@ public final class CBodyBuilder {
             oldValueTemp = newTempVariable("old_obj", targetType, targetCode);
             declareTempVar(oldValueTemp);
         }
-        var assignCode = convertPtrIfNeeded(rhsCode, rhsPtrKind, targetType);
+        var assignCode = convertPtrIfNeeded(rhsCode, rhsPtrKind, rhsObjType, targetType);
         out.append(targetCode).append(" = ").append(assignCode).append(";\n");
         if (ownership == OwnershipKind.BORROWED) {
             // BORROWED rhs must be retained by the slot after assignment.
@@ -899,7 +955,7 @@ public final class CBodyBuilder {
 
         if (returnType instanceof GdObjectType objType) {
             var rhsPtrKind = resolveCallResultPtrKind(cFuncName, objType);
-            var assignCode = convertPtrIfNeeded(callExpr, rhsPtrKind, objType);
+            var assignCode = convertPtrIfNeeded(callExpr, rhsPtrKind, objType, objType);
             var discardTemp = newTempVariable("discard", returnType, assignCode);
             declareTempVar(discardTemp);
             // Discarded OWNED object returns are consumed by immediate release.
@@ -928,11 +984,12 @@ public final class CBodyBuilder {
     }
 
     /// Converts a GDCC object pointer to Godot object pointer.
-    /// For GDCC types: use godot_object_from_gdcc_object_ptr(...)
+    /// For GDCC types: use class-specific helper through gdcc_object_to_godot_object_ptr.
     /// For engine types: use as-is
     private @NotNull String toGodotObjectPtr(@NotNull String varCode, @NotNull GdObjectType objType) {
         if (objType.checkGdccType(classRegistry())) {
-            return "godot_object_from_gdcc_object_ptr(" + varCode + ")";
+            var objectPtrHelper = helper.renderGdccObjectPtrHelperName(objType);
+            return "gdcc_object_to_godot_object_ptr(" + varCode + ", " + objectPtrHelper + ")";
         }
         return varCode;
     }
@@ -940,17 +997,22 @@ public final class CBodyBuilder {
     /// Converts an object pointer expression between GDCC and Godot representations if needed.
     ///
     /// - GODOT_PTR value → GDCC_PTR target: wraps with `fromGodotObjectPtr`
-    /// - GDCC_PTR value → GODOT_PTR target: wraps with `godot_object_from_gdcc_object_ptr(...)`
+    /// - GDCC_PTR value → GODOT_PTR target: wraps with `gdcc_object_to_godot_object_ptr(...)`
     /// - Same kind or NON_OBJECT: no conversion
     private @NotNull String convertPtrIfNeeded(@NotNull String code,
                                                @NotNull PtrKind valuePtrKind,
+                                               @Nullable GdObjectType valueObjType,
                                                @NotNull GdObjectType targetObjType) {
         var targetPtrKind = resolvePtrKind(targetObjType);
         if (valuePtrKind == PtrKind.GODOT_PTR && targetPtrKind == PtrKind.GDCC_PTR) {
             return fromGodotObjectPtr(code, targetObjType);
         }
         if (valuePtrKind == PtrKind.GDCC_PTR && targetPtrKind == PtrKind.GODOT_PTR) {
-            return "godot_object_from_gdcc_object_ptr(" + code + ")";
+            if (valueObjType == null || !valueObjType.checkGdccType(classRegistry())) {
+                throw invalidInsn("Cannot convert GDCC_PTR value '" + code +
+                        "' to Godot pointer: missing GDCC static type");
+            }
+            return toGodotObjectPtr(code, valueObjType);
         }
         return code;
     }
@@ -1014,7 +1076,7 @@ public final class CBodyBuilder {
     }
 
     private @NotNull PtrKind resolveCallResultPtrKind(@NotNull String cFuncName,
-                                                       @NotNull GdObjectType returnObjType) {
+                                                      @NotNull GdObjectType returnObjType) {
         if (checkGlobalFuncReturnGodotRawPtr(cFuncName)) {
             // godot_* calls return raw Godot object pointers.
             return PtrKind.GODOT_PTR;

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
@@ -336,7 +336,7 @@ public final class CGenHelper {
     /// Mainly used for preventing direct assignment of Godot object ptr to GDCC object ptr.
     ///
     /// @param sourceExpr This expr is in C which is a GDExtension function call. It never returns direct GDCC type ptr,
-    ///                   but the underlying proxy Godot object ptr.
+    ///                                     but the underlying proxy Godot object ptr.
     public @NotNull String renderVarAssignWithGodotReturn(@NotNull LirFunctionDef func,
                                                           @NotNull String targetVarName,
                                                           @NotNull GdType sourceType,
@@ -383,6 +383,28 @@ public final class CGenHelper {
 
     public boolean checkGdccClassByName(@NotNull String className) {
         return context.classRegistry().isGdccClass(className);
+    }
+
+    /// Resolve the nearest constructible native ancestor for a GDCC class.
+    /// This walks up GDCC inheritance chain until the first non-GDCC parent.
+    public @NotNull String resolveNearestNativeAncestorName(@NotNull ClassDef classDef) {
+        var registry = context.classRegistry();
+        var ancestorName = classDef.getSuperName();
+        var visited = new HashSet<String>();
+        while (registry.isGdccClass(ancestorName)) {
+            if (!visited.add(ancestorName)) {
+                throw new IllegalStateException("Detected GDCC inheritance cycle while resolving native ancestor for class " + classDef.getName());
+            }
+            var parentDef = registry.findGdccClass(ancestorName);
+            if (parentDef == null) {
+                throw new IllegalStateException("Missing GDCC class definition for parent " + ancestorName + " while resolving native ancestor for class " + classDef.getName());
+            }
+            ancestorName = parentDef.getSuperName();
+        }
+        if (ancestorName.isEmpty()) {
+            throw new IllegalStateException("Class " + classDef.getName() + " does not have a native ancestor");
+        }
+        return ancestorName;
     }
 
     public @NotNull CodegenContext context() {

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
@@ -276,10 +276,9 @@ public final class CGenHelper {
     public @NotNull String renderPackFunctionName(@NotNull GdType type) {
         if (type instanceof GdObjectType objectType) {
             if (objectType.checkGdccType(context.classRegistry())) {
-                return "godot_new_Variant_with_gdcc_Object";
-            } else {
-                return "godot_new_Variant_with_Object";
+                return "gdcc_new_Variant_with_gdcc_Object";
             }
+            return "godot_new_Variant_with_Object";
         } else {
             return "godot_new_Variant_with_" + renderGdTypeName(type);
         }

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
@@ -385,6 +385,14 @@ public final class CGenHelper {
         return context.classRegistry().isGdccClass(className);
     }
 
+    /// Renders generated per-class object pointer helper name for a GDCC object type.
+    public @NotNull String renderGdccObjectPtrHelperName(@NotNull GdObjectType gdObjectType) {
+        if (!gdObjectType.checkGdccType(context.classRegistry())) {
+            throw new IllegalArgumentException("Type " + gdObjectType.getTypeName() + " is not a GDCC object type");
+        }
+        return gdObjectType.getTypeName() + "_object_ptr";
+    }
+
     /// Resolve the nearest constructible native ancestor for a GDCC class.
     /// This walks up GDCC inheritance chain until the first non-GDCC parent.
     public @NotNull String resolveNearestNativeAncestorName(@NotNull ClassDef classDef) {

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
@@ -381,6 +381,10 @@ public final class CGenHelper {
         return false;
     }
 
+    public boolean checkGdccClassByName(@NotNull String className) {
+        return context.classRegistry().isGdccClass(className);
+    }
+
     public @NotNull CodegenContext context() {
         return context;
     }

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
@@ -335,7 +335,7 @@ public final class CGenHelper {
     /// Mainly used for preventing direct assignment of Godot object ptr to GDCC object ptr.
     ///
     /// @param sourceExpr This expr is in C which is a GDExtension function call. It never returns direct GDCC type ptr,
-    ///                                     but the underlying proxy Godot object ptr.
+    ///                                                       but the underlying proxy Godot object ptr.
     public @NotNull String renderVarAssignWithGodotReturn(@NotNull LirFunctionDef func,
                                                           @NotNull String targetVarName,
                                                           @NotNull GdType sourceType,
@@ -352,17 +352,31 @@ public final class CGenHelper {
             throw new InvalidInsnException("Cannot assign value of type " + sourceType.getTypeName() + " to variable " +
                     targetVarName + " of type " + targetVar.type().getTypeName() + " in function " + func.getName());
         }
-        if (targetVar.type() instanceof GdObjectType targetType) {
-            if (targetType.checkGdccType(context.classRegistry())) {
-                return "$" + targetVarName + " = (" + targetType.getTypeName() + "*)gdcc_object_from_godot_object_ptr(" + sourceExpr + ");";
-            } else if (!targetType.getTypeName().equals(sourceType.getTypeName())) {
-                return "$" + targetVarName + " = (" + renderGdTypeInC(targetType) + ")(" + sourceExpr + ");";
-            } else {
-                return "$" + targetVarName + " = " + sourceExpr + ";";
-            }
-        } else {
-            return "$" + targetVarName + " = " + sourceExpr + ";";
+        if (targetVar.type() instanceof GdObjectType targetType && sourceType instanceof GdObjectType sourceObjectType) {
+            var assignExpr = renderObjectAssignExprWithSafeConversion(sourceExpr, sourceObjectType, targetType);
+            return "$" + targetVarName + " = " + assignExpr + ";";
         }
+        return "$" + targetVarName + " = " + sourceExpr + ";";
+    }
+
+    private @NotNull String renderObjectAssignExprWithSafeConversion(@NotNull String sourceExpr,
+                                                                     @NotNull GdObjectType sourceType,
+                                                                     @NotNull GdObjectType targetType) {
+        if (targetType.checkGdccType(context.classRegistry())) {
+            var castType = renderGdTypeInC(targetType);
+            return "(" + castType + ")gdcc_object_from_godot_object_ptr(" + sourceExpr + ")";
+        }
+
+        var convertedSourceExpr = sourceExpr;
+        if (sourceType.checkGdccType(context.classRegistry())) {
+            convertedSourceExpr = "gdcc_object_to_godot_object_ptr(" + sourceExpr + ", " +
+                    renderGdccObjectPtrHelperName(sourceType) + ")";
+        }
+        if (!targetType.getTypeName().equals(sourceType.getTypeName())) {
+            var castType = renderGdTypeInC(targetType);
+            return "(" + castType + ")(" + convertedSourceExpr + ")";
+        }
+        return convertedSourceExpr;
     }
 
     public boolean checkVirtualMethod(@NotNull ClassDef classDef, @NotNull FunctionDef functionDef) {

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/LoadPropertyInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/LoadPropertyInsnGen.java
@@ -78,7 +78,7 @@ public final class LoadPropertyInsnGen implements CInsnGen<LoadPropertyInsn> {
             }
             case GENERAL -> {
                 // Pass objectVar directly; renderArgument will auto-convert GDCC ptrs
-                // to Godot raw ptrs via godot_object_from_gdcc_object_ptr(...) since godot_Object_get requires Godot ptrs.
+                // to Godot raw ptrs via gdcc_object_to_godot_object_ptr(value, Type_object_ptr) since godot_Object_get requires Godot ptrs.
                 var objectValue = bodyBuilder.valueOfVar(objectVar);
                 var propertyName = bodyBuilder.valueOfStringNamePtrLiteral(insn.propertyName());
                 var tempVar = bodyBuilder.newTempVariable("variant", GdVariantType.VARIANT);

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java
@@ -443,7 +443,7 @@ public class CBodyBuilderPhaseCTest {
 
             var result = builder.build();
             // GDCC class inherits RefCounted, should use helper conversion
-            assertTrue(result.contains("godot_object_from_gdcc_object_ptr($myObj)"),
+            assertTrue(result.contains("gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr)"),
                     "Should use godot_object_from_gdcc_object_ptr for GDCC object");
         }
 
@@ -887,7 +887,7 @@ public class CBodyBuilderPhaseCTest {
 
             builder.callVoid("godot_some_func", List.of(value));
 
-            assertEquals("godot_some_func(godot_object_from_gdcc_object_ptr($myObj));\n", builder.build());
+            assertEquals("godot_some_func(gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr));\n", builder.build());
         }
 
         @Test
@@ -920,7 +920,7 @@ public class CBodyBuilderPhaseCTest {
 
             builder.callVoid("godot_Node_queue_free", List.of(casted));
 
-            assertEquals("godot_Node_queue_free((godot_Node*)godot_object_from_gdcc_object_ptr($self));\n", builder.build());
+            assertEquals("godot_Node_queue_free((godot_Node*)gdcc_object_to_godot_object_ptr($self, MyGdccClass_object_ptr));\n", builder.build());
         }
 
         @Test
@@ -932,6 +932,34 @@ public class CBodyBuilderPhaseCTest {
             builder.callVoid("my_custom_func", List.of(casted));
 
             assertEquals("my_custom_func((MyGdccClass*)gdcc_object_from_godot_object_ptr($node));\n", builder.build());
+        }
+
+        @Test
+        @DisplayName("valueOfCastedVar should render GDCC upcast via _super chain")
+        void testCastedGdccChildToAncestorShouldUseSuperChain() {
+            builder.classRegistry().addGdccClass(new LirClassDef("GdccGrandParent", "RefCounted"));
+            builder.classRegistry().addGdccClass(new LirClassDef("GdccParent", "GdccGrandParent"));
+            builder.classRegistry().addGdccClass(new LirClassDef("GdccChild", "GdccParent"));
+            var childVar = new LirVariable("child", new GdObjectType("GdccChild"), lirFunctionDef);
+            var casted = builder.valueOfCastedVar(childVar, new GdObjectType("GdccGrandParent"));
+
+            builder.callVoid("my_custom_func", List.of(casted));
+
+            assertEquals("my_custom_func(&($child->_super._super));\n", builder.build());
+        }
+
+        @Test
+        @DisplayName("valueOfCastedVar should reject GDCC non-upcast conversion")
+        void testCastedGdccParentToChildShouldFailFast() {
+            builder.classRegistry().addGdccClass(new LirClassDef("GdccParent", "RefCounted"));
+            builder.classRegistry().addGdccClass(new LirClassDef("GdccChild", "GdccParent"));
+            var parentVar = new LirVariable("parent", new GdObjectType("GdccParent"), lirFunctionDef);
+
+            var ex = assertThrows(InvalidInsnException.class, () ->
+                    builder.valueOfCastedVar(parentVar, new GdObjectType("GdccChild"))
+            );
+            assertInstanceOf(InvalidInsnException.class, ex);
+            assertTrue(ex.getMessage().contains("safe upcast"), ex.getMessage());
         }
 
         @Test
@@ -951,7 +979,7 @@ public class CBodyBuilderPhaseCTest {
 
             builder.callVoid("try_own_object", List.of(value));
 
-            assertEquals("try_own_object(godot_object_from_gdcc_object_ptr($myObj));\n", builder.build());
+            assertEquals("try_own_object(gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr));\n", builder.build());
         }
 
         @Test
@@ -965,7 +993,7 @@ public class CBodyBuilderPhaseCTest {
                     builder.valueOfVar(strVar)
             ));
 
-            assertEquals("godot_Object_set(godot_object_from_gdcc_object_ptr($myObj), &$name);\n", builder.build());
+            assertEquals("godot_Object_set(gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr), &$name);\n", builder.build());
         }
 
         @Test
@@ -1045,9 +1073,9 @@ public class CBodyBuilderPhaseCTest {
 
             var result = builder.build();
             // MyGdccClass extends RefCounted; owned call results should not be owned again.
-            assertTrue(result.contains("release_object(godot_object_from_gdcc_object_ptr(__gdcc_tmp_old_obj_0))"),
+            assertTrue(result.contains("release_object(gdcc_object_to_godot_object_ptr(__gdcc_tmp_old_obj_0, MyGdccClass_object_ptr))"),
                     "Should release captured old GDCC object. Actual:\n" + result);
-            assertFalse(result.contains("own_object(godot_object_from_gdcc_object_ptr($myObj))"),
+            assertFalse(result.contains("own_object(gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr))"),
                     "Should consume owned call result without own. Actual:\n" + result);
         }
 
@@ -1063,7 +1091,7 @@ public class CBodyBuilderPhaseCTest {
 
             var result = builder.build();
             // Arg should be converted
-            assertTrue(result.contains("godot_object_from_gdcc_object_ptr($input)"),
+            assertTrue(result.contains("gdcc_object_to_godot_object_ptr($input, MyGdccClass_object_ptr)"),
                     "Should convert GDCC arg to godot ptr. Actual:\n" + result);
             // Return should be wrapped
             assertTrue(result.contains("gdcc_object_from_godot_object_ptr"),
@@ -1104,7 +1132,7 @@ public class CBodyBuilderPhaseCTest {
             builder.assignVar(targetRef, value);
 
             var result = builder.build();
-            assertTrue(result.contains("$obj = godot_object_from_gdcc_object_ptr($myObj)"),
+            assertTrue(result.contains("$obj = gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr)"),
                     "Should convert GDCC_PTR to GODOT_PTR via helper conversion. Actual:\n" + result);
         }
 
@@ -1123,7 +1151,7 @@ public class CBodyBuilderPhaseCTest {
                     "Should assign directly without conversion. Actual:\n" + result);
             assertFalse(result.contains("gdcc_object_from_godot_object_ptr"),
                     "Should NOT wrap with fromGodotObjectPtr. Actual:\n" + result);
-            assertFalse(result.contains("godot_object_from_gdcc_object_ptr($source);"),
+            assertFalse(result.contains("gdcc_object_to_godot_object_ptr($source, MyGdccClass_object_ptr);"),
                     "Should NOT use helper conversion on RHS. Actual:\n" + result);
         }
 
@@ -1155,9 +1183,9 @@ public class CBodyBuilderPhaseCTest {
 
             var result = builder.build();
             // MyGdccClass extends RefCounted, should have own/release with helper conversion
-            assertTrue(result.contains("release_object(godot_object_from_gdcc_object_ptr(__gdcc_tmp_old_obj_0))"),
+            assertTrue(result.contains("release_object(gdcc_object_to_godot_object_ptr(__gdcc_tmp_old_obj_0, MyGdccClass_object_ptr))"),
                     "Should release captured old GDCC object via helper conversion. Actual:\n" + result);
-            assertTrue(result.contains("own_object(godot_object_from_gdcc_object_ptr($myObj))"),
+            assertTrue(result.contains("own_object(gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr))"),
                     "Should own new GDCC object via helper conversion. Actual:\n" + result);
             // Should also convert the assignment value
             assertTrue(result.contains("gdcc_object_from_godot_object_ptr(some_godot_result)"),
@@ -1206,7 +1234,7 @@ public class CBodyBuilderPhaseCTest {
             builder.assignVar(targetRef, value);
 
             var result = builder.build();
-            assertTrue(result.contains("$rc = godot_object_from_gdcc_object_ptr($myObj)"),
+            assertTrue(result.contains("$rc = gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr)"),
                     "Should convert GDCC_PTR to GODOT_PTR via helper conversion. Actual:\n" + result);
         }
 
@@ -1222,8 +1250,8 @@ public class CBodyBuilderPhaseCTest {
             var result = builder.build();
             var captureIndex = result.indexOf("MyGdccClass* __gdcc_tmp_old_obj_0 = $myObj;");
             var assignIndex = result.indexOf("$myObj = (MyGdccClass*)gdcc_object_from_godot_object_ptr(godot_result);");
-            var ownIndex = result.indexOf("own_object(godot_object_from_gdcc_object_ptr($myObj))");
-            var releaseOldIndex = result.indexOf("release_object(godot_object_from_gdcc_object_ptr(__gdcc_tmp_old_obj_0));");
+            var ownIndex = result.indexOf("own_object(gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr))");
+            var releaseOldIndex = result.indexOf("release_object(gdcc_object_to_godot_object_ptr(__gdcc_tmp_old_obj_0, MyGdccClass_object_ptr));");
 
             assertTrue(captureIndex >= 0, "Should capture old slot value. Actual:\n" + result);
             assertTrue(assignIndex >= 0, "Should have converted assignment. Actual:\n" + result);

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java
@@ -444,7 +444,7 @@ public class CBodyBuilderPhaseCTest {
             var result = builder.build();
             // GDCC class inherits RefCounted, should use helper conversion
             assertTrue(result.contains("gdcc_object_to_godot_object_ptr($myObj, MyGdccClass_object_ptr)"),
-                    "Should use godot_object_from_gdcc_object_ptr for GDCC object");
+                    "Should use class-specific GDCC object pointer helper conversion");
         }
 
         @Test
@@ -997,13 +997,13 @@ public class CBodyBuilderPhaseCTest {
         }
 
         @Test
-        @DisplayName("GDCC object arg should stay GDCC ptr for godot_new_Variant_with_gdcc_Object")
+        @DisplayName("GDCC object arg should stay GDCC ptr for gdcc_new_Variant_with_gdcc_Object")
         void testGdccObjectArgNotConvertedForGdccVariantPackFunc() {
             var gdccVar = new LirVariable("myObj", new GdObjectType("MyGdccClass"), lirFunctionDef);
 
-            builder.callVoid("godot_new_Variant_with_gdcc_Object", List.of(builder.valueOfVar(gdccVar)));
+            builder.callVoid("gdcc_new_Variant_with_gdcc_Object", List.of(builder.valueOfVar(gdccVar)));
 
-            assertEquals("godot_new_Variant_with_gdcc_Object($myObj);\n", builder.build());
+            assertEquals("gdcc_new_Variant_with_gdcc_Object($myObj);\n", builder.build());
         }
 
         @Test
@@ -1168,7 +1168,7 @@ public class CBodyBuilderPhaseCTest {
             var result = builder.build();
             assertTrue(result.contains("$target = $source;"),
                     "Should assign directly without conversion. Actual:\n" + result);
-            assertFalse(result.contains("godot_object_from_gdcc_object_ptr"),
+            assertFalse(result.contains("gdcc_object_to_godot_object_ptr"),
                     "Should NOT use helper conversion. Actual:\n" + result);
         }
 

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
@@ -99,7 +99,6 @@ public class CCodegenTest {
         assertTrue(cCode.contains("GDParentNode_class_constructor(&self->_super);"));
         assertTrue(cCode.contains("try_release_object(GDParentNode_object_ptr(self->peer));"));
         assertTrue(cCode.contains("GDParentNode_class_destructor(&self->_super);"));
-        assertFalse(cCode.contains("godot_object_from_gdcc_object_ptr(self->peer)"));
 
         assertEquals("Node", resolveConstructTarget(cCode, "GDParentNode"));
         assertEquals("Node", resolveConstructTarget(cCode, "GDChildNode"));

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
@@ -10,6 +10,7 @@ import dev.superice.gdcc.lir.LirModule;
 import dev.superice.gdcc.lir.LirPropertyDef;
 import dev.superice.gdcc.scope.ClassRegistry;
 import dev.superice.gdcc.type.GdFloatType;
+import dev.superice.gdcc.type.GdObjectType;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CCodegenTest {
@@ -57,5 +59,45 @@ public class CCodegenTest {
         System.out.println(cCode);
         assertTrue(cCode.contains("Loading my_module"));
         assertTrue(hCode.contains("GDEXTENSION_MY_MODULE_ENTRY_H"));
+    }
+
+    @Test
+    public void generatesExplicitGdccInheritanceLayoutAndObjectPtrHelpers() throws Exception {
+        var parentClass = new LirClassDef("GDParentNode", "Node");
+        parentClass.addProperty(new LirPropertyDef("speed", GdFloatType.FLOAT));
+
+        var childClass = new LirClassDef("GDChildNode", "GDParentNode");
+        childClass.addProperty(new LirPropertyDef("peer", new GdObjectType("GDParentNode")));
+
+        var module = new LirModule("inheritance_layout_module", List.of(parentClass, childClass));
+
+        var api = ExtensionApiLoader.loadDefault();
+        var classRegistry = new ClassRegistry(api);
+        ProjectInfo projectInfo = new ProjectInfo("test", GodotVersion.V451, Path.of(".")) {
+        };
+        var ctx = new CodegenContext(projectInfo, classRegistry);
+
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+        List<GeneratedFile> files = codegen.generate();
+
+        var cCode = new String(files.get(0).contentWriter());
+        var hCode = new String(files.get(1).contentWriter());
+
+        assertTrue(hCode.contains("struct GDParentNode {"));
+        assertTrue(hCode.contains("GDExtensionObjectPtr _object;"));
+        assertTrue(hCode.contains("struct GDChildNode {"));
+        assertTrue(hCode.contains("GDParentNode _super;"));
+        assertTrue(hCode.contains("static inline GDExtensionObjectPtr GDParentNode_object_ptr(GDParentNode* self);"));
+        assertTrue(hCode.contains("static inline GDExtensionObjectPtr GDChildNode_object_ptr(GDChildNode* self);"));
+        assertTrue(hCode.contains("static inline void GDChildNode_set_object_ptr(GDChildNode* self, GDExtensionObjectPtr obj);"));
+
+        assertTrue(cCode.contains("static inline GDExtensionObjectPtr GDChildNode_object_ptr(GDChildNode* self)"));
+        assertTrue(cCode.contains("return GDParentNode_object_ptr(&self->_super);"));
+        assertTrue(cCode.contains("GDChildNode_set_object_ptr(self, obj);"));
+        assertTrue(cCode.contains("GDParentNode_class_constructor(&self->_super);"));
+        assertTrue(cCode.contains("try_release_object(GDParentNode_object_ptr(self->peer));"));
+        assertTrue(cCode.contains("GDParentNode_class_destructor(&self->_super);"));
+        assertFalse(cCode.contains("godot_object_from_gdcc_object_ptr(self->peer)"));
     }
 }

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -99,5 +100,70 @@ public class CCodegenTest {
         assertTrue(cCode.contains("try_release_object(GDParentNode_object_ptr(self->peer));"));
         assertTrue(cCode.contains("GDParentNode_class_destructor(&self->_super);"));
         assertFalse(cCode.contains("godot_object_from_gdcc_object_ptr(self->peer)"));
+
+        assertEquals("Node", resolveConstructTarget(cCode, "GDParentNode"));
+        assertEquals("Node", resolveConstructTarget(cCode, "GDChildNode"));
+        var directParentConstructPattern = Pattern.compile(
+                "GDExtensionObjectPtr\\s+GDChildNode_class_create_instance\\([^)]*\\)\\s*\\{\\s*GDExtensionObjectPtr obj = godot_classdb_construct_object2\\(GD_STATIC_SN\\(u8\"GDParentNode\"\\)\\);",
+                Pattern.DOTALL);
+        assertFalse(directParentConstructPattern.matcher(cCode).find());
+    }
+
+    @Test
+    public void createInstanceUsesSingleBindingAndNearestNativeAncestorForDeepGdccInheritance() throws Exception {
+        var rootClass = new LirClassDef("GDRootNode", "Node");
+        var midClass = new LirClassDef("GDMidNode", "GDRootNode");
+        var leafClass = new LirClassDef("GDLeafNode", "GDMidNode");
+        var module = new LirModule("deep_inheritance_module", List.of(rootClass, midClass, leafClass));
+
+        var api = ExtensionApiLoader.loadDefault();
+        var classRegistry = new ClassRegistry(api);
+        ProjectInfo projectInfo = new ProjectInfo("test", GodotVersion.V451, Path.of(".")) {
+        };
+        var ctx = new CodegenContext(projectInfo, classRegistry);
+
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+        var files = codegen.generate();
+        var cCode = new String(files.getFirst().contentWriter());
+
+        assertEquals("Node", resolveConstructTarget(cCode, "GDRootNode"));
+        assertEquals("Node", resolveConstructTarget(cCode, "GDMidNode"));
+        assertEquals("Node", resolveConstructTarget(cCode, "GDLeafNode"));
+
+        var leafCreateInstanceBody = resolveCreateInstanceBody(cCode, "GDLeafNode");
+        assertEquals(1, countOccurrences(leafCreateInstanceBody, "godot_object_set_instance("));
+        assertEquals(1, countOccurrences(leafCreateInstanceBody, "godot_object_set_instance_binding("));
+    }
+
+    private static String resolveConstructTarget(String cCode, String className) {
+        var functionPrefix = "GDExtensionObjectPtr\\s+" + Pattern.quote(className) + "_class_create_instance";
+        var pattern = Pattern.compile(functionPrefix +
+                "\\([^)]*\\)\\s*\\{\\s*GDExtensionObjectPtr obj = godot_classdb_construct_object2\\(GD_STATIC_SN\\(u8\"([^\"]+)\"\\)\\);",
+                Pattern.DOTALL);
+        var matcher = pattern.matcher(cCode);
+        assertTrue(matcher.find(), "Missing create_instance construct target for class " + className);
+        return matcher.group(1);
+    }
+
+    private static String resolveCreateInstanceBody(String cCode, String className) {
+        var functionPrefix = "GDExtensionObjectPtr\\s+" + Pattern.quote(className) + "_class_create_instance";
+        var pattern = Pattern.compile(functionPrefix + "\\([^)]*\\)\\s*\\{(.*?)return obj;\\s*}", Pattern.DOTALL);
+        var matcher = pattern.matcher(cCode);
+        assertTrue(matcher.find(), "Missing create_instance body for class " + className);
+        return matcher.group(1);
+    }
+
+    private static int countOccurrences(String text, String needle) {
+        var count = 0;
+        var fromIndex = 0;
+        while (true) {
+            var index = text.indexOf(needle, fromIndex);
+            if (index < 0) {
+                return count;
+            }
+            count++;
+            fromIndex = index + needle.length();
+        }
     }
 }

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CDestructInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CDestructInsnGenTest.java
@@ -69,7 +69,7 @@ public class CDestructInsnGenTest {
         var codegen = newCodegen(module, List.of(workerClass, gdccObjectClass), emptyApi());
 
         var body = codegen.generateFuncBody(workerClass, func);
-        assertTrue(body.contains("release_object(godot_object_from_gdcc_object_ptr($obj));"));
+        assertTrue(body.contains("release_object(gdcc_object_to_godot_object_ptr($obj, MyObject_object_ptr));"));
     }
 
     @Test

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CGenHelperTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CGenHelperTest.java
@@ -1,0 +1,125 @@
+package dev.superice.gdcc.backend.c.gen;
+
+import dev.superice.gdcc.backend.CodegenContext;
+import dev.superice.gdcc.backend.ProjectInfo;
+import dev.superice.gdcc.enums.GodotVersion;
+import dev.superice.gdcc.exception.InvalidInsnException;
+import dev.superice.gdcc.gdextension.ExtensionApiLoader;
+import dev.superice.gdcc.lir.LirClassDef;
+import dev.superice.gdcc.lir.LirFunctionDef;
+import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdIntType;
+import dev.superice.gdcc.type.GdObjectType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CGenHelperTest {
+    private CGenHelper helper;
+    private LirFunctionDef function;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        var projectInfo = new ProjectInfo("TestProject", GodotVersion.V451, Path.of(".")) {
+        };
+        var extensionApi = ExtensionApiLoader.loadDefault();
+        var classRegistry = new ClassRegistry(extensionApi);
+
+        var gdccBase = new LirClassDef("MyBase", "RefCounted");
+        var gdccChild = new LirClassDef("MyChild", "MyBase");
+        classRegistry.addGdccClass(gdccBase);
+        classRegistry.addGdccClass(gdccChild);
+
+        var context = new CodegenContext(projectInfo, classRegistry);
+        helper = new CGenHelper(context, List.of(gdccBase, gdccChild));
+
+        function = new LirFunctionDef("test");
+    }
+
+    @Test
+    @DisplayName("renderVarAssignWithGodotReturn should convert Godot object ptr to GDCC ptr for GDCC target")
+    void renderVarAssignWithGodotReturnShouldConvertToGdccPtr() {
+        function.createAndAddVariable("target", new GdObjectType("MyBase"));
+
+        var statement = helper.renderVarAssignWithGodotReturn(
+                function,
+                "target",
+                new GdObjectType("MyChild"),
+                "godot_api_result()"
+        );
+
+        assertEquals("$target = (MyBase*)gdcc_object_from_godot_object_ptr(godot_api_result());", statement);
+    }
+
+    @Test
+    @DisplayName("renderVarAssignWithGodotReturn should convert GDCC source ptr via helper before engine cast")
+    void renderVarAssignWithGodotReturnShouldConvertGdccSourceBeforeEngineCast() {
+        function.createAndAddVariable("target", new GdObjectType("RefCounted"));
+
+        var statement = helper.renderVarAssignWithGodotReturn(
+                function,
+                "target",
+                new GdObjectType("MyChild"),
+                "$child_expr"
+        );
+
+        assertEquals("$target = (godot_RefCounted*)(gdcc_object_to_godot_object_ptr($child_expr, MyChild_object_ptr));", statement);
+    }
+
+    @Test
+    @DisplayName("renderVarAssignWithGodotReturn should keep same-type engine pointer assignment direct")
+    void renderVarAssignWithGodotReturnShouldKeepDirectAssignmentForSameEngineType() {
+        function.createAndAddVariable("target", new GdObjectType("Node"));
+
+        var statement = helper.renderVarAssignWithGodotReturn(
+                function,
+                "target",
+                new GdObjectType("Node"),
+                "godot_make_node()"
+        );
+
+        assertEquals("$target = godot_make_node();", statement);
+    }
+
+    @Test
+    @DisplayName("renderVarAssignWithGodotReturn should reject readonly ref variable")
+    void renderVarAssignWithGodotReturnShouldRejectReadonlyRefVariable() {
+        function.createAndAddRefVariable("target", new GdObjectType("Node"));
+
+        var ex = assertThrows(InvalidInsnException.class, () ->
+                helper.renderVarAssignWithGodotReturn(
+                        function,
+                        "target",
+                        new GdObjectType("Node"),
+                        "godot_make_node()"
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+    }
+
+    @Test
+    @DisplayName("renderVarAssignWithGodotReturn should reject incompatible assignment")
+    void renderVarAssignWithGodotReturnShouldRejectIncompatibleAssignment() {
+        function.createAndAddVariable("target", GdIntType.INT);
+
+        var ex = assertThrows(InvalidInsnException.class, () ->
+                helper.renderVarAssignWithGodotReturn(
+                        function,
+                        "target",
+                        new GdObjectType("Node"),
+                        "godot_make_node()"
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+    }
+}

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/COwnReleaseObjectInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/COwnReleaseObjectInsnGenTest.java
@@ -51,8 +51,8 @@ public class COwnReleaseObjectInsnGenTest {
         codegen.prepare(newContext(new ExtensionAPI(null, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of()), List.of(workerClass, objectClass)), module);
 
         var body = codegen.generateFuncBody(workerClass, func);
-        assertTrue(body.contains("own_object(godot_object_from_gdcc_object_ptr($obj));"));
-        assertFalse(body.contains("try_own_object(godot_object_from_gdcc_object_ptr($obj));"));
+        assertTrue(body.contains("own_object(gdcc_object_to_godot_object_ptr($obj, MyObject_object_ptr));"));
+        assertFalse(body.contains("try_own_object(gdcc_object_to_godot_object_ptr($obj, MyObject_object_ptr));"));
     }
 
     @Test

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CPackUnpackVariantInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CPackUnpackVariantInsnGenTest.java
@@ -121,8 +121,8 @@ public class CPackUnpackVariantInsnGenTest {
 
         var body = codegen.generateFuncBody(workerClass, func);
         assertTrue(body.contains("godot_Variant_destroy(&$result);"));
-        assertTrue(body.contains("$result = godot_new_Variant_with_gdcc_Object($value);"));
-        assertFalse(body.contains("godot_new_Variant_with_gdcc_Object(godot_object_from_gdcc_object_ptr($value));"));
+        assertTrue(body.contains("$result = gdcc_new_Variant_with_gdcc_Object($value);"));
+        assertFalse(body.contains("godot_new_Variant_with_Object("));
     }
 
     @Test

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenEngineInheritanceTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenEngineInheritanceTest.java
@@ -1,0 +1,285 @@
+package dev.superice.gdcc.backend.c.gen;
+
+import dev.superice.gdcc.backend.CodegenContext;
+import dev.superice.gdcc.backend.c.build.COptimizationLevel;
+import dev.superice.gdcc.backend.c.build.CProjectBuilder;
+import dev.superice.gdcc.backend.c.build.CProjectInfo;
+import dev.superice.gdcc.backend.c.build.GodotGdextensionTestRunner;
+import dev.superice.gdcc.backend.c.build.TargetPlatform;
+import dev.superice.gdcc.backend.c.build.ZigUtil;
+import dev.superice.gdcc.enums.GodotVersion;
+import dev.superice.gdcc.gdextension.ExtensionApiLoader;
+import dev.superice.gdcc.lir.LirBasicBlock;
+import dev.superice.gdcc.lir.LirClassDef;
+import dev.superice.gdcc.lir.LirFunctionDef;
+import dev.superice.gdcc.lir.LirInstruction;
+import dev.superice.gdcc.lir.LirModule;
+import dev.superice.gdcc.lir.LirParameterDef;
+import dev.superice.gdcc.lir.insn.CallMethodInsn;
+import dev.superice.gdcc.lir.insn.LiteralIntInsn;
+import dev.superice.gdcc.lir.insn.ReturnInsn;
+import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdIntType;
+import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdType;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CallMethodInsnGenEngineInheritanceTest {
+
+    @Test
+    @DisplayName("CALL_METHOD inheritance should preserve safe GDCC conversion and variant packing in real engine")
+    void callMethodInheritanceShouldUseSafeConversionsAndRunInRealGodot() throws IOException, InterruptedException {
+        if (!hasZig()) {
+            Assumptions.abort("Zig not found; skipping integration test");
+            return;
+        }
+
+        var tempDir = Path.of("tmp/test/call_method_engine_inheritance");
+        Files.createDirectories(tempDir);
+
+        var projectInfo = new CProjectInfo(
+                "call_method_engine_inheritance",
+                GodotVersion.V451,
+                tempDir,
+                COptimizationLevel.DEBUG,
+                TargetPlatform.WINDOWS_X86_64
+        );
+        var builder = new CProjectBuilder();
+        builder.initProject(projectInfo);
+
+        var hostClass = newInheritanceHostClass();
+        var baseClass = newInheritanceBaseClass();
+        var childClass = newInheritanceChildClass();
+        var peerClass = newInheritancePeerClass();
+
+        var module = new LirModule(
+                "call_method_engine_inheritance_module",
+                List.of(hostClass, baseClass, childClass, peerClass)
+        );
+        var api = ExtensionApiLoader.loadVersion(GodotVersion.V451);
+        var codegen = new CCodegen();
+        codegen.prepare(new CodegenContext(projectInfo, new ClassRegistry(api)), module);
+
+        var buildResult = builder.buildProject(projectInfo, codegen);
+        assertTrue(buildResult.success(), "Compilation should succeed. Build log:\n" + buildResult.buildLog());
+        assertFalse(buildResult.artifacts().isEmpty(), "Compilation should produce extension artifacts.");
+
+        var entrySource = Files.readString(tempDir.resolve("entry.c"));
+        assertTrue(
+                entrySource.contains("GDInheritanceBaseWorker_base_value(&($child->_super));"),
+                "Child receiver should upcast via _super chain for parent static dispatch."
+        );
+        assertTrue(
+                entrySource.contains("godot_Object_call(gdcc_object_to_godot_object_ptr($baseRef, GDInheritanceBaseWorker_object_ptr), GD_STATIC_SN(u8\"child_only_consume_peer\")"),
+                "Base-typed GDCC receiver should use OBJECT_DYNAMIC dispatch with helper conversion."
+        );
+        assertTrue(
+                entrySource.contains("gdcc_new_Variant_with_gdcc_Object($peer)"),
+                "OBJECT_DYNAMIC arg packing should use gdcc_new_Variant_with_gdcc_Object."
+        );
+        assertFalse(
+                entrySource.contains("gdcc_new_Variant_with_gdcc_Object(gdcc_object_to_godot_object_ptr("),
+                "gdcc_new_Variant_with_gdcc_Object must receive raw GDCC pointer and convert exactly once inside macro."
+        );
+        assertFalse(
+                entrySource.contains("godot_new_Variant_with_Object(gdcc_object_to_godot_object_ptr($peer"),
+                "No direct replacement should bypass gdcc_new_Variant_with_gdcc_Object entry point."
+        );
+
+        var headerSource = Files.readString(tempDir.resolve("entry.h"));
+        assertTrue(
+                headerSource.contains("#define gdcc_new_Variant_with_gdcc_Object(obj)"),
+                "Generated header should provide gdcc_new_Variant_with_gdcc_Object macro."
+        );
+        assertTrue(
+                headerSource.contains("gdcc_object_to_godot_object_ptr((obj), _Generic((obj),"),
+                "GDCC object variant pack macro should route through helper-based conversion."
+        );
+
+        var runner = new GodotGdextensionTestRunner(Path.of("test_project"));
+        runner.prepareProject(new GodotGdextensionTestRunner.ProjectSetup(
+                buildResult.artifacts(),
+                List.of(new GodotGdextensionTestRunner.SceneNodeSpec(
+                        "CallMethodInheritanceNode",
+                        hostClass.getName(),
+                        ".",
+                        Map.of()
+                )),
+                new GodotGdextensionTestRunner.TestScriptSpec(inheritanceEngineTestScript())
+        ));
+
+        var runResult = runner.run(true);
+        var combinedOutput = runResult.combinedOutput();
+
+        assertTrue(runResult.stopSignalSeen(), "Godot run should emit stop signal.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("gdcc inheritance call_method check passed."), "Inheritance path should pass.\nOutput:\n" + combinedOutput);
+        assertFalse(combinedOutput.contains("check failed"), "No check should fail.\nOutput:\n" + combinedOutput);
+    }
+
+    private static boolean hasZig() {
+        return ZigUtil.findZig() != null;
+    }
+
+    private static LirClassDef newInheritanceHostClass() {
+        var clazz = new LirClassDef("GDCallMethodInheritanceNode", "Node");
+        clazz.setSourceFile("call_method_engine_inheritance_host.gd");
+
+        var selfType = new GdObjectType(clazz.getName());
+        clazz.addFunction(newCallBaseValueFromChild(selfType));
+        clazz.addFunction(newCallChildOnlyFromBaseWithPeer(selfType));
+        return clazz;
+    }
+
+    private static LirClassDef newInheritanceBaseClass() {
+        var clazz = new LirClassDef("GDInheritanceBaseWorker", "RefCounted");
+        clazz.setSourceFile("call_method_engine_inheritance_base.gd");
+
+        var selfType = new GdObjectType(clazz.getName());
+        clazz.addFunction(newBaseValueFunction(selfType));
+        return clazz;
+    }
+
+    private static LirClassDef newInheritanceChildClass() {
+        var clazz = new LirClassDef("GDInheritanceChildWorker", "GDInheritanceBaseWorker");
+        clazz.setSourceFile("call_method_engine_inheritance_child.gd");
+
+        var selfType = new GdObjectType(clazz.getName());
+        clazz.addFunction(newChildOnlyConsumePeerFunction(selfType));
+        return clazz;
+    }
+
+    private static LirClassDef newInheritancePeerClass() {
+        var clazz = new LirClassDef("GDInheritancePeerWorker", "RefCounted");
+        clazz.setSourceFile("call_method_engine_inheritance_peer.gd");
+
+        var selfType = new GdObjectType(clazz.getName());
+        clazz.addFunction(newPeerEchoFunction(selfType));
+        return clazz;
+    }
+
+    private static LirFunctionDef newCallBaseValueFromChild(GdObjectType selfType) {
+        var func = newMethod("call_base_value_from_child", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("child", new GdObjectType("GDInheritanceChildWorker"), null, func));
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        entry(func).instructions().add(new CallMethodInsn(
+                "result",
+                "base_value",
+                "child",
+                List.of()
+        ));
+        entry(func).instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static LirFunctionDef newCallChildOnlyFromBaseWithPeer(GdObjectType selfType) {
+        var func = newMethod("call_child_only_from_base_with_peer", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("baseRef", new GdObjectType("GDInheritanceBaseWorker"), null, func));
+        func.addParameter(new LirParameterDef("peer", new GdObjectType("GDInheritancePeerWorker"), null, func));
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        entry(func).instructions().add(new CallMethodInsn(
+                "result",
+                "child_only_consume_peer",
+                "baseRef",
+                List.of(varRef("peer"))
+        ));
+        entry(func).instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static LirFunctionDef newBaseValueFunction(GdObjectType selfType) {
+        var func = newMethod("base_value", GdIntType.INT, selfType);
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        entry(func).instructions().add(new LiteralIntInsn("result", 41));
+        entry(func).instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static LirFunctionDef newChildOnlyConsumePeerFunction(GdObjectType selfType) {
+        var func = newMethod("child_only_consume_peer", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("peer", new GdObjectType("GDInheritancePeerWorker"), null, func));
+        func.createAndAddVariable("seed", GdIntType.INT);
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        entry(func).instructions().add(new LiteralIntInsn("seed", 101));
+        entry(func).instructions().add(new CallMethodInsn(
+                "result",
+                "echo_value",
+                "peer",
+                List.of(varRef("seed"))
+        ));
+        entry(func).instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static LirFunctionDef newPeerEchoFunction(GdObjectType selfType) {
+        var func = newMethod("echo_value", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("value", GdIntType.INT, null, func));
+        entry(func).instructions().add(new ReturnInsn("value"));
+        return func;
+    }
+
+    private static LirFunctionDef newMethod(String name, GdType returnType, GdObjectType selfType) {
+        var func = new LirFunctionDef(name);
+        func.setReturnType(returnType);
+        func.addParameter(new LirParameterDef("self", selfType, null, func));
+        func.addBasicBlock(new LirBasicBlock("entry"));
+        func.setEntryBlockId("entry");
+        return func;
+    }
+
+    private static LirBasicBlock entry(LirFunctionDef functionDef) {
+        return functionDef.getBasicBlock("entry");
+    }
+
+    private static LirInstruction.VariableOperand varRef(String id) {
+        return new LirInstruction.VariableOperand(id);
+    }
+
+    private static String inheritanceEngineTestScript() {
+        return """
+                extends Node
+                
+                const TARGET_NODE_NAME = "CallMethodInheritanceNode"
+                
+                func _ready() -> void:
+                    var target = get_parent().get_node_or_null(TARGET_NODE_NAME)
+                    if target == null:
+                        push_error("Target node missing.")
+                        return
+                
+                    var child = GDInheritanceChildWorker.new()
+                    var peer = GDInheritancePeerWorker.new()
+                
+                    var parent_value = int(target.call("call_base_value_from_child", child))
+                    if parent_value != 41:
+                        push_error("gdcc inheritance call_method check failed.")
+                        return
+                
+                    var dynamic_value = int(target.call("call_child_only_from_base_with_peer", child, peer))
+                    if dynamic_value != 101:
+                        push_error("gdcc inheritance call_method check failed.")
+                        return
+                
+                    var is_parent_ok = child is GDInheritanceBaseWorker
+                    var classdb_parent_ok = ClassDB.is_parent_class("GDInheritanceChildWorker", "GDInheritanceBaseWorker")
+                    if is_parent_ok and classdb_parent_ok:
+                        print("gdcc inheritance call_method check passed.")
+                    else:
+                        push_error("gdcc inheritance call_method check failed.")
+                """;
+    }
+}

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenEngineTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenEngineTest.java
@@ -193,7 +193,7 @@ class CallMethodInsnGenEngineTest {
 
         var entrySource = Files.readString(tempDir.resolve("entry.c"));
         assertTrue(
-                entrySource.contains("godot_Object_call(godot_object_from_gdcc_object_ptr($baseRef), GD_STATIC_SN(u8\"child_only_echo\")"),
+                entrySource.contains("godot_Object_call(gdcc_object_to_godot_object_ptr($baseRef, GDBaseDynamicWorker_object_ptr), GD_STATIC_SN(u8\"child_only_echo\")"),
                 "Parent-typed GDCC receiver should use OBJECT_DYNAMIC dispatch with GDCC pointer conversion."
         );
         assertFalse(
@@ -255,7 +255,7 @@ class CallMethodInsnGenEngineTest {
 
         var entrySource = Files.readString(tempDir.resolve("entry.c"));
         assertTrue(
-                entrySource.contains("godot_Node_get_child_count((godot_Node*)godot_object_from_gdcc_object_ptr($self)"),
+                entrySource.contains("godot_Node_get_child_count((godot_Node*)gdcc_object_to_godot_object_ptr($self, GDGdccEngineOwnerBridgeNode_object_ptr)"),
                 "Engine dispatch on GDCC receiver should cast after helper conversion."
         );
         assertFalse(

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenTest.java
@@ -105,7 +105,7 @@ class CallMethodInsnGenTest {
         clazz.addFunction(func);
 
         var body = generateBody(clazz, func, newApi(List.of(), List.of(nodeClassWithQueueFree())), List.of(clazz));
-        assertTrue(body.contains("godot_Node_queue_free((godot_Node*)godot_object_from_gdcc_object_ptr($self));"), body);
+        assertTrue(body.contains("godot_Node_queue_free((godot_Node*)gdcc_object_to_godot_object_ptr($self, GDMyNode_object_ptr));"), body);
         assertFalse(body.contains("godot_Node_queue_free((godot_Node*)$self);"), body);
     }
 
@@ -133,6 +133,38 @@ class CallMethodInsnGenTest {
         assertTrue(body.contains("Worker_ping($worker);"), body);
         assertFalse(body.contains("godot_Object_call("), body);
         assertFalse(body.contains("godot_Variant_call("), body);
+    }
+
+    @Test
+    @DisplayName("CALL_METHOD should upcast GDCC receiver to parent owner via _super chain without bare cast")
+    void callMethodGdccReceiverToParentOwnerShouldUseSuperChainUpcast() {
+        var baseClass = newClass("BaseWorker");
+        var basePing = newFunction("base_ping");
+        basePing.addParameter(new LirParameterDef("self", new GdObjectType("BaseWorker"), null, basePing));
+        entry(basePing).instructions().add(new ReturnInsn(null));
+        baseClass.addFunction(basePing);
+
+        var childClass = newClass("ChildWorker", "BaseWorker");
+        var childOnly = newFunction("child_only");
+        childOnly.addParameter(new LirParameterDef("self", new GdObjectType("ChildWorker"), null, childOnly));
+        entry(childOnly).instructions().add(new ReturnInsn(null));
+        childClass.addFunction(childOnly);
+
+        var hostClass = newClass("Host");
+        var caller = newFunction("run");
+        caller.createAndAddVariable("child", new GdObjectType("ChildWorker"));
+        entry(caller).instructions().add(new CallMethodInsn(
+                null,
+                "base_ping",
+                "child",
+                List.of()
+        ));
+        hostClass.addFunction(caller);
+
+        var body = generateBody(hostClass, caller, newApi(List.of(), List.of()), List.of(hostClass, childClass, baseClass));
+        assertTrue(body.contains("BaseWorker_base_ping(&($child->_super));"), body);
+        assertFalse(body.contains("BaseWorker_base_ping((BaseWorker*)$child);"), body);
+        assertFalse(body.contains("godot_Object_call("), body);
     }
 
     @Test
@@ -170,7 +202,7 @@ class CallMethodInsnGenTest {
         hostClass.addFunction(caller);
 
         var body = generateBody(hostClass, caller, newApi(List.of(), List.of()), List.of(hostClass, workerClass));
-        assertTrue(body.contains("godot_Object_call(godot_object_from_gdcc_object_ptr($worker), GD_STATIC_SN(u8\"missing_method\")"), body);
+        assertTrue(body.contains("godot_Object_call(gdcc_object_to_godot_object_ptr($worker, Worker_object_ptr), GD_STATIC_SN(u8\"missing_method\")"), body);
         assertFalse(body.contains("Worker_missing_method("), body);
     }
 
@@ -205,7 +237,7 @@ class CallMethodInsnGenTest {
         hostClass.addFunction(caller);
 
         var body = generateBody(hostClass, caller, newApi(List.of(), List.of()), List.of(hostClass, baseClass, childClass));
-        assertTrue(body.contains("godot_Object_call(godot_object_from_gdcc_object_ptr($baseRef), GD_STATIC_SN(u8\"child_only_echo\")"), body);
+        assertTrue(body.contains("godot_Object_call(gdcc_object_to_godot_object_ptr($baseRef, BaseWorker_object_ptr), GD_STATIC_SN(u8\"child_only_echo\")"), body);
         assertFalse(body.contains("ChildWorker_child_only_echo("), body);
         assertFalse(body.contains("godot_Variant_call("), body);
     }
@@ -250,7 +282,7 @@ class CallMethodInsnGenTest {
                 newApi(List.of(), List.of()),
                 List.of(hostClass, baseClass, childClass, peerClass)
         );
-        assertTrue(body.contains("godot_Object_call(godot_object_from_gdcc_object_ptr($baseRef), GD_STATIC_SN(u8\"child_only_consume_peer\")"), body);
+        assertTrue(body.contains("godot_Object_call(gdcc_object_to_godot_object_ptr($baseRef, BaseWorker_object_ptr), GD_STATIC_SN(u8\"child_only_consume_peer\")"), body);
         assertTrue(body.contains("godot_new_Variant_with_gdcc_Object($peer)"), body);
         assertFalse(body.contains("godot_new_Variant_with_Object(godot_object_from_gdcc_object_ptr($peer))"), body);
         assertFalse(body.contains("godot_Variant_call("), body);

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenTest.java
@@ -283,8 +283,8 @@ class CallMethodInsnGenTest {
                 List.of(hostClass, baseClass, childClass, peerClass)
         );
         assertTrue(body.contains("godot_Object_call(gdcc_object_to_godot_object_ptr($baseRef, BaseWorker_object_ptr), GD_STATIC_SN(u8\"child_only_consume_peer\")"), body);
-        assertTrue(body.contains("godot_new_Variant_with_gdcc_Object($peer)"), body);
-        assertFalse(body.contains("godot_new_Variant_with_Object(godot_object_from_gdcc_object_ptr($peer))"), body);
+        assertTrue(body.contains("gdcc_new_Variant_with_gdcc_Object($peer)"), body);
+        assertFalse(body.contains("godot_new_Variant_with_Object("), body);
         assertFalse(body.contains("godot_Variant_call("), body);
     }
 


### PR DESCRIPTION
## Summary
This PR completes the explicit GDCC C inheritance layout migration in the C backend and removes legacy GDCC-object conversion paths. It unifies GDCC -> Godot pointer conversion through class-specific helpers, tightens cast/call conversion semantics, and adds engine integration coverage for inheritance and dynamic dispatch paths.

## What changed
- Implemented explicit inheritance-safe object layout/codegen behavior in backend C templates:
- Added generated per-class object pointer helper usage and helper-based GDCC variant pack macro in `entry.h.ftl`.
- Kept create-instance behavior aligned with nearest native ancestor construction path.
- Removed deprecated helper macros from shared C helper header:
- Removed `godot_object_from_gdcc_object_ptr` and `godot_new_Variant_with_gdcc_Object` from `gdcc_helper.h`.
- Updated Java backend codegen logic:
- `CGenHelper.renderPackFunctionName(...)` now emits `gdcc_new_Variant_with_gdcc_Object` for GDCC object types.
- `CBodyBuilder` conversion gate updated to avoid incorrect pre-conversion for GDCC variant pack calls and prevent double-conversion in call paths.
- Strengthened/updated tests for new conversion baseline:
- Updated unit tests across body builder, pack/unpack, own/release, destruct, and call_method generation.
- Added new engine integration test `CallMethodInsnGenEngineInheritanceTest` to validate inheritance dispatch, GDCC object variant packing, helper conversion behavior, and ClassDB parent visibility.
- Synced docs and PR guidance/template files:
- Updated backend/module implementation docs and PR template/guideline files to reflect the new baseline.

## Why
- Legacy conversion paths relied on assumptions that are unsafe under explicit `_super` inheritance layout (e.g., direct `_object`-style access through deprecated macros).
- `renderPackFunctionName` is used in multiple generation paths, not all of which go through `renderArgument`; a helper-only pack entrypoint is required to keep conversion behavior correct and consistent.
- Without conversion tightening, dynamic call/pack scenarios can introduce incorrect or duplicate GDCC -> Godot conversion.

## Affected packages/files
- `src/main/java/dev/superice/gdcc/backend/c/gen/`
- `src/main/java/dev/superice/gdcc/backend/c/gen/insn/`
- `src/main/c/codegen/template_451/`
- `src/main/c/codegen/include_451/gdcc/`
- `src/test/java/dev/superice/gdcc/backend/c/gen/`
- `doc/`
- `.github/pull_request_template.md`

## Validation
- `./gradlew test --tests CCodegenTest --tests CBodyBuilderPhaseCTest --tests CPackUnpackVariantInsnGenTest --tests CallMethodInsnGenTest --tests CallMethodInsnGenEngineTest --tests CallMethodInsnGenEngineInheritanceTest --tests COwnReleaseObjectInsnGenTest --tests CDestructInsnGenTest --no-daemon --info --console=plain`
- `./gradlew classes --no-daemon --info --console=plain`

Result: `BUILD SUCCESSFUL`

## Risks / Notes
- The generated `gdcc_new_Variant_with_gdcc_Object` macro uses `_Generic`; behavior assumes C11-compatible compilation in codegen output.
- Conversion policy is intentionally stricter for GDCC object paths; invalid/non-provable casts are expected to fail fast.
- Non-goal: no build script/configuration changes.

## Key behaviors covered (Optional)
- GDCC child -> parent static dispatch uses safe `_super`-chain upcast expression.
- Parent-typed GDCC receiver dynamic dispatch uses helper-based GDCC -> Godot conversion.
- GDCC object variant packing uses `gdcc_new_Variant_with_gdcc_Object` (no legacy macro path).
- CallAssign/call-path conversion avoids double conversion around GDCC object values.

## Diff stats (Optional)
- 20 files changed, 1129 insertions, 80 deletions.

## Breaking changes (Optional)
- None

## Related docs (Optional)
- `doc/gdcc_c_backend.md`
- `doc/module_impl/call_method_implementation.md`
- `doc/module_impl/cbodybuilder_implementation.md`
- `doc/module_impl/explicit_c_inheritance_layout_plan.md`
- `doc/pr_message_guideline.md`
