### PR TITLE
feat(backend): support packed construct_array and unify extension type parsing

### DIFF
--- a/doc/gdcc_c_backend.md
+++ b/doc/gdcc_c_backend.md
@@ -182,6 +182,16 @@ Transform2D(1, 0, 0, 1, 0, 0), RID(), -99, "000000000000000000000000000000000000
 - For non-object type constructor, generate a c constructor function call, see more details in `gdextension-lite.md`.
 - For `$"..."`, generate NodePath constructor with utf8_chars.
 
+### Extension Type Metadata Parsing Ownership
+
+- `parseExtensionType` is a shared helper capability owned by `CGenHelper`.
+- Resolver/generator code (including `MethodCallResolver`) must reuse `CGenHelper.parseExtensionType(...)` instead of defining local parsing forks.
+- Required normalization behavior remains:
+  - `enum::...` / `bitfield::...` -> `int`
+  - `typedarray::Packed*Array` -> `GdPacked*ArrayType`
+  - non-packed `typedarray::T` -> `GdArrayType(T)`
+  - malformed or unsupported text -> fail fast
+
 ### Validation Logic
 
 - `CBodyBuilder` and `CBuiltinBuilder` is only for generating code, they are NOT responsible for validating IR correctness, so they should assume the IR is already valid and throw `InvalidInsnException` when they encounter invalid IR.

--- a/doc/gdcc_low_ir.md
+++ b/doc/gdcc_low_ir.md
@@ -85,8 +85,17 @@ $<result_id> = construct_builtin $<arg1_id> $<arg2_id> ...
 ```
 
 #### construct_array
-Constructs a new TypedArray of a specific class / type.
-If the class_name is omitted, constructs a generic Array.
+Constructs a new `Array` or `Packed*Array` depending on the result variable type.
+
+Rules:
+- If result variable type is `Array` (`GdArrayType`):
+  - `class_name` is optional.
+  - If omitted, constructs generic `Array[Variant]`.
+  - If provided, it is a typed hint and must match the result variable element type.
+- If result variable type is `Packed*Array` (`GdPackedArrayType`):
+  - Construction type is inferred only from the result variable type.
+  - `class_name` must not be provided; providing it is invalid and should fail fast.
+
 ```
 $<result_id> = construct_array "<class_name>"?
 ```

--- a/doc/gdcc_type_system.md
+++ b/doc/gdcc_type_system.md
@@ -38,6 +38,15 @@
     - `GdMetaType`: holds annotations/metadata to assist code generation and IDE features.
     - `GdExtensionTypeEnum`: enumerated extension options.
 
+## Container Type Boundaries
+
+- `GdArrayType` and `GdPackedArrayType` are different container families:
+  - `GdArrayType` models `Array[T]` with optional element typing metadata.
+  - `GdPackedArrayType` models concrete packed containers (for example `PackedInt32Array`, `PackedVector3Array`), and is not represented as `Array[T]`.
+- For extension metadata normalization in backend type parsing:
+  - `typedarray::Packed*Array` maps to the corresponding `GdPacked*ArrayType`.
+  - non-packed `typedarray::T` maps to `GdArrayType(T)`.
+
 ## Size & Layout
 - `PrimitiveSize.java` provides size references for basic types used by binary serialization, alignment, and packed array optimizations.
 - Packed arrays aim for compact binary layout for memory/disk efficiency.

--- a/doc/module_impl/c_builtin_builder_refactor.md
+++ b/doc/module_impl/c_builtin_builder_refactor.md
@@ -364,3 +364,11 @@ shim 构造函数也应被纳入考虑。
 - `Array[T]([])` 默认值在表达式内完成：
   1) 先以逗号表达式初始化 `godot_new_Array()`
   2) 再调用 `godot_new_Array_with_Array_int_StringName_Variant(...)` 返回 typed array
+
+### 实施补充记录（2026-03-03，construct_array 语义收敛）
+
+- 本轮 `construct_array` 重构不改变 `ConstructBuiltinInsn` 的既有行为与职责边界。
+- `Packed*Array` 的构造策略统一收敛到 `construct_array`：
+  - 仅根据结果变量类型构造。
+  - 出现 `class_name` 操作数时 fail-fast。
+- 扩展类型文本规范化由 `CGenHelper.parseExtensionType(...)` 统一提供，避免 resolver 层重复实现。

--- a/doc/module_impl/call_method_implementation.md
+++ b/doc/module_impl/call_method_implementation.md
@@ -111,8 +111,9 @@
 - 无可用行号时回退 `insnIndex`，并将 `file_name` 标记为 `(assemble)`。
 - `file_name` 必须以 C 字面量传递给 `godot_Variant_call`，不复用对象指针占位类型。
 
-### 6. 类型规范化约束（resolver 内局部实现）
+### 6. 类型规范化约束（CGenHelper 共享实现）
 
+- `MethodCallResolver` 必须复用 `CGenHelper.parseExtensionType(...)`，不再维护私有解析实现。
 - `enum::...` / `bitfield::...` 规范化为 `int`
 - `typedarray::Packed*Array` 规范化为对应 `GdPacked*ArrayType`
 - 非 packed 的 `typedarray::T` 规范化为 `GdArrayType(T)`

--- a/doc/module_impl/construct_array_implementation.md
+++ b/doc/module_impl/construct_array_implementation.md
@@ -2,7 +2,7 @@
 
 ## 文档状态
 
-- 状态：In Progress（阶段 0-1 已完成）
+- 状态：In Progress（阶段 0-4 已完成）
 - 更新时间：2026-03-03
 - 范围：`construct_array` 在 C Backend 的语义、实现与验证
 - 关联模块：Low IR / Type System / backend.c / module_impl
@@ -15,6 +15,16 @@
 - 2026-03-03 阶段 1 完成：
   - 已更新 `gdcc_low_ir.md`、`gdcc_type_system.md`、`gdcc_c_backend.md` 的语义文档。
   - 已同步 module_impl 引用：`c_builtin_builder_refactor.md`、`call_method_implementation.md`。
+- 2026-03-03 阶段 2 完成：
+  - `MethodCallResolver` 已移除私有 `parseExtensionType`，改为复用 `CGenHelper.parseExtensionType(...)`。
+  - 新增 helper 级解析测试并通过：`./gradlew test --tests CGenHelperTest --no-daemon --info --console=plain`。
+  - 回归通过：`./gradlew test --tests CallMethodInsnGenTest --no-daemon --info --console=plain`。
+- 2026-03-03 阶段 3 完成：
+  - `ConstructInsnGen` 的 `construct_array` 已支持 `GdArrayType` + `GdPackedArrayType` 分流。
+  - `GdPackedArrayType` 场景新增 `class_name` 非法校验并 fail-fast。
+- 2026-03-03 阶段 4 完成：
+  - `CCodegen` 两处自动初始化分支已为 `GdPackedArrayType` 注入 `new ConstructArrayInsn(varId, null)`。
+  - 回归通过：`./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain`。
 
 ## 合并后的硬性约束（最终口径）
 
@@ -195,10 +205,10 @@
 
 ## 最终验收清单（逐项打勾）
 
-- [ ] `construct_array` 已支持 `GdPackedArrayType`（仅依赖结果类型）。
-- [ ] `Packed*Array` 场景出现 `class_name` 会 fail-fast。
-- [ ] `ConstructBuiltinInsn` 无行为改动。
-- [ ] `MethodCallResolver#parseExtensionType` 已抽取到 `CGenHelper`。
-- [ ] `CCodegen` 两处自动初始化对 packed 改为注入 `ConstructArrayInsn(..., null)`。
-- [ ] 文档同步完成：`gdcc_low_ir`、`gdcc_type_system`、`gdcc_c_backend`、module_impl。
+- [x] `construct_array` 已支持 `GdPackedArrayType`（仅依赖结果类型）。
+- [x] `Packed*Array` 场景出现 `class_name` 会 fail-fast。
+- [x] `ConstructBuiltinInsn` 无行为改动。
+- [x] `MethodCallResolver#parseExtensionType` 已抽取到 `CGenHelper`。
+- [x] `CCodegen` 两处自动初始化对 packed 改为注入 `ConstructArrayInsn(..., null)`。
+- [x] 文档同步完成：`gdcc_low_ir`、`gdcc_type_system`、`gdcc_c_backend`、module_impl。
 - [ ] 目标测试命令全部通过（或按规则 skip）。

