### PR TITLE
feat(backend): reuse shared include and compiler cache for C builds

### DIFF
--- a/src/main/java/dev/superice/gdcc/backend/c/build/CProjectBuilder.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/build/CProjectBuilder.java
@@ -12,15 +12,22 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CProjectBuilder implements ProjectBuilder<CProjectInfo, CCodegen, CBuildResult> {
+    private static final String INCLUDE_RESOURCE_DIR = "include_451";
+    private static final String PROJECT_INCLUDE_DIR_NAME = "include";
+    private static final String SHARED_INCLUDE_DIR_NAME = "shared-include";
+
     private CCompiler cCompiler;
+    private boolean ignoreSharedInclude;
 
     public CProjectBuilder() {
         this.cCompiler = new ZigCcCompiler();
+        this.ignoreSharedInclude = false;
     }
 
     // For tests - allow injecting a fake/compiler wrapper
     public CProjectBuilder(@NotNull CCompiler cCompiler) {
         this.cCompiler = cCompiler;
+        this.ignoreSharedInclude = false;
     }
 
     public CCompiler getCCompiler() {
@@ -31,17 +38,26 @@ public class CProjectBuilder implements ProjectBuilder<CProjectInfo, CCodegen, C
         this.cCompiler = cCompiler;
     }
 
+    public boolean isIgnoreSharedInclude() {
+        return ignoreSharedInclude;
+    }
+
+    public void setIgnoreSharedInclude(boolean ignoreSharedInclude) {
+        this.ignoreSharedInclude = ignoreSharedInclude;
+    }
+
     @Override
     public void initProject(@NotNull CProjectInfo projectInfo) throws IOException {
         var projectPath = projectInfo.projectPath();
-        var includeDir = projectPath.resolve("include");
-        // extract all files under resource folder include_451 into project include dir
-        ResourceExtractor.extract("include_451", includeDir, getClass().getClassLoader());
+        var includeRoot = resolveIncludeRoot(projectPath);
+        ResourceExtractor.extract(INCLUDE_RESOURCE_DIR, includeRoot, getClass().getClassLoader());
     }
 
     @Override
     public CBuildResult buildProject(@NotNull CProjectInfo projectInfo, @NotNull CCodegen codegen) throws IOException {
         var projectPath = projectInfo.projectPath();
+        var includeRoot = resolveIncludeRoot(projectPath);
+        ResourceExtractor.extract(INCLUDE_RESOURCE_DIR, includeRoot, getClass().getClassLoader());
 
         // Generate files
         var generated = codegen.generate();
@@ -59,14 +75,14 @@ public class CProjectBuilder implements ProjectBuilder<CProjectInfo, CCodegen, C
             }
         }
 
-        // gdextension-lite-one.c should be under include/gdextension-lite/gdextension-lite-one.c
-        var gdextOne = projectPath.resolve("include").resolve("gdextension-lite").resolve("gdextension-lite-one.c");
+        // gdextension-lite-one.c should be under <includeRoot>/gdextension-lite/gdextension-lite-one.c
+        var gdextOne = includeRoot.resolve("gdextension-lite").resolve("gdextension-lite-one.c");
         if (Files.exists(gdextOne)) cFiles.add(gdextOne);
 
         // include dir
         var includeDirs = List.of(
-                projectPath.resolve("include/gdcc"),
-                projectPath.resolve("include/gdextension-lite")
+                includeRoot.resolve("gdcc"),
+                includeRoot.resolve("gdextension-lite")
         );
 
         // output name: projectName
@@ -79,5 +95,27 @@ public class CProjectBuilder implements ProjectBuilder<CProjectInfo, CCodegen, C
 
         // Delegate compile to CCompiler and return
         return cCompiler.compile(projectPath, includeDirs, cFiles, outputName, opt, tp);