--- a/doc/module_impl/construct_array_implementation.md
+++ b/doc/module_impl/construct_array_implementation.md
@@ -1,0 +1,195 @@
+# construct_array 重构实施方案（Array + Packed*Array）
+
+## 文档状态
+
+- 状态：Planned
+- 更新时间：2026-03-03
+- 范围：`construct_array` 在 C Backend 的语义、实现与验证
+- 关联模块：Low IR / Type System / backend.c / module_impl
+
+## 合并后的硬性约束（最终口径）
+
+- `construct_array` 在构造 `Packed*Array` 时，仅根据结果变量类型构造。
+- 当结果变量类型是 `Packed*Array` 时，`construct_array` 的 `class_name` 操作数不允许出现；出现即视为 IR 错误并 fail-fast。
+- `ConstructBuiltinInsn` 保持现有行为，不做语义或实现改动。
+- `MethodCallResolver#parseExtensionType` 下沉到 `CGenHelper`，由共享 helper 提供扩展类型解析能力。
+
+## 现状与问题
+
+- Low IR 文档把 `construct_array` 描述为“TypedArray/generic Array 构造”，但未明确 `Packed*Array` 路径与 `class_name` 约束。
+- `ConstructInsnGen` 当前 `construct_array` 分支只接受 `GdArrayType` 结果变量，不接受 `GdPackedArrayType`。
+- `CCodegen` 在 `__prepare__` 与默认字段初始化路径中，对 `Packed*Array` 变量走了 `construct_builtin`，未统一到 `construct_array`。
+- `MethodCallResolver` 内部持有 `parseExtensionType` 私有实现，导致扩展类型解析规则分散，和 `CGenHelper` 的职责边界不一致。
+
+## 目标与非目标
+
+### 目标
+
+- 让 `construct_array` 支持 `GdArrayType` 与 `GdPackedArrayType` 两类结果变量。
+- 固化 `Packed*Array` 的无操作数语义：仅由结果类型决定构造目标。
+- 对 `Packed*Array + class_name` 输入进行显式拒绝并给出可定位错误信息。
+- 将扩展类型字符串解析规则收敛到 `CGenHelper`，供 `MethodCallResolver` 复用。
+- 补齐文档、单测、集成测试和验收命令，确保行为可回归。
+
+### 非目标
+
+- 不修改 `GdInstruction.CONSTRUCT_ARRAY` 的 opcode/操作数数量定义。
+- 不修改 `ConstructBuiltinInsn` 的行为与调用路径。
+- 不改变 `construct_dictionary` 现有语义。
+- 不改动 build 脚本或工程配置。
+
+## 统一语义定义（实施后）
+
+- `construct_array` 对 `GdArrayType`：
+  - `class_name` 可选。
+  - 缺省时表示 generic `Array[Variant]`。
+  - 提供时必须与结果变量元素类型一致，否则 fail-fast。
+- `construct_array` 对 `GdPackedArrayType`：
+  - 不接受 `class_name`。
+  - 构造目标完全由结果变量类型决定（如 `PackedInt32Array`、`PackedVector3Array`）。
+  - 若传入 `class_name`（包含空白字符串），直接 fail-fast。
+
+## 需要改动的文档（必须同步）
+
+- `doc/gdcc_low_ir.md`
+  - 更新 `construct_array` 章节：显式区分 `Array` 与 `Packed*Array` 语义。
+  - 新增 `Packed*Array` 示例：`$x = construct_array`（无 `class_name`）。
+  - 新增错误约束说明：`Packed*Array` 场景出现 `class_name` 非法。
+- `doc/gdcc_type_system.md`
+  - 补充 `GdArrayType` 与 `GdPackedArrayType` 的语义边界。
+  - 明确 `typedarray::Packed*Array -> GdPacked*ArrayType`、`typedarray::T -> GdArrayType(T)` 的解析规则。
+- `doc/gdcc_c_backend.md`
+  - 更新 `__prepare__` 与字段默认初始化策略：`Packed*Array` 注入 `construct_array`，不走 `construct_builtin`。
+  - 增加 `construct_array` 对 packed 的 fail-fast 约束（`class_name` 禁止）。
+- `doc/module_impl/c_builtin_builder_refactor.md`
+  - 同步说明：本次不变更 `ConstructBuiltinInsn`，仅调整 `construct_array` 路由与校验。
+- `doc/module_impl/call_method_implementation.md`
+  - 将“扩展类型规范化约束”中的实现归属更新为 `CGenHelper.parseExtensionType(...)`。
+- `doc/module_impl/construct_array_implementation.md`
+  - 保留本文作为实施与验收主文档。
+
+## 需要改动的代码（必须同步）
+
+- `src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java`
+  - `ConstructArrayInsn` 分支从“仅 `GdArrayType`”扩展为“`GdArrayType` 或 `GdPackedArrayType`”。
+  - 对 `GdPackedArrayType` 增加 `class_name` 非法检查。
+  - 对 `GdArrayType` 保持现有 typed hint 校验语义。
+  - 错误信息需包含指令名与冲突原因，便于定位。
+- `src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`
+  - `generateDefaultGetterSetterInitialization()` 中新增 `GdPackedArrayType` 分支，注入 `new ConstructArrayInsn(varId, null)`。
+  - `generateFunctionPrepareBlock()` 中新增 `GdPackedArrayType` 分支，注入 `new ConstructArrayInsn(varId, null)`。
+  - `default -> new ConstructBuiltinInsn(... )` 保持不变，仅覆盖非容器 builtin 路径。
+- `src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java`
+  - 新增共享扩展类型解析方法（建议命名：`parseExtensionType`）。
+  - 规则与现有 resolver 保持一致：
+    - 空/空白 -> `GdVoidType.VOID`
+    - `enum::` / `bitfield::` -> `GdIntType.INT`
+    - `typedarray::Packed*Array` -> 对应 `GdPacked*ArrayType`
+    - `typedarray::T` -> `new GdArrayType(T)`
+    - 无法识别 -> 抛出明确异常
+- `src/main/java/dev/superice/gdcc/backend/c/gen/insn/MethodCallResolver.java`
+  - 删除私有 `parseExtensionType` 实现。
+  - 改为调用 `bodyBuilder.helper().parseExtensionType(...)`（或等效共享 API）。
+  - 保持现有诊断文本与失败策略（fail-fast）语义一致。
+
+## 测试改动清单
+
+- `src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java`
+  - 新增：`construct_array` 构造 `Packed*Array` 成功用例（无 `class_name`）。
+  - 新增：`Packed*Array` 场景传入 `class_name` 报错用例。
+  - 新增：`__prepare__` 注入 `Packed*Array` 时应生成 `ConstructArrayInsn(..., null)` 的断言。
+  - 新增：`generateFuncBody` 输出 packed 构造调用的断言（如 `godot_new_PackedInt32Array()`）。
+- `src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java`
+  - 新增显式 packed 构造函数（手写 `ConstructArrayInsn(var, null)`）。
+  - 新增 prepare packed 构造函数（依赖自动注入）。
+  - 测试脚本新增 packed 类型断言（`typeof` / 容器属性检查）。
+- `src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenTest.java`
+  - 回归验证 `typedarray::Packed*Array` 与 `typedarray::T` 解析语义未回退。
+- `src/test/java/dev/superice/gdcc/backend/c/gen/CGenHelperUtilityResolutionTest.java`
+  - 新增/迁移 `parseExtensionType` 的正反向测试，覆盖 malformed/unsupported 输入。
+
+## 分阶段执行与验收计划
+
+### 阶段 0：基线冻结
+
+- 执行：记录当前 HEAD 与目标测试基线，确认工作区无脏改动。
+- 验收：
+  - `git status --short` 为空或仅存在本任务文档改动。
+  - `CConstructInsnGenTest` 基线通过。
+
+### 阶段 1：规范文档先行
+
+- 执行：先更新 `gdcc_low_ir.md`、`gdcc_type_system.md`、`gdcc_c_backend.md` 的语义文本，再更新 module_impl 文档引用。
+- 验收：
+  - 文档明确写出 `Packed*Array` 禁止 `class_name`。
+  - 文档明确 `ConstructBuiltinInsn` 非本次改动对象。
+  - 文档明确 `parseExtensionType` 归属 `CGenHelper`。
+
+### 阶段 2：共享类型解析抽取（MethodCallResolver -> CGenHelper）
+
+- 执行：在 `CGenHelper` 增加解析 API，替换 `MethodCallResolver` 私有实现与调用点。
+- 验收：
+  - `MethodCallResolver` 不再定义 `parseExtensionType` 私有方法。
+  - `CallMethodInsnGenTest` 通过，`typedarray::Packed*Array` 解析结果不变。
+  - 新增 helper 级测试覆盖 malformed 与 unsupported 分支。
+
+### 阶段 3：construct_array 支持 Packed*Array
+
+- 执行：修改 `ConstructInsnGen`，按结果类型分流 `GdArrayType` 与 `GdPackedArrayType`。
+- 验收：
+  - `GdPackedArrayType + class_name == null` 成功生成 packed 构造调用。
+  - `GdPackedArrayType + class_name != null` 抛 `InvalidInsnException`。
+  - 原有 `GdArrayType` typed hint 校验行为不变。
+
+### 阶段 4：自动注入路径切换到 construct_array
+
+- 执行：修改 `CCodegen` 两处初始化 switch，将 `GdPackedArrayType` 显式分支改为 `ConstructArrayInsn(..., null)`。
+- 验收：
+  - `__prepare__` 中 packed 变量注入 `ConstructArrayInsn` 而非 `ConstructBuiltinInsn`。
+  - 字段默认初始化函数对 packed 返回值同样注入 `ConstructArrayInsn(..., null)`。
+  - 相关用例生成 C 文本包含 `godot_new_Packed*Array()`。
+
+### 阶段 5：测试补齐与引擎回归
+
+- 执行：补单测与引擎集成测试，覆盖 explicit/prepare 两条 packed 路径。
+- 验收：
+  - `CConstructInsnGenTest` 全绿，包含新增失败路径断言。
+  - `CConstructInsnGenEngineTest` 在 Zig 可用时通过；Zig 不可用时按现有策略 skip。
+
+### 阶段 6：整体验收与收口
+
+- 执行：跑目标回归命令并整理结果，更新本文档状态与风险结论。
+- 验收命令：
+
+```bash
+./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain
+./gradlew test --tests CConstructInsnGenEngineTest --no-daemon --info --console=plain
+./gradlew test --tests CallMethodInsnGenTest --no-daemon --info --console=plain
+./gradlew test --tests CPhaseAControlFlowAndFinallyTest --no-daemon --info --console=plain
+./gradlew test --tests CGenHelperUtilityResolutionTest --no-daemon --info --console=plain
+./gradlew classes --no-daemon --info --console=plain
+```
+
+- 收口标准：
+  - 文档、实现、测试三者口径一致。
+  - `construct_array` 对 packed 的限制与行为可由测试稳定证明。
+  - 无对 `ConstructBuiltinInsn` 的行为回归。
+
+## 风险与防线
+
+- 风险：已有 IR 可能向 packed `construct_array` 传入 `class_name`，改造后会 fail-fast。
+  - 防线：明确错误文案，尽早暴露上游生成问题。
+- 风险：`parseExtensionType` 抽取后出现行为漂移。
+  - 防线：在 helper 级与 call-method 级同时加测试，覆盖 typedarray/enum/bitfield/非法输入。
+- 风险：自动注入路径切换影响 `__prepare__` 既有顺序。
+  - 防线：保持仅分支替换，不改变注入顺序与 `appendInsnIfAbsent` 语义。
+
+## 最终验收清单（逐项打勾）
+
+- [ ] `construct_array` 已支持 `GdPackedArrayType`（仅依赖结果类型）。
+- [ ] `Packed*Array` 场景出现 `class_name` 会 fail-fast。
+- [ ] `ConstructBuiltinInsn` 无行为改动。
+- [ ] `MethodCallResolver#parseExtensionType` 已抽取到 `CGenHelper`。
+- [ ] `CCodegen` 两处自动初始化对 packed 改为注入 `ConstructArrayInsn(..., null)`。
+- [ ] 文档同步完成：`gdcc_low_ir`、`gdcc_type_system`、`gdcc_c_backend`、module_impl。
+- [ ] 目标测试命令全部通过（或按规则 skip）。

--- a/doc/module_impl/construct_array_implementation.md
+++ b/doc/module_impl/construct_array_implementation.md
@@ -2,7 +2,7 @@
 
 ## 文档状态
 
-- 状态：In Progress（阶段 0-4 已完成）
+- 状态：Completed（阶段 0-6 已完成）
 - 更新时间：2026-03-03
 - 范围：`construct_array` 在 C Backend 的语义、实现与验证
 - 关联模块：Low IR / Type System / backend.c / module_impl
@@ -25,6 +25,17 @@
 - 2026-03-03 阶段 4 完成：
   - `CCodegen` 两处自动初始化分支已为 `GdPackedArrayType` 注入 `new ConstructArrayInsn(varId, null)`。
   - 回归通过：`./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain`。
+- 2026-03-03 阶段 5 完成：
+  - 新增额外引擎集成测试：`constructPackedArrayInsnsShouldRunInRealGodot`（覆盖 `PackedInt32Array` 的 explicit/prepare 两条路径）。
+  - 回归通过：`./gradlew test --tests CConstructInsnGenEngineTest --no-daemon --info --console=plain`。
+- 2026-03-03 阶段 6 完成：
+  - 回归通过：`./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain`。
+  - 回归通过：`./gradlew test --tests CConstructInsnGenEngineTest --no-daemon --info --console=plain`。
+  - 回归通过：`./gradlew test --tests CallMethodInsnGenTest --no-daemon --info --console=plain`。
+  - 回归通过：`./gradlew test --tests CPhaseAControlFlowAndFinallyTest --no-daemon --info --console=plain`。
+  - 计划命令 `CGenHelperUtilityResolutionTest` 无匹配测试类（`No tests found for given includes`），已以现有测试类 `CGenHelperTest` 完成等价回归：
+    `./gradlew test --tests CGenHelperTest --no-daemon --info --console=plain`。
+  - 回归通过：`./gradlew classes --no-daemon --info --console=plain`。
 
 ## 合并后的硬性约束（最终口径）
 
@@ -122,9 +133,10 @@
   - 新增显式 packed 构造函数（手写 `ConstructArrayInsn(var, null)`）。
   - 新增 prepare packed 构造函数（依赖自动注入）。
   - 测试脚本新增 packed 类型断言（`typeof` / 容器属性检查）。
+  - 新增独立引擎集成测试 `constructPackedArrayInsnsShouldRunInRealGodot`，专项验证 `PackedInt32Array` 的 explicit/prepare 路径。
 - `src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenTest.java`
   - 回归验证 `typedarray::Packed*Array` 与 `typedarray::T` 解析语义未回退。
-- `src/test/java/dev/superice/gdcc/backend/c/gen/CGenHelperUtilityResolutionTest.java`
+- `src/test/java/dev/superice/gdcc/backend/c/gen/CGenHelperTest.java`
   - 新增/迁移 `parseExtensionType` 的正反向测试，覆盖 malformed/unsupported 输入。
 
 ## 分阶段执行与验收计划
@@ -185,7 +197,7 @@
 ./gradlew test --tests CConstructInsnGenEngineTest --no-daemon --info --console=plain
 ./gradlew test --tests CallMethodInsnGenTest --no-daemon --info --console=plain
 ./gradlew test --tests CPhaseAControlFlowAndFinallyTest --no-daemon --info --console=plain
-./gradlew test --tests CGenHelperUtilityResolutionTest --no-daemon --info --console=plain
+./gradlew test --tests CGenHelperTest --no-daemon --info --console=plain
 ./gradlew classes --no-daemon --info --console=plain
 ```
 
@@ -211,4 +223,4 @@
 - [x] `MethodCallResolver#parseExtensionType` 已抽取到 `CGenHelper`。
 - [x] `CCodegen` 两处自动初始化对 packed 改为注入 `ConstructArrayInsn(..., null)`。
 - [x] 文档同步完成：`gdcc_low_ir`、`gdcc_type_system`、`gdcc_c_backend`、module_impl。
-- [ ] 目标测试命令全部通过（或按规则 skip）。
+- [x] 目标测试命令全部通过（或按规则 skip）。

--- a/doc/module_impl/construct_array_implementation.md
+++ b/doc/module_impl/construct_array_implementation.md
@@ -79,6 +79,20 @@
   - 构造目标完全由结果变量类型决定（如 `PackedInt32Array`、`PackedVector3Array`）。
   - 若传入 `class_name`（包含空白字符串），直接 fail-fast。
 
+## 下游代码路由说明（显式记录）
+
+- `ConstructInsnGen` 的 `construct_array` 分支中：
+  - `GdArrayType` 与 `GdPackedArrayType` 都会在完成指令级校验后调用 `builtinBuilder.constructBuiltin(bodyBuilder, target, List.of())`。
+- `CBuiltinBuilder.constructBuiltin(...)` 的实际分发为：
+  - `GdArrayType` -> `constructArray(...)`（容器专用 typed 路径）
+  - `GdDictionaryType` -> `constructDictionary(...)`（容器专用 typed 路径）
+  - 其他类型（包含 `GdPackedArrayType`）-> `constructRegularBuiltin(...)`（通用 builtin 路径）
+- 因此，`Packed*Array` 与 `Array/Dictionary` 存在“路由不对称”是当前设计中的显式事实，不是遗漏：
+  - `Packed*Array` 的构造函数解析依赖 `ExtensionBuiltinClass` 元数据中的构造签名（当前为零参构造）。
+  - 当元数据缺失或签名不匹配时，按既有策略 fail-fast，抛出 builtin constructor validation 错误。
+- 维护约束：
+  - 若后续为 `Packed*Array` 增加专用构造路径（类似 `constructArray`），必须同步更新本文档“语义定义/路由说明/风险与防线/验收清单”四处内容，并补充回归测试。
+
 ## 需要改动的文档（必须同步）
 
 - `doc/gdcc_low_ir.md`
@@ -109,6 +123,9 @@
   - `generateDefaultGetterSetterInitialization()` 中新增 `GdPackedArrayType` 分支，注入 `new ConstructArrayInsn(varId, null)`。
   - `generateFunctionPrepareBlock()` 中新增 `GdPackedArrayType` 分支，注入 `new ConstructArrayInsn(varId, null)`。
   - `default -> new ConstructBuiltinInsn(... )` 保持不变，仅覆盖非容器 builtin 路径。
+- `src/main/java/dev/superice/gdcc/backend/c/gen/CBuiltinBuilder.java`
+  - 记录并确认当前路由：`GdPackedArrayType` 通过 `constructBuiltin(...)` 的 `default` 分支进入 `constructRegularBuiltin(...)`，不走 `constructArray(...)` 容器专用分支。
+  - 本次不改变该路由行为，仅将其文档化并纳入验收约束。
 - `src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java`
   - 新增共享扩展类型解析方法（建议命名：`parseExtensionType`）。
   - 规则与现有 resolver 保持一致：
@@ -214,6 +231,8 @@
   - 防线：在 helper 级与 call-method 级同时加测试，覆盖 typedarray/enum/bitfield/非法输入。
 - 风险：自动注入路径切换影响 `__prepare__` 既有顺序。
   - 防线：保持仅分支替换，不改变注入顺序与 `appendInsnIfAbsent` 语义。
+- 风险：`Packed*Array` 依赖 `constructRegularBuiltin` 的元数据校验路径，若 API 元数据构造签名缺失/变更会导致构造失败。
+  - 防线：保留 fail-fast 文案并通过引擎集成测试覆盖 explicit/prepare 路径；升级 Godot API 版本时优先执行该测试集。
 
 ## 最终验收清单（逐项打勾）
 
@@ -223,4 +242,5 @@
 - [x] `MethodCallResolver#parseExtensionType` 已抽取到 `CGenHelper`。
 - [x] `CCodegen` 两处自动初始化对 packed 改为注入 `ConstructArrayInsn(..., null)`。
 - [x] 文档同步完成：`gdcc_low_ir`、`gdcc_type_system`、`gdcc_c_backend`、module_impl。
+- [x] 已在实施文档显式记录 `Packed*Array` 的 `CBuiltinBuilder` 路由不对称性（`constructRegularBuiltin` 路径）与维护约束。
 - [x] 目标测试命令全部通过（或按规则 skip）。

--- a/doc/module_impl/construct_array_implementation.md
+++ b/doc/module_impl/construct_array_implementation.md
@@ -2,10 +2,19 @@
 
 ## 文档状态
 
-- 状态：Planned
+- 状态：In Progress（阶段 0-1 已完成）
 - 更新时间：2026-03-03
 - 范围：`construct_array` 在 C Backend 的语义、实现与验证
 - 关联模块：Low IR / Type System / backend.c / module_impl
+
+## 执行记录
+
+- 2026-03-03 阶段 0 完成：
+  - 基线 `HEAD`：`f2f4103aa2baa709701f776272e585432a1b89cc`
+  - 基线测试：`./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain` 通过。
+- 2026-03-03 阶段 1 完成：
+  - 已更新 `gdcc_low_ir.md`、`gdcc_type_system.md`、`gdcc_c_backend.md` 的语义文档。
+  - 已同步 module_impl 引用：`c_builtin_builder_refactor.md`、`call_method_implementation.md`。
 
 ## 合并后的硬性约束（最终口径）
 

--- a/doc/module_impl/construct_array_implementation.md
+++ b/doc/module_impl/construct_array_implementation.md
@@ -1,74 +1,31 @@
-# construct_array 重构实施方案（Array + Packed*Array）
+# construct_array 实现说明（Array + Packed*Array）
+
+> 本文档作为 `construct_array` 在 C Backend 的长期维护说明。
+> 只保留已完成实现、当前状态和后续工程仍有价值的约定与反思。
 
 ## 文档状态
 
-- 状态：Completed（阶段 0-6 已完成）
+- 状态：Implemented / Maintained
+- 范围：`construct_array` 在 C Backend 的语义、路由与校验
 - 更新时间：2026-03-03
-- 范围：`construct_array` 在 C Backend 的语义、实现与验证
-- 关联模块：Low IR / Type System / backend.c / module_impl
+- 关联基线：
+  - `doc/gdcc_low_ir.md`
+  - `doc/gdcc_type_system.md`
+  - `doc/gdcc_c_backend.md`
+  - `doc/module_impl/c_builtin_builder_refactor.md`
+  - `doc/module_impl/call_method_implementation.md`
 
-## 执行记录
+## 当前最终状态（与代码对齐）
 
-- 2026-03-03 阶段 0 完成：
-  - 基线 `HEAD`：`f2f4103aa2baa709701f776272e585432a1b89cc`
-  - 基线测试：`./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain` 通过。
-- 2026-03-03 阶段 1 完成：
-  - 已更新 `gdcc_low_ir.md`、`gdcc_type_system.md`、`gdcc_c_backend.md` 的语义文档。
-  - 已同步 module_impl 引用：`c_builtin_builder_refactor.md`、`call_method_implementation.md`。
-- 2026-03-03 阶段 2 完成：
-  - `MethodCallResolver` 已移除私有 `parseExtensionType`，改为复用 `CGenHelper.parseExtensionType(...)`。
-  - 新增 helper 级解析测试并通过：`./gradlew test --tests CGenHelperTest --no-daemon --info --console=plain`。
-  - 回归通过：`./gradlew test --tests CallMethodInsnGenTest --no-daemon --info --console=plain`。
-- 2026-03-03 阶段 3 完成：
-  - `ConstructInsnGen` 的 `construct_array` 已支持 `GdArrayType` + `GdPackedArrayType` 分流。
-  - `GdPackedArrayType` 场景新增 `class_name` 非法校验并 fail-fast。
-- 2026-03-03 阶段 4 完成：
-  - `CCodegen` 两处自动初始化分支已为 `GdPackedArrayType` 注入 `new ConstructArrayInsn(varId, null)`。
-  - 回归通过：`./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain`。
-- 2026-03-03 阶段 5 完成：
-  - 新增额外引擎集成测试：`constructPackedArrayInsnsShouldRunInRealGodot`（覆盖 `PackedInt32Array` 的 explicit/prepare 两条路径）。
-  - 回归通过：`./gradlew test --tests CConstructInsnGenEngineTest --no-daemon --info --console=plain`。
-- 2026-03-03 阶段 6 完成：
-  - 回归通过：`./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain`。
-  - 回归通过：`./gradlew test --tests CConstructInsnGenEngineTest --no-daemon --info --console=plain`。
-  - 回归通过：`./gradlew test --tests CallMethodInsnGenTest --no-daemon --info --console=plain`。
-  - 回归通过：`./gradlew test --tests CPhaseAControlFlowAndFinallyTest --no-daemon --info --console=plain`。
-  - 计划命令 `CGenHelperUtilityResolutionTest` 无匹配测试类（`No tests found for given includes`），已以现有测试类 `CGenHelperTest` 完成等价回归：
-    `./gradlew test --tests CGenHelperTest --no-daemon --info --console=plain`。
-  - 回归通过：`./gradlew classes --no-daemon --info --console=plain`。
+### 覆盖范围
 
-## 合并后的硬性约束（最终口径）
+- 指令生成入口：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java`
+- Builtin 构造分发：`src/main/java/dev/superice/gdcc/backend/c/gen/CBuiltinBuilder.java`
+- 自动注入路径：`src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`
+- 共享类型解析：`src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java`
+- LIR 指令定义：`src/main/java/dev/superice/gdcc/lir/insn/ConstructArrayInsn.java`
 
-- `construct_array` 在构造 `Packed*Array` 时，仅根据结果变量类型构造。
-- 当结果变量类型是 `Packed*Array` 时，`construct_array` 的 `class_name` 操作数不允许出现；出现即视为 IR 错误并 fail-fast。
-- `ConstructBuiltinInsn` 保持现有行为，不做语义或实现改动。
-- `MethodCallResolver#parseExtensionType` 下沉到 `CGenHelper`，由共享 helper 提供扩展类型解析能力。
-
-## 现状与问题
-
-- Low IR 文档把 `construct_array` 描述为“TypedArray/generic Array 构造”，但未明确 `Packed*Array` 路径与 `class_name` 约束。
-- `ConstructInsnGen` 当前 `construct_array` 分支只接受 `GdArrayType` 结果变量，不接受 `GdPackedArrayType`。
-- `CCodegen` 在 `__prepare__` 与默认字段初始化路径中，对 `Packed*Array` 变量走了 `construct_builtin`，未统一到 `construct_array`。
-- `MethodCallResolver` 内部持有 `parseExtensionType` 私有实现，导致扩展类型解析规则分散，和 `CGenHelper` 的职责边界不一致。
-
-## 目标与非目标
-
-### 目标
-
-- 让 `construct_array` 支持 `GdArrayType` 与 `GdPackedArrayType` 两类结果变量。
-- 固化 `Packed*Array` 的无操作数语义：仅由结果类型决定构造目标。
-- 对 `Packed*Array + class_name` 输入进行显式拒绝并给出可定位错误信息。
-- 将扩展类型字符串解析规则收敛到 `CGenHelper`，供 `MethodCallResolver` 复用。
-- 补齐文档、单测、集成测试和验收命令，确保行为可回归。
-
-### 非目标
-
-- 不修改 `GdInstruction.CONSTRUCT_ARRAY` 的 opcode/操作数数量定义。
-- 不修改 `ConstructBuiltinInsn` 的行为与调用路径。
-- 不改变 `construct_dictionary` 现有语义。
-- 不改动 build 脚本或工程配置。
-
-## 统一语义定义（实施后）
+### 已实现语义
 
 - `construct_array` 对 `GdArrayType`：
   - `class_name` 可选。
@@ -79,7 +36,31 @@
   - 构造目标完全由结果变量类型决定（如 `PackedInt32Array`、`PackedVector3Array`）。
   - 若传入 `class_name`（包含空白字符串），直接 fail-fast。
 
-## 下游代码路由说明（显式记录）
+### 已实现自动注入路径
+
+- `CCodegen.generateFunctionPrepareBlock()`：`GdPackedArrayType` 变量注入 `new ConstructArrayInsn(varId, null)`。
+- `CCodegen.generateDefaultGetterSetterInitialization()`：`GdPackedArrayType` 变量注入 `new ConstructArrayInsn(varId, null)`。
+- `default -> new ConstructBuiltinInsn(...)` 保持不变，仅覆盖非容器 builtin 路径。
+
+### 已实现共享类型解析
+
+- `MethodCallResolver#parseExtensionType` 已下沉到 `CGenHelper.parseExtensionType(...)`。
+- 解析规则：
+  - 空/空白 -> `GdVoidType.VOID`
+  - `enum::` / `bitfield::` -> `GdIntType.INT`
+  - `typedarray::Packed*Array` -> 对应 `GdPacked*ArrayType`
+  - `typedarray::T` -> `new GdArrayType(T)`
+  - 无法识别 -> 抛出明确异常
+
+## 长期约定（必须保持）
+
+### 1. Packed*Array 构造约束
+
+- `construct_array` 在构造 `Packed*Array` 时，仅根据结果变量类型构造。
+- 当结果变量类型是 `Packed*Array` 时，`class_name` 操作数不允许出现；出现即视为 IR 错误并 fail-fast。
+- `ConstructBuiltinInsn` 保持现有行为，不做语义或实现改动。
+
+### 2. 下游代码路由
 
 - `ConstructInsnGen` 的 `construct_array` 分支中：
   - `GdArrayType` 与 `GdPackedArrayType` 都会在完成指令级校验后调用 `builtinBuilder.constructBuiltin(bodyBuilder, target, List.of())`。
@@ -87,141 +68,14 @@
   - `GdArrayType` -> `constructArray(...)`（容器专用 typed 路径）
   - `GdDictionaryType` -> `constructDictionary(...)`（容器专用 typed 路径）
   - 其他类型（包含 `GdPackedArrayType`）-> `constructRegularBuiltin(...)`（通用 builtin 路径）
-- 因此，`Packed*Array` 与 `Array/Dictionary` 存在“路由不对称”是当前设计中的显式事实，不是遗漏：
+- `Packed*Array` 与 `Array/Dictionary` 存在"路由不对称"是当前设计中的显式事实，不是遗漏：
   - `Packed*Array` 的构造函数解析依赖 `ExtensionBuiltinClass` 元数据中的构造签名（当前为零参构造）。
   - 当元数据缺失或签名不匹配时，按既有策略 fail-fast，抛出 builtin constructor validation 错误。
-- 维护约束：
-  - 若后续为 `Packed*Array` 增加专用构造路径（类似 `constructArray`），必须同步更新本文档“语义定义/路由说明/风险与防线/验收清单”四处内容，并补充回归测试。
 
-## 需要改动的文档（必须同步）
+### 3. 维护约束
 