+    }
+
+    private @NotNull Path resolveIncludeRoot(@NotNull Path projectPath) throws IOException {
+        var normalizedProjectPath = projectPath.toAbsolutePath().normalize();
+        if (ignoreSharedInclude) {
+            return normalizedProjectPath.resolve(PROJECT_INCLUDE_DIR_NAME);
+        }
+
+        var projectParent = normalizedProjectPath.getParent();
+        if (projectParent == null) {
+            return normalizedProjectPath.resolve(PROJECT_INCLUDE_DIR_NAME);
+        }
+
+        var sharedInclude = projectParent.resolve(SHARED_INCLUDE_DIR_NAME);
+        if (Files.exists(sharedInclude) && !Files.isDirectory(sharedInclude)) {
+            throw new IOException("Shared include path exists but is not a directory: " + sharedInclude);
+        }
+
+        if (Files.isDirectory(sharedInclude)) {
+            return sharedInclude;
+        }
+        return normalizedProjectPath.resolve(PROJECT_INCLUDE_DIR_NAME);
     }
 }

--- a/src/main/java/dev/superice/gdcc/backend/c/build/CProjectBuilder.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/build/CProjectBuilder.java
@@ -97,7 +97,7 @@ public class CProjectBuilder implements ProjectBuilder<CProjectInfo, CCodegen, C
         return cCompiler.compile(projectPath, includeDirs, cFiles, outputName, opt, tp);
     }
 