-- `doc/gdcc_low_ir.md`
-  - 更新 `construct_array` 章节：显式区分 `Array` 与 `Packed*Array` 语义。
-  - 新增 `Packed*Array` 示例：`$x = construct_array`（无 `class_name`）。
-  - 新增错误约束说明：`Packed*Array` 场景出现 `class_name` 非法。
-- `doc/gdcc_type_system.md`
-  - 补充 `GdArrayType` 与 `GdPackedArrayType` 的语义边界。
-  - 明确 `typedarray::Packed*Array -> GdPacked*ArrayType`、`typedarray::T -> GdArrayType(T)` 的解析规则。
-- `doc/gdcc_c_backend.md`
-  - 更新 `__prepare__` 与字段默认初始化策略：`Packed*Array` 注入 `construct_array`，不走 `construct_builtin`。
-  - 增加 `construct_array` 对 packed 的 fail-fast 约束（`class_name` 禁止）。
-- `doc/module_impl/c_builtin_builder_refactor.md`
-  - 同步说明：本次不变更 `ConstructBuiltinInsn`，仅调整 `construct_array` 路由与校验。
-- `doc/module_impl/call_method_implementation.md`
-  - 将“扩展类型规范化约束”中的实现归属更新为 `CGenHelper.parseExtensionType(...)`。
-- `doc/module_impl/construct_array_implementation.md`
-  - 保留本文作为实施与验收主文档。
-
-## 需要改动的代码（必须同步）
-
-- `src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java`
-  - `ConstructArrayInsn` 分支从“仅 `GdArrayType`”扩展为“`GdArrayType` 或 `GdPackedArrayType`”。
-  - 对 `GdPackedArrayType` 增加 `class_name` 非法检查。
-  - 对 `GdArrayType` 保持现有 typed hint 校验语义。
-  - 错误信息需包含指令名与冲突原因，便于定位。
-- `src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`
-  - `generateDefaultGetterSetterInitialization()` 中新增 `GdPackedArrayType` 分支，注入 `new ConstructArrayInsn(varId, null)`。
-  - `generateFunctionPrepareBlock()` 中新增 `GdPackedArrayType` 分支，注入 `new ConstructArrayInsn(varId, null)`。
-  - `default -> new ConstructBuiltinInsn(... )` 保持不变，仅覆盖非容器 builtin 路径。
-- `src/main/java/dev/superice/gdcc/backend/c/gen/CBuiltinBuilder.java`
-  - 记录并确认当前路由：`GdPackedArrayType` 通过 `constructBuiltin(...)` 的 `default` 分支进入 `constructRegularBuiltin(...)`，不走 `constructArray(...)` 容器专用分支。
-  - 本次不改变该路由行为，仅将其文档化并纳入验收约束。
-- `src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java`
-  - 新增共享扩展类型解析方法（建议命名：`parseExtensionType`）。
-  - 规则与现有 resolver 保持一致：
-    - 空/空白 -> `GdVoidType.VOID`
-    - `enum::` / `bitfield::` -> `GdIntType.INT`
-    - `typedarray::Packed*Array` -> 对应 `GdPacked*ArrayType`
-    - `typedarray::T` -> `new GdArrayType(T)`
-    - 无法识别 -> 抛出明确异常
-- `src/main/java/dev/superice/gdcc/backend/c/gen/insn/MethodCallResolver.java`
-  - 删除私有 `parseExtensionType` 实现。
-  - 改为调用 `bodyBuilder.helper().parseExtensionType(...)`（或等效共享 API）。
-  - 保持现有诊断文本与失败策略（fail-fast）语义一致。
-
-## 测试改动清单
-
-- `src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java`
-  - 新增：`construct_array` 构造 `Packed*Array` 成功用例（无 `class_name`）。
-  - 新增：`Packed*Array` 场景传入 `class_name` 报错用例。
-  - 新增：`__prepare__` 注入 `Packed*Array` 时应生成 `ConstructArrayInsn(..., null)` 的断言。
-  - 新增：`generateFuncBody` 输出 packed 构造调用的断言（如 `godot_new_PackedInt32Array()`）。
-- `src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java`
-  - 新增显式 packed 构造函数（手写 `ConstructArrayInsn(var, null)`）。
-  - 新增 prepare packed 构造函数（依赖自动注入）。
-  - 测试脚本新增 packed 类型断言（`typeof` / 容器属性检查）。
-  - 新增独立引擎集成测试 `constructPackedArrayInsnsShouldRunInRealGodot`，专项验证 `PackedInt32Array` 的 explicit/prepare 路径。
-- `src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenTest.java`
-  - 回归验证 `typedarray::Packed*Array` 与 `typedarray::T` 解析语义未回退。
-- `src/test/java/dev/superice/gdcc/backend/c/gen/CGenHelperTest.java`
-  - 新增/迁移 `parseExtensionType` 的正反向测试，覆盖 malformed/unsupported 输入。
-
-## 分阶段执行与验收计划
-
-### 阶段 0：基线冻结
-
-- 执行：记录当前 HEAD 与目标测试基线，确认工作区无脏改动。
-- 验收：
-  - `git status --short` 为空或仅存在本任务文档改动。
-  - `CConstructInsnGenTest` 基线通过。
-
-### 阶段 1：规范文档先行
-
-- 执行：先更新 `gdcc_low_ir.md`、`gdcc_type_system.md`、`gdcc_c_backend.md` 的语义文本，再更新 module_impl 文档引用。
-- 验收：
-  - 文档明确写出 `Packed*Array` 禁止 `class_name`。
-  - 文档明确 `ConstructBuiltinInsn` 非本次改动对象。
-  - 文档明确 `parseExtensionType` 归属 `CGenHelper`。
-
-### 阶段 2：共享类型解析抽取（MethodCallResolver -> CGenHelper）
-
-- 执行：在 `CGenHelper` 增加解析 API，替换 `MethodCallResolver` 私有实现与调用点。
-- 验收：
-  - `MethodCallResolver` 不再定义 `parseExtensionType` 私有方法。
-  - `CallMethodInsnGenTest` 通过，`typedarray::Packed*Array` 解析结果不变。
-  - 新增 helper 级测试覆盖 malformed 与 unsupported 分支。
-
-### 阶段 3：construct_array 支持 Packed*Array
-
-- 执行：修改 `ConstructInsnGen`，按结果类型分流 `GdArrayType` 与 `GdPackedArrayType`。
-- 验收：
-  - `GdPackedArrayType + class_name == null` 成功生成 packed 构造调用。
-  - `GdPackedArrayType + class_name != null` 抛 `InvalidInsnException`。
-  - 原有 `GdArrayType` typed hint 校验行为不变。
-
-### 阶段 4：自动注入路径切换到 construct_array
-
-- 执行：修改 `CCodegen` 两处初始化 switch，将 `GdPackedArrayType` 显式分支改为 `ConstructArrayInsn(..., null)`。
-- 验收：
-  - `__prepare__` 中 packed 变量注入 `ConstructArrayInsn` 而非 `ConstructBuiltinInsn`。
-  - 字段默认初始化函数对 packed 返回值同样注入 `ConstructArrayInsn(..., null)`。
-  - 相关用例生成 C 文本包含 `godot_new_Packed*Array()`。
-
-### 阶段 5：测试补齐与引擎回归
-
-- 执行：补单测与引擎集成测试，覆盖 explicit/prepare 两条 packed 路径。
-- 验收：
-  - `CConstructInsnGenTest` 全绿，包含新增失败路径断言。
-  - `CConstructInsnGenEngineTest` 在 Zig 可用时通过；Zig 不可用时按现有策略 skip。
-
-### 阶段 6：整体验收与收口
-
-- 执行：跑目标回归命令并整理结果，更新本文档状态与风险结论。
-- 验收命令：
-
-```bash
-./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain
-./gradlew test --tests CConstructInsnGenEngineTest --no-daemon --info --console=plain
-./gradlew test --tests CallMethodInsnGenTest --no-daemon --info --console=plain
-./gradlew test --tests CPhaseAControlFlowAndFinallyTest --no-daemon --info --console=plain
-./gradlew test --tests CGenHelperTest --no-daemon --info --console=plain
-./gradlew classes --no-daemon --info --console=plain
-```
-
-- 收口标准：
-  - 文档、实现、测试三者口径一致。
-  - `construct_array` 对 packed 的限制与行为可由测试稳定证明。
-  - 无对 `ConstructBuiltinInsn` 的行为回归。
+- 若后续为 `Packed*Array` 增加专用构造路径（类似 `constructArray`），必须同步更新本文档"语义定义 / 路由说明 / 风险与防线 / 回归测试基线"四处内容，并补充回归测试。
+- `MethodCallResolver` 必须复用 `CGenHelper.parseExtensionType(...)`，不再维护私有解析实现。
 
 ## 风险与防线
 
@@ -234,13 +88,41 @@
 - 风险：`Packed*Array` 依赖 `constructRegularBuiltin` 的元数据校验路径，若 API 元数据构造签名缺失/变更会导致构造失败。
   - 防线：保留 fail-fast 文案并通过引擎集成测试覆盖 explicit/prepare 路径；升级 Godot API 版本时优先执行该测试集。
 
-## 最终验收清单（逐项打勾）
+## 回归测试基线
 
-- [x] `construct_array` 已支持 `GdPackedArrayType`（仅依赖结果类型）。
-- [x] `Packed*Array` 场景出现 `class_name` 会 fail-fast。
-- [x] `ConstructBuiltinInsn` 无行为改动。
-- [x] `MethodCallResolver#parseExtensionType` 已抽取到 `CGenHelper`。
-- [x] `CCodegen` 两处自动初始化对 packed 改为注入 `ConstructArrayInsn(..., null)`。
-- [x] 文档同步完成：`gdcc_low_ir`、`gdcc_type_system`、`gdcc_c_backend`、module_impl。
-- [x] 已在实施文档显式记录 `Packed*Array` 的 `CBuiltinBuilder` 路由不对称性（`constructRegularBuiltin` 路径）与维护约束。
-- [x] 目标测试命令全部通过（或按规则 skip）。
+- `src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java`
+  - `construct_array` 构造 `Packed*Array` 成功用例（无 `class_name`）
+  - `Packed*Array` 场景传入 `class_name` 报错用例
+  - `__prepare__` 注入 `Packed*Array` 时生成 `ConstructArrayInsn(..., null)` 的断言
+  - `generateFuncBody` 输出 packed 构造调用的断言（如 `godot_new_PackedInt32Array()`）
+- `src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java`
+  - 显式 packed 构造函数与 prepare packed 构造函数的引擎集成测试
+  - 覆盖 `PackedInt32Array` 等类型的 explicit/prepare 路径
+- `src/test/java/dev/superice/gdcc/backend/c/gen/CallMethodInsnGenTest.java`
+  - `typedarray::Packed*Array` 与 `typedarray::T` 解析语义回归
+- `src/test/java/dev/superice/gdcc/backend/c/gen/CGenHelperTest.java`
+  - `parseExtensionType` 正反向测试，覆盖 malformed/unsupported 输入
+
+建议命令：
+
+```bash
+./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain
+./gradlew test --tests CConstructInsnGenEngineTest --no-daemon --info --console=plain
+./gradlew test --tests CallMethodInsnGenTest --no-daemon --info --console=plain
+./gradlew test --tests CGenHelperTest --no-daemon --info --console=plain
+./gradlew test --tests CPhaseAControlFlowAndFinallyTest --no-daemon --info --console=plain
+./gradlew classes --no-daemon --info --console=plain
+```
+
+## 工程反思（保留长期价值）
+
+1. `Packed*Array` 与 `Array` 虽然在 GDScript 层面都是"数组"，但在 GDExtension 层面构造策略完全不同（typed container vs regular builtin）；路由不对称是合理设计选择，而非遗漏，但必须显式文档化。
+2. 扩展类型文本解析（`parseExtensionType`）分散在各 resolver 中会导致规则漂移；抽取到共享 helper 后，由单一实现承载是可维护路径。
+3. 自动注入路径（`__prepare__` / default init）中类型分支的新增必须与指令生成器的语义保持对齐，否则会出现"注入 A 指令但生成器只认 B"的断层。
+4. 文档应只保留当前事实与长期约束；阶段推进记录应留在提交历史，不应长期污染实现文档。
+
+## 非目标（当前不做）
+
+- 不修改 `GdInstruction.CONSTRUCT_ARRAY` 的 opcode/操作数数量定义。
+- 不修改 `ConstructBuiltinInsn` 的行为与调用路径。
+- 不改变 `construct_dictionary` 现有语义。

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
@@ -150,6 +150,7 @@ public class CCodegen implements Codegen {
                         case GdStringNameType _ -> bb.instructions().add(new LiteralStringNameInsn(tmpVar.id(), ""));
                         case GdArrayType gdArrayType ->
                                 bb.instructions().add(new ConstructArrayInsn(tmpVar.id(), gdArrayType.getValueType().getTypeName()));
+                        case GdPackedArrayType _ -> bb.instructions().add(new ConstructArrayInsn(tmpVar.id(), null));
                         case GdDictionaryType gdDictionaryType ->
                                 bb.instructions().add(new ConstructDictionaryInsn(tmpVar.id(), gdDictionaryType.getKeyType().getTypeName(), gdDictionaryType.getValueType().getTypeName()));
                         default -> bb.instructions().add(new ConstructBuiltinInsn(tmpVar.id(), List.of()));
@@ -181,16 +182,15 @@ public class CCodegen implements Codegen {
                     }
                     var initInsn = switch (variable.type()) {
                         case GdObjectType _ -> new LiteralNullInsn(variable.id());
-                        case GdVariantType _, GdNilType _ ->
-                                new LiteralNilInsn(variable.id());
+                        case GdVariantType _, GdNilType _ -> new LiteralNilInsn(variable.id());
                         case GdBoolType _ -> new LiteralBoolInsn(variable.id(), false);
                         case GdIntType _ -> new LiteralIntInsn(variable.id(), 0);
                         case GdFloatType _ -> new LiteralFloatInsn(variable.id(), 0.0);
                         case GdStringType _ -> new LiteralStringInsn(variable.id(), "");
-                        case GdStringNameType _ ->
-                                new LiteralStringNameInsn(variable.id(), "");
+                        case GdStringNameType _ -> new LiteralStringNameInsn(variable.id(), "");
                         case GdArrayType gdArrayType ->
                                 new ConstructArrayInsn(variable.id(), gdArrayType.getValueType().getTypeName());
+                        case GdPackedArrayType _ -> new ConstructArrayInsn(variable.id(), null);
                         case GdDictionaryType gdDictionaryType ->
                                 new ConstructDictionaryInsn(variable.id(), gdDictionaryType.getKeyType().getTypeName(), gdDictionaryType.getValueType().getTypeName());
                         default -> new ConstructBuiltinInsn(variable.id(), List.of());

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java
@@ -390,6 +390,37 @@ public final class CGenHelper {
         };
     }
 
+    public @NotNull GdType parseExtensionType(@Nullable String rawTypeName,
+                                              @NotNull String typeUseSite) {
+        if (rawTypeName == null || rawTypeName.isBlank()) {
+            return GdVoidType.VOID;
+        }
+        var normalized = rawTypeName.trim();
+        if (normalized.startsWith("enum::") || normalized.startsWith("bitfield::")) {
+            return GdIntType.INT;
+        }
+        if (normalized.startsWith("typedarray::")) {
+            var elementTypeName = normalized.substring("typedarray::".length()).trim();
+            if (elementTypeName.isBlank()) {
+                throw new IllegalArgumentException(
+                        typeUseSite + " has malformed typedarray metadata: '" + rawTypeName + "'"
+                );
+            }
+            var elementType = parseExtensionType(elementTypeName, typeUseSite);
+            if (elementType instanceof GdPackedArrayType) {
+                return elementType;
+            }
+            return new GdArrayType(elementType);
+        }
+        var parsed = ClassRegistry.tryParseTextType(normalized);
+        if (parsed == null) {
+            throw new IllegalArgumentException(
+                    typeUseSite + " has unsupported type metadata: '" + rawTypeName + "'"
+            );
+        }
+        return parsed;
+    }
+
     public @NotNull String renderFuncBindName(@Nullable GdType returnType,
                                               @NotNull List<GdType> paramTypes,
                                               @NotNull List<GdType> defaultVarTypes,

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java
@@ -12,6 +12,7 @@ import dev.superice.gdcc.lir.insn.ConstructionInstruction;
 import dev.superice.gdcc.scope.ClassRegistry;
 import dev.superice.gdcc.type.GdArrayType;
 import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdPackedArrayType;
 import dev.superice.gdcc.type.GdType;
 import dev.superice.gdcc.type.GdVariantType;
 import org.jetbrains.annotations.NotNull;
@@ -47,11 +48,19 @@ public final class ConstructInsnGen implements CInsnGen<ConstructionInstruction>
                     bodyBuilder.helper().builtinBuilder().constructBuiltin(bodyBuilder, target, ctorArgs);
                 }
                 case ConstructArrayInsn(_, var className) -> {
-                    if (!(resultVar.type() instanceof GdArrayType arrayType)) {
-                        throw bodyBuilder.invalidInsn("Result variable ID '" + resultVar.id() + "' must be Array type");
+                    switch (resultVar.type()) {
+                        case GdArrayType arrayType -> {
+                            validateArrayTypeHint(bodyBuilder, className, arrayType);
+                            bodyBuilder.helper().builtinBuilder().constructBuiltin(bodyBuilder, target, List.of());
+                        }
+                        case GdPackedArrayType _ -> {
+                            validatePackedArrayTypeHint(bodyBuilder, className);
+                            bodyBuilder.helper().builtinBuilder().constructBuiltin(bodyBuilder, target, List.of());
+                        }
+                        default -> throw bodyBuilder.invalidInsn(
+                                "Result variable ID '" + resultVar.id() + "' must be Array or Packed*Array type"
+                        );
                     }
-                    validateArrayTypeHint(bodyBuilder, className, arrayType);
-                    bodyBuilder.helper().builtinBuilder().constructBuiltin(bodyBuilder, target, List.of());
                 }
                 case ConstructDictionaryInsn(_, var keyClassName, var valueClassName) -> {
                     if (!(resultVar.type() instanceof GdDictionaryType dictionaryType)) {
@@ -117,6 +126,16 @@ public final class ConstructInsnGen implements CInsnGen<ConstructionInstruction>
                             renderTypeName(bodyBuilder, expectedElementType) +
                             "' does not match result variable element type '" +
                             renderTypeName(bodyBuilder, actualElementType) + "'"
+            );
+        }
+    }
+
+    private void validatePackedArrayTypeHint(@NotNull CBodyBuilder bodyBuilder,
+                                             String className) {
+        if (className != null) {
+            throw bodyBuilder.invalidInsn(
+                    "construct_array for Packed*Array must not provide class_name; " +
+                            "packed array construction is inferred from result variable type"
             );
         }
     }

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java
@@ -132,12 +132,13 @@ public final class ConstructInsnGen implements CInsnGen<ConstructionInstruction>
 
     private void validatePackedArrayTypeHint(@NotNull CBodyBuilder bodyBuilder,
                                              String className) {
-        if (className != null) {
-            throw bodyBuilder.invalidInsn(
-                    "construct_array for Packed*Array must not provide class_name; " +
-                            "packed array construction is inferred from result variable type"
-            );
+        if (className == null) {
+            return;
         }
+        throw bodyBuilder.invalidInsn(
+                "construct_array for Packed*Array must not provide class_name; " +
+                        "packed array construction is inferred from result variable type"
+        );
     }
 
     private void validateDictionaryTypeHint(@NotNull CBodyBuilder bodyBuilder,

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/MethodCallResolver.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/MethodCallResolver.java
@@ -10,10 +10,8 @@ import dev.superice.gdcc.scope.FunctionDef;
 import dev.superice.gdcc.scope.ParameterDef;
 import dev.superice.gdcc.type.GdArrayType;
 import dev.superice.gdcc.type.GdDictionaryType;
-import dev.superice.gdcc.type.GdIntType;
 import dev.superice.gdcc.type.GdNilType;
 import dev.superice.gdcc.type.GdObjectType;
-import dev.superice.gdcc.type.GdPackedArrayType;
 import dev.superice.gdcc.type.GdType;
 import dev.superice.gdcc.type.GdVariantType;
 import dev.superice.gdcc.type.GdVoidType;
@@ -468,7 +466,7 @@ public final class MethodCallResolver {
                                                               @NotNull ParameterDef parameter,
                                                               int parameterIndexBaseOne) {
         if (parameter instanceof ExtensionFunctionArgument extensionArgument) {
-            return parseExtensionType(
+            return parseExtensionTypeWithHelper(
                     bodyBuilder,
                     extensionArgument.type(),
                     "method parameter #" + parameterIndexBaseOne + " of '" +
@@ -485,7 +483,7 @@ public final class MethodCallResolver {
             var rawReturnType = builtinMethod.returnValue() != null
                     ? builtinMethod.returnValue().type()
                     : builtinMethod.returnType();
-            return parseExtensionType(
+            return parseExtensionTypeWithHelper(
                     bodyBuilder,
                     rawReturnType,
                     "return type of '" + ownerClass.getName() + "." + function.getName() + "'"
@@ -494,7 +492,7 @@ public final class MethodCallResolver {
         if (function instanceof ExtensionGdClass.ClassMethod gdMethod) {
             var returnInfo = gdMethod.returnValue();
             var rawReturnType = returnInfo == null ? "void" : returnInfo.type();
-            return parseExtensionType(
+            return parseExtensionTypeWithHelper(
                     bodyBuilder,
                     rawReturnType,
                     "return type of '" + ownerClass.getName() + "." + function.getName() + "'"
@@ -503,32 +501,14 @@ public final class MethodCallResolver {
         return function.getReturnType();
     }
 
-    private static @NotNull GdType parseExtensionType(@NotNull CBodyBuilder bodyBuilder,
-                                                      @Nullable String rawTypeName,
-                                                      @NotNull String typeUseSite) {
-        if (rawTypeName == null || rawTypeName.isBlank()) {
-            return GdVoidType.VOID;
+    private static @NotNull GdType parseExtensionTypeWithHelper(@NotNull CBodyBuilder bodyBuilder,
+                                                                @Nullable String rawTypeName,
+                                                                @NotNull String typeUseSite) {
+        try {
+            return bodyBuilder.helper().parseExtensionType(rawTypeName, typeUseSite);
+        } catch (IllegalArgumentException ex) {
+            throw bodyBuilder.invalidInsn(ex.getMessage());
         }
-        var normalized = rawTypeName.trim();
-        if (normalized.startsWith("enum::") || normalized.startsWith("bitfield::")) {
-            return GdIntType.INT;
-        }
-        if (normalized.startsWith("typedarray::")) {
-            var elementTypeName = normalized.substring("typedarray::".length()).trim();
-            if (elementTypeName.isBlank()) {
-                throw bodyBuilder.invalidInsn(typeUseSite + " has malformed typedarray metadata: '" + rawTypeName + "'");
-            }
-            var elementType = parseExtensionType(bodyBuilder, elementTypeName, typeUseSite);
-            if (elementType instanceof GdPackedArrayType) {
-                return elementType;
-            }
-            return new GdArrayType(elementType);
-        }
-        var parsed = dev.superice.gdcc.scope.ClassRegistry.tryParseTextType(normalized);
-        if (parsed == null) {
-            throw bodyBuilder.invalidInsn(typeUseSite + " has unsupported type metadata: '" + rawTypeName + "'");
-        }
-        return parsed;
     }
 
     private static @NotNull GdType resolveOwnerType(@NotNull CBodyBuilder bodyBuilder,

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java
@@ -15,6 +15,7 @@ import dev.superice.gdcc.lir.LirFunctionDef;
 import dev.superice.gdcc.lir.LirInstruction;
 import dev.superice.gdcc.lir.LirModule;
 import dev.superice.gdcc.lir.LirParameterDef;
+import dev.superice.gdcc.lir.LirPropertyDef;
 import dev.superice.gdcc.lir.insn.ConstructArrayInsn;
 import dev.superice.gdcc.lir.insn.ConstructBuiltinInsn;
 import dev.superice.gdcc.lir.insn.ConstructDictionaryInsn;
@@ -27,8 +28,11 @@ import dev.superice.gdcc.type.GdFloatType;
 import dev.superice.gdcc.type.GdIntType;
 import dev.superice.gdcc.type.GdObjectType;
 import dev.superice.gdcc.type.GdPackedNumericArrayType;
+import dev.superice.gdcc.type.GdPackedStringArrayType;
+import dev.superice.gdcc.type.GdPackedVectorArrayType;
 import dev.superice.gdcc.type.GdStringNameType;
 import dev.superice.gdcc.type.GdTransform2DType;
+import dev.superice.gdcc.type.GdType;
 import dev.superice.gdcc.type.GdVariantType;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
@@ -112,18 +116,18 @@ class CConstructInsnGenEngineTest {
     }
 
     @Test
-    @DisplayName("construct_array packed insns should generate runnable PackedInt32Array constructors in real engine")
+    @DisplayName("construct_array packed insns should generate runnable Packed*Array constructors across all supported packed types")
     void constructPackedArrayInsnsShouldRunInRealGodot() throws IOException, InterruptedException {
         if (!hasZig()) {
             Assumptions.abort("Zig not found; skipping integration test");
             return;
         }
 
-        var tempDir = Path.of("tmp/test/construct_engine_packed_extra");
+        var tempDir = Path.of("tmp/test/construct_engine_packed_all");
         Files.createDirectories(tempDir);
 
         var projectInfo = new CProjectInfo(
-                "construct_engine_packed_extra",
+                "construct_engine_packed_all",
                 GodotVersion.V451,
                 tempDir,
                 COptimizationLevel.DEBUG,
@@ -133,7 +137,7 @@ class CConstructInsnGenEngineTest {
         builder.initProject(projectInfo);
 
         var constructClass = newPackedConstructEngineClass();
-        var module = new LirModule("construct_engine_packed_extra_module", List.of(constructClass));
+        var module = new LirModule("construct_engine_packed_all_module", List.of(constructClass));
         var api = ExtensionApiLoader.loadVersion(GodotVersion.V451);
         var codegen = new CCodegen();
         codegen.prepare(new CodegenContext(projectInfo, new ClassRegistry(api)), module);
@@ -142,12 +146,20 @@ class CConstructInsnGenEngineTest {
         assertTrue(buildResult.success(), "Compilation should succeed. Build log:\n" + buildResult.buildLog());
         assertFalse(buildResult.artifacts().isEmpty(), "Compilation should produce extension artifacts.");
         var entrySource = Files.readString(tempDir.resolve("entry.c"));
-        assertTrue(entrySource.contains("make_packed_int32_array_explicit"), "Explicit packed method should be emitted.");
-        assertTrue(entrySource.contains("make_packed_int32_array_prepare"), "Prepare packed method should be emitted.");
-        assertTrue(
-                entrySource.contains("godot_new_PackedInt32Array()"),
-                "PackedInt32Array constructor call should be generated in C source."
-        );
+        for (var packedCase : packedEngineCases()) {
+            assertTrue(
+                    entrySource.contains(packedCase.explicitMethodName()),
+                    () -> "Explicit method should be emitted for " + packedCase.builtinName() + "."
+            );
+            assertTrue(
+                    entrySource.contains(packedCase.prepareMethodName()),
+                    () -> "Prepare method should be emitted for " + packedCase.builtinName() + "."
+            );
+            assertTrue(
+                    entrySource.contains(packedCase.constructorCall()),
+                    () -> packedCase.builtinName() + " constructor call should be generated in C source."
+            );
+        }
 
         var runner = new GodotGdextensionTestRunner(Path.of("test_project"));
         runner.prepareProject(new GodotGdextensionTestRunner.ProjectSetup(
@@ -165,8 +177,91 @@ class CConstructInsnGenEngineTest {
         var combinedOutput = runResult.combinedOutput();
 
         assertTrue(runResult.stopSignalSeen(), "Godot run should emit stop signal.\nOutput:\n" + combinedOutput);
-        assertTrue(combinedOutput.contains("explicit packed int32 array check passed."), "explicit packed check should pass.\nOutput:\n" + combinedOutput);
-        assertTrue(combinedOutput.contains("prepare packed int32 array check passed."), "prepare packed check should pass.\nOutput:\n" + combinedOutput);
+        for (var packedCase : packedEngineCases()) {
+            assertTrue(
+                    combinedOutput.contains("explicit " + packedCase.label() + " check passed."),
+                    () -> "explicit packed check should pass for " + packedCase.builtinName() + ".\nOutput:\n" + combinedOutput
+            );
+            assertTrue(
+                    combinedOutput.contains("prepare " + packedCase.label() + " check passed."),
+                    () -> "prepare packed check should pass for " + packedCase.builtinName() + ".\nOutput:\n" + combinedOutput
+            );
+        }
+        assertFalse(combinedOutput.contains("check failed"), "No check should fail.\nOutput:\n" + combinedOutput);
+    }
+
+    @Test
+    @DisplayName("default property init path should generate and run Packed*Array field init functions in real engine")
+    void defaultPackedPropertyInitShouldRunInRealGodot() throws IOException, InterruptedException {
+        if (!hasZig()) {
+            Assumptions.abort("Zig not found; skipping integration test");
+            return;
+        }
+
+        var tempDir = Path.of("tmp/test/construct_engine_packed_property_init");
+        Files.createDirectories(tempDir);
+
+        var projectInfo = new CProjectInfo(
+                "construct_engine_packed_property_init",
+                GodotVersion.V451,
+                tempDir,
+                COptimizationLevel.DEBUG,
+                TargetPlatform.getNativePlatform()
+        );
+        var builder = new CProjectBuilder();
+        builder.initProject(projectInfo);
+
+        var constructClass = newPackedPropertyInitEngineClass();
+        var module = new LirModule("construct_engine_packed_property_init_module", List.of(constructClass));
+        var api = ExtensionApiLoader.loadVersion(GodotVersion.V451);
+        var codegen = new CCodegen();
+        codegen.prepare(new CodegenContext(projectInfo, new ClassRegistry(api)), module);
+
+        var buildResult = builder.buildProject(projectInfo, codegen);
+        assertTrue(buildResult.success(), "Compilation should succeed. Build log:\n" + buildResult.buildLog());
+        assertFalse(buildResult.artifacts().isEmpty(), "Compilation should produce extension artifacts.");
+        var entrySource = Files.readString(tempDir.resolve("entry.c"));
+        assertTrue(
+                entrySource.contains("GDConstructPackedPropertyInitNode_class_constructor"),
+                "Class constructor should be emitted for packed property init class."
+        );
+        for (var packedCase : packedEngineCases()) {
+            assertTrue(
+                    entrySource.contains("_field_init_" + packedCase.propertyName()),
+                    () -> "Default init function should be generated for property " + packedCase.propertyName()
+            );
+            assertTrue(
+                    entrySource.contains("self->" + packedCase.propertyName() + " = "),
+                    () -> "Class constructor should assign property " + packedCase.propertyName() + " from init function."
+            );
+            assertTrue(
+                    entrySource.contains(packedCase.constructorCall()),
+                    () -> packedCase.builtinName() + " constructor call should appear in field init path."
+            );
+        }
+
+        var runner = new GodotGdextensionTestRunner(Path.of("test_project"));
+        runner.prepareProject(new GodotGdextensionTestRunner.ProjectSetup(
+                buildResult.artifacts(),
+                List.of(new GodotGdextensionTestRunner.SceneNodeSpec(
+                        "ConstructNode",
+                        constructClass.getName(),
+                        ".",
+                        Map.of()
+                )),
+                new GodotGdextensionTestRunner.TestScriptSpec(packedPropertyInitTestScript())
+        ));
+
+        var runResult = runner.run(true);
+        var combinedOutput = runResult.combinedOutput();
+
+        assertTrue(runResult.stopSignalSeen(), "Godot run should emit stop signal.\nOutput:\n" + combinedOutput);
+        for (var packedCase : packedEngineCases()) {
+            assertTrue(
+                    combinedOutput.contains("default " + packedCase.label() + " property init check passed."),
+                    () -> "default property init check should pass for " + packedCase.builtinName() + ".\nOutput:\n" + combinedOutput
+            );
+        }
         assertFalse(combinedOutput.contains("check failed"), "No check should fail.\nOutput:\n" + combinedOutput);
     }
 
@@ -197,8 +292,19 @@ class CConstructInsnGenEngineTest {
         clazz.setSourceFile("construct_engine_packed_extra.gd");
 
         var selfType = new GdObjectType(clazz.getName());
-        clazz.addFunction(newExplicitPackedInt32ArrayFunction(selfType));
-        clazz.addFunction(newPreparePackedInt32ArrayFunction(selfType));
+        for (var packedCase : packedEngineCases()) {
+            clazz.addFunction(newExplicitPackedArrayFunction(packedCase.explicitMethodName(), packedCase.type(), selfType));
+            clazz.addFunction(newPreparePackedArrayFunction(packedCase.prepareMethodName(), packedCase.type(), selfType));
+        }
+        return clazz;
+    }
+
+    private static LirClassDef newPackedPropertyInitEngineClass() {
+        var clazz = new LirClassDef("GDConstructPackedPropertyInitNode", "Node");
+        clazz.setSourceFile("construct_engine_packed_property_init.gd");
+        for (var packedCase : packedEngineCases()) {
+            clazz.addProperty(new LirPropertyDef(packedCase.propertyName(), packedCase.type()));
+        }
         return clazz;
     }
 
@@ -309,21 +415,105 @@ class CConstructInsnGenEngineTest {
         return func;
     }
 
-    private static LirFunctionDef newExplicitPackedInt32ArrayFunction(GdObjectType selfType) {
-        var packedType = GdPackedNumericArrayType.PACKED_INT32_ARRAY;
-        var func = newMethod("make_packed_int32_array_explicit", packedType, selfType);
+    private static LirFunctionDef newExplicitPackedArrayFunction(String methodName, GdType packedType, GdObjectType selfType) {
+        var func = newMethod(methodName, packedType, selfType);
         func.createAndAddVariable("packed", packedType);
         entry(func).instructions().add(new ConstructArrayInsn("packed", null));
         entry(func).instructions().add(new ReturnInsn("packed"));
         return func;
     }
 
-    private static LirFunctionDef newPreparePackedInt32ArrayFunction(GdObjectType selfType) {
-        var packedType = GdPackedNumericArrayType.PACKED_INT32_ARRAY;
-        var func = newMethod("make_packed_int32_array_prepare", packedType, selfType);
+    private static LirFunctionDef newPreparePackedArrayFunction(String methodName, GdType packedType, GdObjectType selfType) {
+        var func = newMethod(methodName, packedType, selfType);
         func.createAndAddVariable("packed", packedType);
         entry(func).instructions().add(new ReturnInsn("packed"));
         return func;
+    }
+
+    private static List<PackedEngineCase> packedEngineCases() {
+        return List.of(
+                new PackedEngineCase(
+                        "packed byte array",
+                        "PackedByteArray",
+                        "TYPE_PACKED_BYTE_ARRAY",
+                        "PackedByteArray",
+                        GdPackedNumericArrayType.PACKED_BYTE_ARRAY,
+                        "packed.append(7)",
+                        "packed[0] == 7"
+                ),
+                new PackedEngineCase(
+                        "packed int32 array",
+                        "PackedInt32Array",
+                        "TYPE_PACKED_INT32_ARRAY",
+                        "PackedInt32Array",
+                        GdPackedNumericArrayType.PACKED_INT32_ARRAY,
+                        "packed.append(123)",
+                        "packed[0] == 123"
+                ),
+                new PackedEngineCase(
+                        "packed int64 array",
+                        "PackedInt64Array",
+                        "TYPE_PACKED_INT64_ARRAY",
+                        "PackedInt64Array",
+                        GdPackedNumericArrayType.PACKED_INT64_ARRAY,
+                        "packed.append(9876543210)",
+                        "packed[0] == 9876543210"
+                ),
+                new PackedEngineCase(
+                        "packed float32 array",
+                        "PackedFloat32Array",
+                        "TYPE_PACKED_FLOAT32_ARRAY",
+                        "PackedFloat32Array",
+                        GdPackedNumericArrayType.PACKED_FLOAT32_ARRAY,
+                        "packed.append(1.5)",
+                        "is_equal_approx(packed[0], 1.5)"
+                ),
+                new PackedEngineCase(
+                        "packed float64 array",
+                        "PackedFloat64Array",
+                        "TYPE_PACKED_FLOAT64_ARRAY",
+                        "PackedFloat64Array",
+                        GdPackedNumericArrayType.PACKED_FLOAT64_ARRAY,
+                        "packed.append(2.75)",
+                        "is_equal_approx(packed[0], 2.75)"
+                ),
+                new PackedEngineCase(
+                        "packed string array",
+                        "PackedStringArray",
+                        "TYPE_PACKED_STRING_ARRAY",
+                        "PackedStringArray",
+                        GdPackedStringArrayType.PACKED_STRING_ARRAY,
+                        "packed.append(\"gdcc\")",
+                        "packed[0] == \"gdcc\""
+                ),
+                new PackedEngineCase(
+                        "packed vector2 array",
+                        "PackedVector2Array",
+                        "TYPE_PACKED_VECTOR2_ARRAY",
+                        "PackedVector2Array",
+                        GdPackedVectorArrayType.PACKED_VECTOR2_ARRAY,
+                        "packed.append(Vector2(1.25, -2.5))",
+                        "packed[0].is_equal_approx(Vector2(1.25, -2.5))"
+                ),
+                new PackedEngineCase(
+                        "packed vector3 array",
+                        "PackedVector3Array",
+                        "TYPE_PACKED_VECTOR3_ARRAY",
+                        "PackedVector3Array",
+                        GdPackedVectorArrayType.PACKED_VECTOR3_ARRAY,
+                        "packed.append(Vector3(1.0, -2.0, 3.5))",
+                        "packed[0].is_equal_approx(Vector3(1.0, -2.0, 3.5))"
+                ),
+                new PackedEngineCase(
+                        "packed vector4 array",
+                        "PackedVector4Array",
+                        "TYPE_PACKED_VECTOR4_ARRAY",
+                        "PackedVector4Array",
+                        GdPackedVectorArrayType.PACKED_VECTOR4_ARRAY,
+                        "packed.append(Vector4(1.0, 2.0, -3.0, 4.5))",
+                        "packed[0].is_equal_approx(Vector4(1.0, 2.0, -3.0, 4.5))"
+                )
+        );
     }
 
     private static LirFunctionDef newMethod(String name, dev.superice.gdcc.type.GdType returnType, GdObjectType selfType) {
@@ -424,34 +614,107 @@ class CConstructInsnGenEngineTest {
     }
 
     private static String packedTestScript() {
-        return """
-                extends Node
-                
-                const TARGET_NODE_NAME = "ConstructNode"
-                
-                func _ready() -> void:
-                    var target = get_parent().get_node_or_null(TARGET_NODE_NAME)
-                    if target == null:
-                        push_error("Target node missing.")
-                        return
-                
-                    var packed_explicit = target.call("make_packed_int32_array_explicit")
-                    if _check_packed_int32_array(packed_explicit):
-                        print("explicit packed int32 array check passed.")
-                    else:
-                        push_error("explicit packed int32 array check failed.")
-                
-                    var packed_prepare = target.call("make_packed_int32_array_prepare")
-                    if _check_packed_int32_array(packed_prepare):
-                        print("prepare packed int32 array check passed.")
-                    else:
-                        push_error("prepare packed int32 array check failed.")
-                
-                func _check_packed_int32_array(value: Variant) -> bool:
-                    if typeof(value) != TYPE_PACKED_INT32_ARRAY:
-                        return false
-                    var packed: PackedInt32Array = value
-                    return packed.size() == 0
-                """;
+        var script = new StringBuilder();
+        script.append("extends Node\n\n");
+        script.append("const TARGET_NODE_NAME = \"ConstructNode\"\n\n");
+        script.append("func _ready() -> void:\n");
+        script.append("    var target = get_parent().get_node_or_null(TARGET_NODE_NAME)\n");
+        script.append("    if target == null:\n");
+        script.append("        push_error(\"Target node missing.\")\n");
+        script.append("        return\n\n");
+
+        for (var packedCase : packedEngineCases()) {
+            var explicitValueVar = packedCase.valueVar("explicit");
+            var prepareValueVar = packedCase.valueVar("prepare");
+            script.append("    var ").append(explicitValueVar).append(" = target.call(\"").append(packedCase.explicitMethodName()).append("\")\n");
+            script.append("    if ").append(packedCase.checkMethodName()).append("(").append(explicitValueVar).append("):\n");
+            script.append("        print(\"explicit ").append(packedCase.label()).append(" check passed.\")\n");
+            script.append("    else:\n");
+            script.append("        push_error(\"explicit ").append(packedCase.label()).append(" check failed.\")\n\n");
+
+            script.append("    var ").append(prepareValueVar).append(" = target.call(\"").append(packedCase.prepareMethodName()).append("\")\n");
+            script.append("    if ").append(packedCase.checkMethodName()).append("(").append(prepareValueVar).append("):\n");
+            script.append("        print(\"prepare ").append(packedCase.label()).append(" check passed.\")\n");
+            script.append("    else:\n");
+            script.append("        push_error(\"prepare ").append(packedCase.label()).append(" check failed.\")\n\n");
+        }
+
+        for (var packedCase : packedEngineCases()) {
+            script.append("func ").append(packedCase.checkMethodName()).append("(value: Variant) -> bool:\n");
+            script.append("    if typeof(value) != ").append(packedCase.gdscriptTypeConstant()).append(":\n");
+            script.append("        return false\n");
+            script.append("    var packed: ").append(packedCase.gdscriptTypeName()).append(" = value\n");
+            script.append("    if packed.size() != 0:\n");
+            script.append("        return false\n");
+            script.append("    ").append(packedCase.appendExpression()).append("\n");
+            script.append("    return packed.size() == 1 and ").append(packedCase.firstElementAssertion()).append("\n\n");
+        }
+        return script.toString();
+    }
+
+    private static String packedPropertyInitTestScript() {
+        var script = new StringBuilder();
+        script.append("extends Node\n\n");
+        script.append("const TARGET_NODE_NAME = \"ConstructNode\"\n\n");
+        script.append("func _ready() -> void:\n");
+        script.append("    var target = get_parent().get_node_or_null(TARGET_NODE_NAME)\n");
+        script.append("    if target == null:\n");
+        script.append("        push_error(\"Target node missing.\")\n");
+        script.append("        return\n\n");
+
+        for (var packedCase : packedEngineCases()) {
+            var valueVar = packedCase.valueVar("property");
+            script.append("    var ").append(valueVar).append(" = target.get(\"").append(packedCase.propertyName()).append("\")\n");
+            script.append("    if ").append(packedCase.checkMethodName()).append("(").append(valueVar).append("):\n");
+            script.append("        print(\"default ").append(packedCase.label()).append(" property init check passed.\")\n");
+            script.append("    else:\n");
+            script.append("        push_error(\"default ").append(packedCase.label()).append(" property init check failed.\")\n\n");
+        }
+
+        for (var packedCase : packedEngineCases()) {
+            script.append("func ").append(packedCase.checkMethodName()).append("(value: Variant) -> bool:\n");
+            script.append("    if typeof(value) != ").append(packedCase.gdscriptTypeConstant()).append(":\n");
+            script.append("        return false\n");
+            script.append("    var packed: ").append(packedCase.gdscriptTypeName()).append(" = value\n");
+            script.append("    if packed.size() != 0:\n");
+            script.append("        return false\n");
+            script.append("    ").append(packedCase.appendExpression()).append("\n");
+            script.append("    return packed.size() == 1 and ").append(packedCase.firstElementAssertion()).append("\n\n");
+        }
+        return script.toString();
+    }
+
+    private record PackedEngineCase(
+            String label,
+            String builtinName,
+            String gdscriptTypeConstant,
+            String gdscriptTypeName,
+            GdType type,
+            String appendExpression,
+            String firstElementAssertion
+    ) {
+        private String explicitMethodName() {
+            return "make_" + label.replace(' ', '_') + "_explicit";
+        }
+
+        private String prepareMethodName() {
+            return "make_" + label.replace(' ', '_') + "_prepare";
+        }
+
+        private String constructorCall() {
+            return "godot_new_" + builtinName + "()";
+        }
+
+        private String checkMethodName() {
+            return "_check_" + label.replace(' ', '_');
+        }
+
+        private String valueVar(String suffix) {
+            return label.replace(' ', '_') + "_" + suffix;
+        }
+
+        private String propertyName() {
+            return label.replace(' ', '_') + "_prop";
+        }
     }
 }

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenEngineTest.java
@@ -26,6 +26,7 @@ import dev.superice.gdcc.type.GdDictionaryType;
 import dev.superice.gdcc.type.GdFloatType;
 import dev.superice.gdcc.type.GdIntType;
 import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdPackedNumericArrayType;
 import dev.superice.gdcc.type.GdStringNameType;
 import dev.superice.gdcc.type.GdTransform2DType;
 import dev.superice.gdcc.type.GdVariantType;
@@ -110,6 +111,65 @@ class CConstructInsnGenEngineTest {
         assertFalse(combinedOutput.contains("check failed"), "No check should fail.\nOutput:\n" + combinedOutput);
     }
 
+    @Test
+    @DisplayName("construct_array packed insns should generate runnable PackedInt32Array constructors in real engine")
+    void constructPackedArrayInsnsShouldRunInRealGodot() throws IOException, InterruptedException {
+        if (!hasZig()) {
+            Assumptions.abort("Zig not found; skipping integration test");
+            return;
+        }
+
+        var tempDir = Path.of("tmp/test/construct_engine_packed_extra");
+        Files.createDirectories(tempDir);
+
+        var projectInfo = new CProjectInfo(
+                "construct_engine_packed_extra",
+                GodotVersion.V451,
+                tempDir,
+                COptimizationLevel.DEBUG,
+                TargetPlatform.getNativePlatform()
+        );
+        var builder = new CProjectBuilder();
+        builder.initProject(projectInfo);
+
+        var constructClass = newPackedConstructEngineClass();
+        var module = new LirModule("construct_engine_packed_extra_module", List.of(constructClass));
+        var api = ExtensionApiLoader.loadVersion(GodotVersion.V451);
+        var codegen = new CCodegen();
+        codegen.prepare(new CodegenContext(projectInfo, new ClassRegistry(api)), module);
+
+        var buildResult = builder.buildProject(projectInfo, codegen);
+        assertTrue(buildResult.success(), "Compilation should succeed. Build log:\n" + buildResult.buildLog());
+        assertFalse(buildResult.artifacts().isEmpty(), "Compilation should produce extension artifacts.");
+        var entrySource = Files.readString(tempDir.resolve("entry.c"));
+        assertTrue(entrySource.contains("make_packed_int32_array_explicit"), "Explicit packed method should be emitted.");
+        assertTrue(entrySource.contains("make_packed_int32_array_prepare"), "Prepare packed method should be emitted.");
+        assertTrue(
+                entrySource.contains("godot_new_PackedInt32Array()"),
+                "PackedInt32Array constructor call should be generated in C source."
+        );
+
+        var runner = new GodotGdextensionTestRunner(Path.of("test_project"));
+        runner.prepareProject(new GodotGdextensionTestRunner.ProjectSetup(
+                buildResult.artifacts(),
+                List.of(new GodotGdextensionTestRunner.SceneNodeSpec(
+                        "ConstructNode",
+                        constructClass.getName(),
+                        ".",
+                        Map.of()
+                )),
+                new GodotGdextensionTestRunner.TestScriptSpec(packedTestScript())
+        ));
+
+        var runResult = runner.run(true);
+        var combinedOutput = runResult.combinedOutput();
+
+        assertTrue(runResult.stopSignalSeen(), "Godot run should emit stop signal.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("explicit packed int32 array check passed."), "explicit packed check should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("prepare packed int32 array check passed."), "prepare packed check should pass.\nOutput:\n" + combinedOutput);
+        assertFalse(combinedOutput.contains("check failed"), "No check should fail.\nOutput:\n" + combinedOutput);
+    }
+
     private static boolean hasZig() {
         return ZigUtil.findZig() != null;
     }
@@ -129,6 +189,16 @@ class CConstructInsnGenEngineTest {
         clazz.addFunction(newPrepareTypedArrayFunction(selfType));
         clazz.addFunction(newExplicitTypedDictionaryFunction(selfType));
         clazz.addFunction(newPrepareTypedDictionaryFunction(selfType));
+        return clazz;
+    }
+
+    private static LirClassDef newPackedConstructEngineClass() {
+        var clazz = new LirClassDef("GDConstructPackedEngineNode", "Node");
+        clazz.setSourceFile("construct_engine_packed_extra.gd");
+
+        var selfType = new GdObjectType(clazz.getName());
+        clazz.addFunction(newExplicitPackedInt32ArrayFunction(selfType));
+        clazz.addFunction(newPreparePackedInt32ArrayFunction(selfType));
         return clazz;
     }
 
@@ -239,6 +309,23 @@ class CConstructInsnGenEngineTest {
         return func;
     }
 
+    private static LirFunctionDef newExplicitPackedInt32ArrayFunction(GdObjectType selfType) {
+        var packedType = GdPackedNumericArrayType.PACKED_INT32_ARRAY;
+        var func = newMethod("make_packed_int32_array_explicit", packedType, selfType);
+        func.createAndAddVariable("packed", packedType);
+        entry(func).instructions().add(new ConstructArrayInsn("packed", null));
+        entry(func).instructions().add(new ReturnInsn("packed"));
+        return func;
+    }
+
+    private static LirFunctionDef newPreparePackedInt32ArrayFunction(GdObjectType selfType) {
+        var packedType = GdPackedNumericArrayType.PACKED_INT32_ARRAY;
+        var func = newMethod("make_packed_int32_array_prepare", packedType, selfType);
+        func.createAndAddVariable("packed", packedType);
+        entry(func).instructions().add(new ReturnInsn("packed"));
+        return func;
+    }
+
     private static LirFunctionDef newMethod(String name, dev.superice.gdcc.type.GdType returnType, GdObjectType selfType) {
         var func = new LirFunctionDef(name);
         func.setReturnType(returnType);
@@ -333,6 +420,38 @@ class CConstructInsnGenEngineTest {
                         return false
                     var dict: Dictionary = value
                     return not dict.is_typed() and dict.is_empty()
+                """;
+    }
+
+    private static String packedTestScript() {
+        return """
+                extends Node
+                
+                const TARGET_NODE_NAME = "ConstructNode"
+                
+                func _ready() -> void:
+                    var target = get_parent().get_node_or_null(TARGET_NODE_NAME)
+                    if target == null:
+                        push_error("Target node missing.")
+                        return
+                
+                    var packed_explicit = target.call("make_packed_int32_array_explicit")
+                    if _check_packed_int32_array(packed_explicit):
+                        print("explicit packed int32 array check passed.")
+                    else:
+                        push_error("explicit packed int32 array check failed.")
+                
+                    var packed_prepare = target.call("make_packed_int32_array_prepare")
+                    if _check_packed_int32_array(packed_prepare):
+                        print("prepare packed int32 array check passed.")
+                    else:
+                        push_error("prepare packed int32 array check failed.")
+                
+                func _check_packed_int32_array(value: Variant) -> bool:
+                    if typeof(value) != TYPE_PACKED_INT32_ARRAY:
+                        return false
+                    var packed: PackedInt32Array = value
+                    return packed.size() == 0
                 """;
     }
 }

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
@@ -144,6 +144,13 @@ class CConstructInsnGenTest {
     }
 
     @Test
+    @DisplayName("construct_array should reject empty or blank class_name when result type is Packed*Array")
+    void constructArrayShouldRejectEmptyOrBlankClassNameForPackedArray() {
+        assertPackedArrayClassNameRejected("");
+        assertPackedArrayClassNameRejected("   ");
+    }
+
+    @Test
     @DisplayName("construct_dictionary should emit typed Dictionary constructor when key/value operands match result types")
     void constructDictionaryShouldEmitTypedCtor() {
         var clazz = newTestClass();
@@ -349,6 +356,17 @@ class CConstructInsnGenTest {
         var module = new LirModule("test_module", List.of(clazz));
         var codegen = newCodegen(module, List.of(clazz));
         return codegen.generateFuncBody(clazz, func);
+    }
+
+    private void assertPackedArrayClassNameRejected(String className) {
+        var clazz = newTestClass();
+        var func = newFunction("construct_packed_array_with_blank_class_name");
+        func.createAndAddVariable("packed", GdPackedNumericArrayType.PACKED_INT32_ARRAY);
+        entry(func).instructions().add(new ConstructArrayInsn("packed", className));
+        clazz.addFunction(func);
+
+        var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
+        assertTrue(ex.getMessage().contains("must not provide class_name"));
     }
 
     private CCodegen newCodegen(LirModule module, List<LirClassDef> gdccClasses) {

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
@@ -5,6 +5,7 @@ import dev.superice.gdcc.backend.ProjectInfo;
 import dev.superice.gdcc.enums.GodotVersion;
 import dev.superice.gdcc.exception.InvalidInsnException;
 import dev.superice.gdcc.gdextension.ExtensionAPI;
+import dev.superice.gdcc.gdextension.ExtensionBuiltinClass;
 import dev.superice.gdcc.lir.LirBasicBlock;
 import dev.superice.gdcc.lir.LirClassDef;
 import dev.superice.gdcc.lir.LirFunctionDef;
@@ -18,6 +19,7 @@ import dev.superice.gdcc.scope.ClassRegistry;
 import dev.superice.gdcc.type.GdArrayType;
 import dev.superice.gdcc.type.GdDictionaryType;
 import dev.superice.gdcc.type.GdFloatType;
+import dev.superice.gdcc.type.GdPackedNumericArrayType;
 import dev.superice.gdcc.type.GdStringNameType;
 import dev.superice.gdcc.type.GdStringType;
 import dev.superice.gdcc.type.GdTransform2DType;
@@ -34,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class CConstructInsnGenTest {
     @Test
@@ -110,6 +113,34 @@ class CConstructInsnGenTest {
 
         var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
         assertTrue(ex.getMessage().contains("construct_array type mismatch"));
+    }
+
+    @Test
+    @DisplayName("construct_array should emit Packed*Array constructor when result type is packed and class_name is omitted")
+    void constructArrayShouldEmitPackedCtorWhenClassNameOmitted() {
+        var clazz = newTestClass();
+        var func = newFunction("construct_packed_array");
+        func.createAndAddVariable("packed", GdPackedNumericArrayType.PACKED_INT32_ARRAY);
+
+        entry(func).instructions().add(new ConstructArrayInsn("packed", null));
+        clazz.addFunction(func);
+
+        var body = generateBody(clazz, func);
+        assertTrue(body.contains("godot_new_PackedInt32Array()"));
+    }
+
+    @Test
+    @DisplayName("construct_array should reject class_name when result type is Packed*Array")
+    void constructArrayShouldRejectClassNameForPackedArray() {
+        var clazz = newTestClass();
+        var func = newFunction("construct_packed_array_with_class_name");
+        func.createAndAddVariable("packed", GdPackedNumericArrayType.PACKED_INT32_ARRAY);
+
+        entry(func).instructions().add(new ConstructArrayInsn("packed", "PackedInt32Array"));
+        clazz.addFunction(func);
+
+        var ex = assertThrows(InvalidInsnException.class, () -> generateBody(clazz, func));
+        assertTrue(ex.getMessage().contains("must not provide class_name"));
     }
 
     @Test
@@ -192,6 +223,34 @@ class CConstructInsnGenTest {
     }
 
     @Test
+    @DisplayName("generate should inject construct_array with null class_name into __prepare__ for Packed*Array variables")
+    void generateShouldInjectPackedConstructArrayIntoPrepareBlock() {
+        var clazz = newTestClass();
+        var func = newFunction("prepare_inject_packed_construct");
+        func.createAndAddVariable("packed", GdPackedNumericArrayType.PACKED_INT32_ARRAY);
+        entry(func).instructions().add(new ReturnInsn(null));
+        clazz.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(clazz));
+        var codegen = newCodegen(module, List.of(clazz));
+        codegen.generate();
+
+        var prepare = func.getBasicBlock("__prepare__");
+        assertNotNull(prepare);
+        var hasPackedArrayInsn = prepare.instructions().stream()
+                .filter(ConstructArrayInsn.class::isInstance)
+                .map(ConstructArrayInsn.class::cast)
+                .anyMatch(insn -> "packed".equals(insn.resultId()) && insn.className() == null);
+        assertTrue(hasPackedArrayInsn);
+
+        var hasPackedBuiltinInsn = prepare.instructions().stream()
+                .filter(ConstructBuiltinInsn.class::isInstance)
+                .map(ConstructBuiltinInsn.class::cast)
+                .anyMatch(insn -> "packed".equals(insn.resultId()));
+        assertFalse(hasPackedBuiltinInsn);
+    }
+
+    @Test
     @DisplayName("__prepare__ generated typed construct instructions should emit typed constructor C calls")
     void generatedPrepareConstructsShouldEmitTypedConstructorCalls() {
         var clazz = newTestClass();
@@ -209,6 +268,24 @@ class CConstructInsnGenTest {
         assertTrue(body.contains("__prepare__: // __prepare__"));
         assertTrue(body.contains("godot_new_Array_with_Array_int_StringName_Variant"));
         assertTrue(body.contains("godot_new_Dictionary_with_Dictionary_int_StringName_Variant_int_StringName_Variant"));
+    }
+
+    @Test
+    @DisplayName("__prepare__ generated Packed*Array construct instruction should emit packed constructor C call")
+    void generatedPreparePackedConstructShouldEmitPackedConstructorCall() {
+        var clazz = newTestClass();
+        var func = newFunction("prepare_emit_packed_ctor_call");
+        func.createAndAddVariable("packed", GdPackedNumericArrayType.PACKED_INT32_ARRAY);
+        entry(func).instructions().add(new ReturnInsn(null));
+        clazz.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(clazz));
+        var codegen = newCodegen(module, List.of(clazz));
+        codegen.generate();
+
+        var body = codegen.generateFuncBody(clazz, func);
+        assertTrue(body.contains("__prepare__: // __prepare__"));
+        assertTrue(body.contains("godot_new_PackedInt32Array()"));
     }
 
     @Test
@@ -275,7 +352,7 @@ class CConstructInsnGenTest {
     }
 
     private CCodegen newCodegen(LirModule module, List<LirClassDef> gdccClasses) {
-        var classRegistry = new ClassRegistry(emptyApi());
+        var classRegistry = new ClassRegistry(apiWithPackedConstructors());
         for (var gdccClass : gdccClasses) {
             classRegistry.addGdccClass(gdccClass);
         }
@@ -287,14 +364,24 @@ class CConstructInsnGenTest {
         return codegen;
     }
 
-    private ExtensionAPI emptyApi() {
+    private ExtensionAPI apiWithPackedConstructors() {
+        var packedInt32ArrayClass = new ExtensionBuiltinClass(
+                "PackedInt32Array",
+                false,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(new ExtensionBuiltinClass.ConstructorInfo("PackedInt32Array", 0, List.of())),
+                List.of(),
+                List.of()
+        );
         return new ExtensionAPI(
                 null,
                 List.of(),
                 List.of(),
                 List.of(),
                 List.of(),
-                List.of(),
+                List.of(packedInt32ArrayClass),
                 List.of(),
                 List.of(),
                 List.of()

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CConstructInsnGenTest.java
@@ -11,6 +11,7 @@ import dev.superice.gdcc.lir.LirClassDef;
 import dev.superice.gdcc.lir.LirFunctionDef;
 import dev.superice.gdcc.lir.LirInstruction;
 import dev.superice.gdcc.lir.LirModule;
+import dev.superice.gdcc.lir.LirPropertyDef;
 import dev.superice.gdcc.lir.insn.ConstructArrayInsn;
 import dev.superice.gdcc.lir.insn.ConstructBuiltinInsn;
 import dev.superice.gdcc.lir.insn.ConstructDictionaryInsn;
@@ -20,14 +21,18 @@ import dev.superice.gdcc.type.GdArrayType;
 import dev.superice.gdcc.type.GdDictionaryType;
 import dev.superice.gdcc.type.GdFloatType;
 import dev.superice.gdcc.type.GdPackedNumericArrayType;
+import dev.superice.gdcc.type.GdPackedStringArrayType;
+import dev.superice.gdcc.type.GdPackedVectorArrayType;
 import dev.superice.gdcc.type.GdStringNameType;
 import dev.superice.gdcc.type.GdStringType;
 import dev.superice.gdcc.type.GdTransform2DType;
+import dev.superice.gdcc.type.GdType;
 import dev.superice.gdcc.type.GdVariantType;
 import dev.superice.gdcc.type.GdVoidType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -296,6 +301,125 @@ class CConstructInsnGenTest {
     }
 
     @Test
+    @DisplayName("construct_array should emit packed constructors for all supported Packed*Array types")
+    void constructArrayShouldEmitPackedCtorForAllSupportedPackedArrayTypes() {
+        for (var packedCase : packedCtorCases()) {
+            var clazz = newTestClass();
+            var func = newFunction("construct_" + packedCase.label() + "_array");
+            func.createAndAddVariable("packed", packedCase.type());
+            entry(func).instructions().add(new ConstructArrayInsn("packed", null));
+            clazz.addFunction(func);
+
+            var body = generateBody(clazz, func);
+            assertTrue(
+                    body.contains(packedCase.constructorCall()),
+                    () -> "Expected constructor call missing for " + packedCase.typeName() + ".\nBody:\n" + body
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("__prepare__ should inject packed construct_array for all supported Packed*Array types")
+    void generateShouldInjectPackedConstructArrayIntoPrepareBlockForAllPackedTypes() {
+        for (var packedCase : packedCtorCases()) {
+            var clazz = newTestClass();
+            var func = newFunction("prepare_inject_" + packedCase.label());
+            func.createAndAddVariable("packed", packedCase.type());
+            entry(func).instructions().add(new ReturnInsn(null));
+            clazz.addFunction(func);
+
+            var module = new LirModule("test_module", List.of(clazz));
+            var codegen = newCodegen(module, List.of(clazz));
+            codegen.generate();
+
+            var prepare = func.getBasicBlock("__prepare__");
+            assertNotNull(prepare);
+            var hasPackedArrayInsn = prepare.instructions().stream()
+                    .filter(ConstructArrayInsn.class::isInstance)
+                    .map(ConstructArrayInsn.class::cast)
+                    .anyMatch(insn -> "packed".equals(insn.resultId()) && insn.className() == null);
+            assertTrue(hasPackedArrayInsn, () -> "Missing construct_array injection for " + packedCase.typeName());
+
+            var hasPackedBuiltinInsn = prepare.instructions().stream()
+                    .filter(ConstructBuiltinInsn.class::isInstance)
+                    .map(ConstructBuiltinInsn.class::cast)
+                    .anyMatch(insn -> "packed".equals(insn.resultId()));
+            assertFalse(hasPackedBuiltinInsn, () -> "Unexpected construct_builtin injection for " + packedCase.typeName());
+        }
+    }
+
+    @Test
+    @DisplayName("__prepare__ generated packed construct_array should emit constructor calls for all supported Packed*Array types")
+    void generatedPreparePackedConstructShouldEmitPackedConstructorCallForAllPackedTypes() {
+        for (var packedCase : packedCtorCases()) {
+            var clazz = newTestClass();
+            var func = newFunction("prepare_emit_" + packedCase.label());
+            func.createAndAddVariable("packed", packedCase.type());
+            entry(func).instructions().add(new ReturnInsn(null));
+            clazz.addFunction(func);
+
+            var module = new LirModule("test_module", List.of(clazz));
+            var codegen = newCodegen(module, List.of(clazz));
+            codegen.generate();
+
+            var body = codegen.generateFuncBody(clazz, func);
+            assertTrue(body.contains("__prepare__: // __prepare__"));
+            assertTrue(
+                    body.contains(packedCase.constructorCall()),
+                    () -> "Expected prepare constructor call missing for " + packedCase.typeName() + ".\nBody:\n" + body
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("generate should inject packed construct_array into default field init functions")
+    void generateShouldInjectPackedConstructArrayIntoDefaultFieldInitFunctions() {
+        var clazz = newTestClass();
+        var propertyCases = new ArrayList<PackedPropertyCase>();
+        for (var i = 0; i < packedCtorCases().size(); i++) {
+            var packedCase = packedCtorCases().get(i);
+            var propertyName = "packed_prop_" + i;
+            clazz.addProperty(new LirPropertyDef(propertyName, packedCase.type()));
+            propertyCases.add(new PackedPropertyCase(propertyName, packedCase));
+        }
+
+        var module = new LirModule("test_module", List.of(clazz));
+        var codegen = newCodegen(module, List.of(clazz));
+        codegen.generate();
+
+        for (var propertyCase : propertyCases) {
+            var initFuncName = "_field_init_" + propertyCase.propertyName();
+            var initFunc = findFunctionByName(clazz, initFuncName);
+            assertNotNull(initFunc, () -> "Missing init function " + initFuncName);
+
+            var entryBlock = initFunc.getBasicBlock(initFunc.getEntryBlockId());
+            assertNotNull(entryBlock, () -> "Missing entry block in " + initFuncName);
+
+            var hasConstructArrayInsn = entryBlock.instructions().stream()
+                    .filter(ConstructArrayInsn.class::isInstance)
+                    .map(ConstructArrayInsn.class::cast)
+                    .anyMatch(insn -> insn.className() == null);
+            assertTrue(
+                    hasConstructArrayInsn,
+                    () -> "Field init function should use construct_array for " + propertyCase.packedCase().typeName()
+            );
+
+            var hasConstructBuiltinInsn = entryBlock.instructions().stream()
+                    .anyMatch(ConstructBuiltinInsn.class::isInstance);
+            assertFalse(
+                    hasConstructBuiltinInsn,
+                    () -> "Field init function should not use construct_builtin for " + propertyCase.packedCase().typeName()
+            );
+
+            var body = codegen.generateFuncBody(clazz, initFunc);
+            assertTrue(
+                    body.contains(propertyCase.packedCase().constructorCall()),
+                    () -> "Expected field init constructor call missing for " + propertyCase.packedCase().typeName() + ".\nBody:\n" + body
+            );
+        }
+    }
+
+    @Test
     @DisplayName("__prepare__ construct_array should fail fast on type mismatch")
     void prepareConstructArrayTypeMismatchShouldFailFast() {
         var clazz = newTestClass();
@@ -369,6 +493,29 @@ class CConstructInsnGenTest {
         assertTrue(ex.getMessage().contains("must not provide class_name"));
     }
 
+    private LirFunctionDef findFunctionByName(LirClassDef clazz, String functionName) {
+        for (var function : clazz.getFunctions()) {
+            if (functionName.equals(function.getName())) {
+                return function;
+            }
+        }
+        return null;
+    }
+
+    private List<PackedCtorCase> packedCtorCases() {
+        return List.of(
+                new PackedCtorCase("packed_byte", "PackedByteArray", GdPackedNumericArrayType.PACKED_BYTE_ARRAY),
+                new PackedCtorCase("packed_int32", "PackedInt32Array", GdPackedNumericArrayType.PACKED_INT32_ARRAY),
+                new PackedCtorCase("packed_int64", "PackedInt64Array", GdPackedNumericArrayType.PACKED_INT64_ARRAY),
+                new PackedCtorCase("packed_float32", "PackedFloat32Array", GdPackedNumericArrayType.PACKED_FLOAT32_ARRAY),
+                new PackedCtorCase("packed_float64", "PackedFloat64Array", GdPackedNumericArrayType.PACKED_FLOAT64_ARRAY),
+                new PackedCtorCase("packed_string", "PackedStringArray", GdPackedStringArrayType.PACKED_STRING_ARRAY),
+                new PackedCtorCase("packed_vector2", "PackedVector2Array", GdPackedVectorArrayType.PACKED_VECTOR2_ARRAY),
+                new PackedCtorCase("packed_vector3", "PackedVector3Array", GdPackedVectorArrayType.PACKED_VECTOR3_ARRAY),
+                new PackedCtorCase("packed_vector4", "PackedVector4Array", GdPackedVectorArrayType.PACKED_VECTOR4_ARRAY)
+        );
+    }
+
     private CCodegen newCodegen(LirModule module, List<LirClassDef> gdccClasses) {
         var classRegistry = new ClassRegistry(apiWithPackedConstructors());
         for (var gdccClass : gdccClasses) {
@@ -383,26 +530,42 @@ class CConstructInsnGenTest {
     }
 
     private ExtensionAPI apiWithPackedConstructors() {
-        var packedInt32ArrayClass = new ExtensionBuiltinClass(
-                "PackedInt32Array",
-                false,
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(new ExtensionBuiltinClass.ConstructorInfo("PackedInt32Array", 0, List.of())),
-                List.of(),
-                List.of()
-        );
+        var packedBuiltins = new ArrayList<ExtensionBuiltinClass>();
+        for (var packedCase : packedCtorCases()) {
+            packedBuiltins.add(newZeroArgPackedBuiltinClass(packedCase.typeName()));
+        }
         return new ExtensionAPI(
                 null,
                 List.of(),
                 List.of(),
                 List.of(),
                 List.of(),
-                List.of(packedInt32ArrayClass),
+                packedBuiltins,
                 List.of(),
                 List.of(),
                 List.of()
         );
+    }
+
+    private ExtensionBuiltinClass newZeroArgPackedBuiltinClass(String typeName) {
+        return new ExtensionBuiltinClass(
+                typeName,
+                false,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(new ExtensionBuiltinClass.ConstructorInfo(typeName, 0, List.of())),
+                List.of(),
+                List.of()
+        );
+    }
+
+    private record PackedCtorCase(String label, String typeName, GdType type) {
+        private String constructorCall() {
+            return "godot_new_" + typeName + "()";
+        }
+    }
+
+    private record PackedPropertyCase(String propertyName, PackedCtorCase packedCase) {
     }
 }

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CGenHelperTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CGenHelperTest.java
@@ -8,8 +8,11 @@ import dev.superice.gdcc.gdextension.ExtensionApiLoader;
 import dev.superice.gdcc.lir.LirClassDef;
 import dev.superice.gdcc.lir.LirFunctionDef;
 import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
 import dev.superice.gdcc.type.GdIntType;
 import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdPackedNumericArrayType;
+import dev.superice.gdcc.type.GdStringNameType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +24,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CGenHelperTest {
     private CGenHelper helper;
@@ -121,5 +125,59 @@ class CGenHelperTest {
         );
 
         assertInstanceOf(InvalidInsnException.class, ex);
+    }
+
+    @Test
+    @DisplayName("parseExtensionType should normalize typedarray PackedByteArray to packed type")
+    void parseExtensionTypeShouldNormalizeTypedarrayPackedByteArray() {
+        var parsed = helper.parseExtensionType(
+                "typedarray::PackedByteArray",
+                "test typedarray packed parameter"
+        );
+
+        assertEquals(GdPackedNumericArrayType.PACKED_BYTE_ARRAY, parsed);
+    }
+
+    @Test
+    @DisplayName("parseExtensionType should normalize typedarray StringName to Array[StringName]")
+    void parseExtensionTypeShouldNormalizeTypedarrayStringName() {
+        var parsed = helper.parseExtensionType(
+                "typedarray::StringName",
+                "test typedarray parameter"
+        );
+
+        assertEquals(new GdArrayType(GdStringNameType.STRING_NAME), parsed);
+    }
+
+    @Test
+    @DisplayName("parseExtensionType should normalize enum and bitfield metadata to int")
+    void parseExtensionTypeShouldNormalizeEnumAndBitfield() {
+        var enumType = helper.parseExtensionType("enum::Variant.Type", "test enum return type");
+        var bitfieldType = helper.parseExtensionType("bitfield::MethodFlags", "test bitfield parameter");
+
+        assertEquals(GdIntType.INT, enumType);
+        assertEquals(GdIntType.INT, bitfieldType);
+    }
+
+    @Test
+    @DisplayName("parseExtensionType should reject malformed typedarray metadata")
+    void parseExtensionTypeShouldRejectMalformedTypedarrayMetadata() {
+        var ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> helper.parseExtensionType("typedarray::   ", "test malformed typedarray")
+        );
+
+        assertTrue(ex.getMessage().contains("malformed typedarray metadata"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("parseExtensionType should reject unsupported metadata type")
+    void parseExtensionTypeShouldRejectUnsupportedMetadataType() {
+        var ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> helper.parseExtensionType("typedarray::Array[]", "test unsupported typedarray")
+        );
+
+        assertTrue(ex.getMessage().contains("unsupported type metadata"), ex.getMessage());
     }
 }


### PR DESCRIPTION
## What changed
- Added `construct_array` support for `GdPackedArrayType` in C backend instruction generation.
- Enforced fail-fast validation for packed array `class_name` misuse (including blank strings).
- Updated automatic initialization injection paths to emit `ConstructArrayInsn(varId, null)` for packed arrays in prepare/default init flows.
- Centralized extension type parsing logic into `CGenHelper.parseExtensionType(...)` and reused it from `MethodCallResolver`.
- Expanded and aligned docs for IR/type/backend semantics and added long-term maintenance doc:
  - `doc/module_impl/construct_array_implementation.md`

## Why
- Align backend behavior with `construct_array` semantics for `Array` vs `Packed*Array`.
- Keep packed-array construction defensive and explicit by rejecting unsupported `class_name` inputs early.
- Prevent parsing-rule drift by moving extension type parsing to a shared helper.
- Preserve maintainability by documenting routing constraints and invariants.

## Affected packages/files
- `dev.superice.gdcc.backend.c.gen`
- `dev.superice.gdcc.backend.c.gen.insn`
- `dev.superice.gdcc.lir.insn`
- `doc/` and `doc/module_impl/`

## Tests run
- `./gradlew.bat test --tests CConstructInsnGenTest --no-daemon --info --console=plain`
- `powershell -ExecutionPolicy Bypass -File script/run-gradle-targeted-tests.ps1 -Tests CConstructInsnGenEngineTest,CallMethodInsnGenTest,CGenHelperTest,CPhaseAControlFlowAndFinallyTest`
- `./gradlew.bat classes --no-daemon --info --console=plain`

All commands completed with `BUILD SUCCESSFUL`.