-    private @NotNull Path resolveIncludeRoot(@NotNull Path projectPath) throws IOException {
+    private @NotNull Path resolveIncludeRoot(@NotNull Path projectPath) {
         var normalizedProjectPath = projectPath.toAbsolutePath().normalize();
         if (ignoreSharedInclude) {
             return normalizedProjectPath.resolve(PROJECT_INCLUDE_DIR_NAME);
@@ -109,10 +109,6 @@ public class CProjectBuilder implements ProjectBuilder<CProjectInfo, CCodegen, C
         }
 
         var sharedInclude = projectParent.resolve(SHARED_INCLUDE_DIR_NAME);
-        if (Files.exists(sharedInclude) && !Files.isDirectory(sharedInclude)) {
-            throw new IOException("Shared include path exists but is not a directory: " + sharedInclude);
-        }
-
         if (Files.isDirectory(sharedInclude)) {
             return sharedInclude;
         }

--- a/src/main/java/dev/superice/gdcc/backend/c/build/ZigCcCompiler.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/build/ZigCcCompiler.java
@@ -95,6 +95,9 @@ public class ZigCcCompiler implements CCompiler {
         }
 
         var sharedCacheDir = projectParent.resolve(SHARED_CACHE_DIR_NAME);
+        if (Files.exists(sharedCacheDir) && !Files.isDirectory(sharedCacheDir)) {
+            return normalizedProjectDir.resolve(PROJECT_CACHE_DIR_NAME);
+        }
         if (Files.isDirectory(sharedCacheDir)) {
             return sharedCacheDir.toAbsolutePath().normalize();
         }

--- a/src/main/java/dev/superice/gdcc/backend/c/build/ZigCcCompiler.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/build/ZigCcCompiler.java
@@ -10,6 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ZigCcCompiler implements CCompiler {
+    private static final String PROJECT_CACHE_DIR_NAME = "compiler-cache";
+    private static final String SHARED_CACHE_DIR_NAME = "shared-compiler-cache";
+
     @Override
     public CBuildResult compile(@NotNull Path projectDir, @NotNull List<Path> includeDirs, @NotNull List<Path> cFiles, @NotNull String outputBaseName, @NotNull COptimizationLevel optimizationLevel, @NotNull TargetPlatform targetPlatform) {
         var zig = ZigUtil.findZig();
@@ -25,7 +28,7 @@ public class ZigCcCompiler implements CCompiler {
         var outName = targetPlatform.sharedLibraryFileName(outputBaseName);
 
         var outputPath = projectDir.resolve(outName).toAbsolutePath();
-        var cachePath = projectDir.resolve("compiler-cache").toAbsolutePath();
+        var cachePath = resolveCompilerCacheRoot(projectDir);
 
         var cmd = new ArrayList<String>();
         cmd.add(zig.toString());
@@ -82,5 +85,20 @@ public class ZigCcCompiler implements CCompiler {
             Thread.currentThread().interrupt();
             return new CBuildResult(false, "Failed to run zig: " + e.getMessage(), List.of());
         }
+    }
+
+    static @NotNull Path resolveCompilerCacheRoot(@NotNull Path projectDir) {
+        var normalizedProjectDir = projectDir.toAbsolutePath().normalize();
+        var projectParent = normalizedProjectDir.getParent();
+        if (projectParent == null) {
+            return normalizedProjectDir.resolve(PROJECT_CACHE_DIR_NAME);
+        }
+
+        var sharedCacheDir = projectParent.resolve(SHARED_CACHE_DIR_NAME);
+        if (Files.isDirectory(sharedCacheDir)) {
+            return sharedCacheDir.toAbsolutePath().normalize();
+        }
+
+        return normalizedProjectDir.resolve(PROJECT_CACHE_DIR_NAME);
     }
 }

--- a/src/test/java/dev/superice/gdcc/backend/c/build/CProjectBuilderIntegrationTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/build/CProjectBuilderIntegrationTest.java
@@ -45,7 +45,10 @@ public class CProjectBuilderIntegrationTest {
         var builder = new CProjectBuilder();
 
         builder.initProject(projectInfo);
-        assertTrue(Files.exists(tempDir.resolve("include")));
+        var projectIncludeDir = tempDir.resolve("include");
+        var projectParent = tempDir.toAbsolutePath().normalize().getParent();
+        var sharedIncludeDir = projectParent == null ? tempDir.resolveSibling("shared-include") : projectParent.resolve("shared-include");
+        assertTrue(Files.exists(projectIncludeDir) || Files.exists(sharedIncludeDir));
 
         var codegen = new CCodegen();
         var api = ExtensionApiLoader.loadVersion(GodotVersion.V451);

--- a/src/test/java/dev/superice/gdcc/backend/c/build/CProjectBuilderSharedIncludeTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/build/CProjectBuilderSharedIncludeTest.java
@@ -83,6 +83,24 @@ public class CProjectBuilderSharedIncludeTest {
         assertFalse(Files.exists(sharedIncludeDir.resolve("gdcc/gdcc_helper.h")));
     }
 
+    @Test
+    public void fallsBackToProjectLocalIncludeWhenSharedIncludePathIsAFile(@TempDir Path tempDir) throws IOException {
+        var workspaceDir = tempDir.resolve("workspace");
+        var projectDir = workspaceDir.resolve("project-a");
+        var sharedIncludePath = workspaceDir.resolve("shared-include");
+        Files.createDirectories(projectDir);
+        Files.createDirectories(sharedIncludePath.getParent());
+        Files.writeString(sharedIncludePath, "not-a-directory");
+
+        var projectInfo = new CProjectInfo("testproj", GodotVersion.V451, projectDir, COptimizationLevel.DEBUG, TargetPlatform.getNativePlatform());
+        var builder = new CProjectBuilder();
+
+        builder.initProject(projectInfo);
+
+        assertTrue(Files.isRegularFile(projectDir.resolve("include/gdcc/gdcc_helper.h")));
+        assertFalse(Files.exists(sharedIncludePath.resolve("gdcc/gdcc_helper.h")));
+    }
+
     private static @NotNull CCodegen prepareCodegen(@NotNull CProjectInfo projectInfo) throws IOException {
         var codegen = new CCodegen();
         var api = ExtensionApiLoader.loadVersion(GodotVersion.V451);

--- a/src/test/java/dev/superice/gdcc/backend/c/build/CProjectBuilderSharedIncludeTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/build/CProjectBuilderSharedIncludeTest.java
@@ -1,0 +1,116 @@
+package dev.superice.gdcc.backend.c.build;
+
+import dev.superice.gdcc.backend.CodegenContext;
+import dev.superice.gdcc.backend.c.gen.CCodegen;
+import dev.superice.gdcc.enums.GodotVersion;
+import dev.superice.gdcc.gdextension.ExtensionApiLoader;
+import dev.superice.gdcc.lir.LirModule;
+import dev.superice.gdcc.scope.ClassRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CProjectBuilderSharedIncludeTest {
+
+    @Test
+    public void initProjectSyncsSharedIncludeAndSkipsProjectInclude(@TempDir Path tempDir) throws IOException {
+        var workspaceDir = tempDir.resolve("workspace");
+        var projectDir = workspaceDir.resolve("project-a");
+        var sharedIncludeDir = workspaceDir.resolve("shared-include");
+        Files.createDirectories(projectDir);
+        Files.createDirectories(sharedIncludeDir.resolve("gdcc"));
+        Files.writeString(sharedIncludeDir.resolve("gdcc/gdcc_helper.h"), "BROKEN");
+
+        var projectInfo = new CProjectInfo("testproj", GodotVersion.V451, projectDir, COptimizationLevel.DEBUG, TargetPlatform.getNativePlatform());
+        var builder = new CProjectBuilder();
+
+        builder.initProject(projectInfo);
+
+        assertFalse(Files.exists(projectDir.resolve("include")));
+        assertTrue(Files.isRegularFile(sharedIncludeDir.resolve("gdcc/gdcc_bind.h")));
+        assertTrue(Files.isRegularFile(sharedIncludeDir.resolve("gdextension-lite/gdextension-lite-one.c")));
+        assertNotEquals("BROKEN", Files.readString(sharedIncludeDir.resolve("gdcc/gdcc_helper.h")).trim());
+    }
+
+    @Test
+    public void buildProjectUsesSharedIncludePaths(@TempDir Path tempDir) throws IOException {
+        var workspaceDir = tempDir.resolve("workspace");
+        var projectDir = workspaceDir.resolve("project-a");
+        var sharedIncludeDir = workspaceDir.resolve("shared-include");
+        Files.createDirectories(projectDir);
+        Files.createDirectories(sharedIncludeDir);
+
+        var projectInfo = new CProjectInfo("testproj", GodotVersion.V451, projectDir, COptimizationLevel.DEBUG, TargetPlatform.getNativePlatform());
+        var compiler = new CapturingCompiler();
+        var builder = new CProjectBuilder(compiler);
+
+        builder.initProject(projectInfo);
+        var result = builder.buildProject(projectInfo, prepareCodegen(projectInfo));
+
+        var expectedGdcc = sharedIncludeDir.toAbsolutePath().normalize().resolve("gdcc");
+        var expectedGdextensionLite = sharedIncludeDir.toAbsolutePath().normalize().resolve("gdextension-lite");
+
+        assertTrue(result.success());
+        assertEquals(List.of(expectedGdcc, expectedGdextensionLite), compiler.includeDirs());
+        assertTrue(compiler.cFiles().contains(expectedGdextensionLite.resolve("gdextension-lite-one.c")));
+    }
+
+    @Test
+    public void ignoreSharedIncludeForcesProjectLocalInclude(@TempDir Path tempDir) throws IOException {
+        var workspaceDir = tempDir.resolve("workspace");
+        var projectDir = workspaceDir.resolve("project-a");
+        var sharedIncludeDir = workspaceDir.resolve("shared-include");
+        Files.createDirectories(projectDir);
+        Files.createDirectories(sharedIncludeDir);
+
+        var projectInfo = new CProjectInfo("testproj", GodotVersion.V451, projectDir, COptimizationLevel.DEBUG, TargetPlatform.getNativePlatform());
+        var builder = new CProjectBuilder();
+        builder.setIgnoreSharedInclude(true);
+
+        builder.initProject(projectInfo);
+
+        assertTrue(Files.isRegularFile(projectDir.resolve("include/gdcc/gdcc_helper.h")));
+        assertFalse(Files.exists(sharedIncludeDir.resolve("gdcc/gdcc_helper.h")));
+    }
+
+    private static @NotNull CCodegen prepareCodegen(@NotNull CProjectInfo projectInfo) throws IOException {
+        var codegen = new CCodegen();
+        var api = ExtensionApiLoader.loadVersion(GodotVersion.V451);
+        var context = new CodegenContext(projectInfo, new ClassRegistry(api));
+        codegen.prepare(context, new LirModule(projectInfo.projectName(), List.of()));
+        return codegen;
+    }
+
+    private static final class CapturingCompiler implements CCompiler {
+        private List<Path> includeDirs = List.of();
+        private List<Path> cFiles = List.of();
+
+        @Override
+        public CBuildResult compile(@NotNull Path projectDir, @NotNull List<Path> includeDirs, @NotNull List<Path> cFiles, @NotNull String outputBaseName, @NotNull COptimizationLevel optimizationLevel, @NotNull TargetPlatform targetPlatform) throws IOException {
+            this.includeDirs = includeDirs.stream().map(path -> path.toAbsolutePath().normalize()).toList();
+            this.cFiles = cFiles.stream().map(path -> path.toAbsolutePath().normalize()).toList();
+
+            var artifact = projectDir.resolve(targetPlatform.sharedLibraryFileName(outputBaseName));
+            Files.writeString(artifact, "dummy");
+            return new CBuildResult(true, "ok", List.of(artifact));
+        }
+
+        private @NotNull List<Path> includeDirs() {
+            return includeDirs;
+        }
+
+        private @NotNull List<Path> cFiles() {
+            return cFiles;
+        }
+    }
+}

--- a/src/test/java/dev/superice/gdcc/backend/c/build/ZigCcCompilerCachePathTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/build/ZigCcCompilerCachePathTest.java
@@ -1,0 +1,50 @@
+package dev.superice.gdcc.backend.c.build;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ZigCcCompilerCachePathTest {
+
+    @Test
+    public void usesProjectCacheWhenSharedCacheIsMissing(@TempDir Path tempDir) throws IOException {
+        var projectDir = tempDir.resolve("project-a");
+        Files.createDirectories(projectDir);
+
+        var cacheRoot = ZigCcCompiler.resolveCompilerCacheRoot(projectDir);
+
+        assertEquals(projectDir.toAbsolutePath().normalize().resolve("compiler-cache"), cacheRoot);
+    }
+
+    @Test
+    public void usesSharedCacheWhenSharedCacheDirectoryExists(@TempDir Path tempDir) throws IOException {
+        var workspaceDir = tempDir.resolve("workspace");
+        var projectDir = workspaceDir.resolve("project-a");
+        var sharedCacheDir = workspaceDir.resolve("shared-compiler-cache");
+        Files.createDirectories(projectDir);
+        Files.createDirectories(sharedCacheDir);
+
+        var cacheRoot = ZigCcCompiler.resolveCompilerCacheRoot(projectDir);
+
+        assertEquals(sharedCacheDir.toAbsolutePath().normalize(), cacheRoot);
+    }
+
+    @Test
+    public void fallsBackToProjectCacheWhenSharedCachePathIsAFile(@TempDir Path tempDir) throws IOException {
+        var workspaceDir = tempDir.resolve("workspace");
+        var projectDir = workspaceDir.resolve("project-a");
+        var sharedCachePath = workspaceDir.resolve("shared-compiler-cache");
+        Files.createDirectories(projectDir);
+        Files.createDirectories(sharedCachePath.getParent());
+        Files.writeString(sharedCachePath, "not-a-directory");
+
+        var cacheRoot = ZigCcCompiler.resolveCompilerCacheRoot(projectDir);
+
+        assertEquals(projectDir.toAbsolutePath().normalize().resolve("compiler-cache"), cacheRoot);
+    }
+}


### PR DESCRIPTION
## What changed
- Prefer sibling `shared-include` for C backend project initialization and build include paths.
- Always extract `include_451` resources into the resolved include root (shared or project-local).
- Add `ignoreSharedInclude` switch in `CProjectBuilder` to force project-local `include` when needed.
- Prefer sibling `shared-compiler-cache` in `ZigCcCompiler` for `ZIG_CACHE_DIR` and `ZIG_GLOBAL_CACHE_DIR`.
- Add/adjust tests for shared include behavior, ignore-shared fallback, cache path resolution, and integration include assertion.

## Why
- Avoid repeatedly extracting dependency headers/sources per test project.
- Reuse compiler cache across test projects to reduce build time and disk usage.
- Keep a deterministic fallback path when shared include should be ignored.

## Affected packages
- `dev.superice.gdcc.backend.c.build`

## Tests run
- `./gradlew test --tests CProjectBuilderSharedIncludeTest --tests CProjectBuilderPlaceHolderTest --tests ZigCcCompilerCachePathTest --no-daemon --info --console=plain`

## Result snippet
- `BUILD SUCCESSFUL`
- `5 actionable tasks: 3 executed, 2 up-to-date`