### PR TITLE
feat(backend): add indexing instruction codegen with ref-semantics engine coverage

### DIFF
--- a/doc/gdcc_c_backend.md
+++ b/doc/gdcc_c_backend.md
@@ -17,16 +17,41 @@
 - There are 3 types: built-in types, engine types, and GDCC types, see [gdcc_type_system.md](gdcc_type_system.md) for more details.
 - Engine types and GDCC types are all Objects, built-in types are not Objects.
 - Only `godot_bool`, `godot_int` and `godot_float` can be used directly as C primitive types, they are always passed by value.
+- Variable `ref` semantics in generated C (mandatory):
+  - LIR invariant:
+    - Function parameters are always `ref=true`.
+    - Function local variables are always `ref=false`.
+  - Primitive types (`godot_bool`, `godot_int`, `godot_float`) are always value types, regardless of `ref`.
+  - Object types are always pointer types, regardless of `ref`:
+    - Engine object types use `godot_<Type>*` / `GDExtensionObjectPtr`.
+    - GDCC object types use `<GdccClass>*`.
+  - Other built-in types are the only category affected by `ref`:
+    - `ref=true` means pointer type in C.
+    - `ref=false` means non-pointer value type in C.
+  - In short:
+    - Primitive types are always by value.
+    - Object types are always object pointers.
+    - Only other built-in types change C type shape based on `ref`.
 - For `String`, `StringName`, `NodePath`, `Callable`, `Signal`, `Packed*Array`:
-  - Though they are syntax passed by value, however the C implementation is a struct that hold an opaque pointer to the actual C++ class inside the engine.
-  - When passing them into functions, we need to pass their pointers of the struct.
+  - They are value-semantic wrapper structs that hold opaque engine-side state.
+  - Their C type shape follows the `ref` rule above:
+    - `ref=true` variable is a pointer to the wrapper struct.
+    - `ref=false` variable is the wrapper struct value itself.
+  - When a callee expects a pointer argument:
+    - pass `ref` variable directly (already a pointer),
+    - or pass `&` of a non-`ref` variable.
   - When returning them from functions, we need to return the struct by value.
   - When assigning them to variables or using them to call functions, we have to copy them using `godot_new_<TypeName>_with_<TypeName>(TypeName* value)`.
   - When a value of these types are no longer used, call `godot_destroy_<TypeName>(TypeName* value)` to destroy them properly.
 - For `Dictionary`, `Array` and `Variant`:
-  - They are passed by ref, however the C implementation is a struct that hold an opaque pointer and other stuff to the actual C++ class inside the engine.
-  - Though they are ref-counted, the passing and returning conventions are the same as `String` etc.
-  - We still need to pass their pointers when passing into functions, and return the struct by value when returning from functions.
+  - They are wrapper structs with shared/ref-counted internals (not raw C pointers).
+  - Their C type shape also follows the `ref` rule above:
+    - `ref=true` variable is pointer form.
+    - `ref=false` variable is struct value form.
+  - For pointer-typed call arguments, use the same rule as other built-ins:
+    - pass `ref` variable directly,
+    - or pass `&` of non-`ref` variable.
+  - Return value convention remains struct-by-value.
   - The copy function of these actually creates a new struct pointing to the same underlying C++ object, so we still need to use `godot_new_<TypeName>_with_<TypeName>(TypeName* value)` to copy them.
   - Destroying them using `godot_destroy_<TypeName>(TypeName* value)` is also needed which will decrease the reference count, and actually destroy the underlying C++ object only when the reference count reaches zero.
 - Especially for `Variant` & `Object`gdcc_object_from_godot_object_ptr the copy, construct and destroy function name use `variant` and `object` (lowercase).

--- a/doc/gdcc_low_ir.md
+++ b/doc/gdcc_low_ir.md
@@ -230,13 +230,13 @@ $<result_id> = variant_get_keyed $<keyed_variant_id> $<Variant>
 #### variant_get_named
 Gets a value from a named Variant (usually Object) by StringName.
 ```
-$<result_id> = variant_get_named $<named_variant_id> $<StringName>
+$<result_id> = variant_get_named $<named_variant_id> $<name_id:StringName>
 ```
 
 #### variant_get_indexed
-Sets a value in a Variant by int.
+Gets a value in a Variant by an int variable.
 ```
-$<result_id> = variant_get_indexed $<variant_id> $<int>
+$<result_id> = variant_get_indexed $<variant_id> $<index_id:int>
 ```
 
 #### variant_set
@@ -254,13 +254,13 @@ variant_set_keyed $<keyed_variant_id> $<key> $<value>
 #### variant_set_named
 Sets a value in a named Variant (usually Object) by StringName.
 ```
-variant_set_named $<named_variant_id> $<key:StringName> $<value>
+variant_set_named $<named_variant_id> $<name_id:StringName> $<value>
 ```
 
 #### variant_set_indexed
-Sets a value in a Variant by int.
+Sets a value in a Variant by an int variable.
 ```
-variant_set_indexed $<variant_id:Variant> $<index:int> $<value>
+variant_set_indexed $<variant_id> $<index_id:int> $<value>
 ```
 
 ### Type Instructions

--- a/doc/module_impl/index_insn_implementation.md
+++ b/doc/module_impl/index_insn_implementation.md
@@ -1,1027 +1,265 @@
-# IndexLoadInsnGen / IndexStoreInsnGen 实现计划
+# Indexing Instructions C Backend 实现说明（归档事实源）
 
-> 本文档为 Indexing Instructions 分类下 8 条 LIR 指令的 C Backend 代码生成器实施计划。
+> 本文档是 `variant_get*` / `variant_set*` 在 C Backend 的单一事实来源。  
+> 仅保留当前已落地语义、长期约定与风险边界；阶段性实施步骤与执行流水已归档移除。
 
 ## 文档状态
 
-- 状态：`Completed`
-- 文档类型：`实施计划`
-- 创建时间：`2026-03-04`
-- 适用范围：`backend.c` 中 8 条 `variant_get*` / `variant_set*` 指令的 C 代码生成
-- 当前进度：`✅ 步骤 1 已完成；✅ 步骤 2 已完成（IndexStoreInsnGen）；✅ 步骤 3 已完成（IndexLoad + IndexStore 注册）；✅ 步骤 4 已完成；✅ 步骤 5 已完成（IndexStoreInsnGenTest + 引擎锚定测试）；✅ 步骤 6 已完成（编译与回归验证）；✅ named/indexed 操作数模型修正（字面量 → VARIABLE）已完成；✅ returnDefault 抽取与调用点替换已完成；✅ ref self 放行策略已收敛（仅放行无需回写类型）；✅ ref key/value/index 约束已按最新语义放开并补齐回归测试`
+- 状态：`Active / 单一事实来源`
+- 更新时间：`2026-03-04`
+- 适用范围：
+  - `src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java`
+  - `src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexStoreInsnGen.java`
+  - `src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`
+- 关联文档：
+  - `doc/gdcc_c_backend.md`
+  - `doc/gdcc_type_system.md`
+  - `doc/gdextension-lite.md`
 
-## 1. 背景与目标
+---
 
-### 1.1 覆盖指令
+## 1. 覆盖范围与指令清单
 
-Indexing Instructions 分类包含 8 条指令，分为 Load（4 条 GET）和 Store（4 条 SET）两组：
+Indexing Instructions 共 8 条，分为 Load（GET）与 Store（SET）两类：
 
-| LIR 指令 | GdInstruction 枚举 | ReturnKind | 操作数签名 | 语义 |
+| LIR 指令 | GdInstruction | ReturnKind | 操作数签名 | 语义 |
 |---|---|---|---|---|
 | `variant_get` | `VARIANT_GET` | REQUIRED | `(VARIABLE, VARIABLE)` | 通用 Variant 键读取 |
 | `variant_get_keyed` | `VARIANT_GET_KEYED` | REQUIRED | `(VARIABLE, VARIABLE)` | 字典式键读取 |
-| `variant_get_named` | `VARIANT_GET_NAMED` | REQUIRED | `(VARIABLE, VARIABLE)` | 属性名读取（StringName 变量） |
-| `variant_get_indexed` | `VARIANT_GET_INDEXED` | REQUIRED | `(VARIABLE, VARIABLE)` | 整数索引读取（index 变量） |
+| `variant_get_named` | `VARIANT_GET_NAMED` | REQUIRED | `(VARIABLE, VARIABLE)` | 属性名读取（`StringName` 变量） |
+| `variant_get_indexed` | `VARIANT_GET_INDEXED` | REQUIRED | `(VARIABLE, VARIABLE)` | 整数索引读取（`int` 变量） |
 | `variant_set` | `VARIANT_SET` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 通用 Variant 键写入 |
 | `variant_set_keyed` | `VARIANT_SET_KEYED` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 字典式键写入 |
-| `variant_set_named` | `VARIANT_SET_NAMED` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 属性名写入（StringName 变量） |
-| `variant_set_indexed` | `VARIANT_SET_INDEXED` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 整数索引写入（index 变量） |
+| `variant_set_named` | `VARIANT_SET_NAMED` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 属性名写入（`StringName` 变量） |
+| `variant_set_indexed` | `VARIANT_SET_INDEXED` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 整数索引写入（`int` 变量） |
 
-### 1.2 LIR 指令类（已实现）
-
-所有 8 个 LIR 指令 record 类均已定义在 `src/main/java/dev/superice/gdcc/lir/insn/` 下：
-
-- `VariantGetInsn(resultId, variantId, keyId)` → `IndexingInstruction`
-- `VariantGetKeyedInsn(resultId, keyedVariantId, keyId)` → `IndexingInstruction`
-- `VariantGetNamedInsn(resultId, namedVariantId, nameId)` → `IndexingInstruction`
-- `VariantGetIndexedInsn(resultId, variantId, indexId)` → `IndexingInstruction`
-- `VariantSetInsn(variantId, keyId, valueId)` → `IndexingInstruction`
-- `VariantSetKeyedInsn(keyedVariantId, keyId, valueId)` → `IndexingInstruction`
-- `VariantSetNamedInsn(namedVariantId, nameId, valueId)` → `IndexingInstruction`
-- `VariantSetIndexedInsn(variantId, indexId, valueId)` → `IndexingInstruction`
-
-公共标记接口：`IndexingInstruction extends LirInstruction`。
-
-### 1.3 GDExtension C API 函数（gdextension-lite 已提供）
-
-所有 8 个 GDExtension C API 函数已通过 `gdextension-lite` 在 `extension_interface.h` 中声明可用：
-
-**GET 函数签名：**
-
-```c
-// variant_get / variant_get_keyed — 签名相同，内部行为不同
-void godot_variant_get(
-    GDExtensionConstVariantPtr p_self,
-    GDExtensionConstVariantPtr p_key,
-    GDExtensionUninitializedVariantPtr r_ret,
-    GDExtensionBool *r_valid);
-
-void godot_variant_get_keyed(
-    GDExtensionConstVariantPtr p_self,
-    GDExtensionConstVariantPtr p_key,
-    GDExtensionUninitializedVariantPtr r_ret,
-    GDExtensionBool *r_valid);
-
-void godot_variant_get_named(
-    GDExtensionConstVariantPtr p_self,
-    GDExtensionConstStringNamePtr p_key,
-    GDExtensionUninitializedVariantPtr r_ret,
-    GDExtensionBool *r_valid);
-
-void godot_variant_get_indexed(
-    GDExtensionConstVariantPtr p_self,
-    GDExtensionInt p_index,
-    GDExtensionUninitializedVariantPtr r_ret,
-    GDExtensionBool *r_valid,
-    GDExtensionBool *r_oob);          // ← 独有 out-of-bounds 标志
-```
-
-**SET 函数签名：**
-
-```c
-void godot_variant_set(
-    GDExtensionVariantPtr p_self,      // ← 可变
-    GDExtensionConstVariantPtr p_key,
-    GDExtensionConstVariantPtr p_value,
-    GDExtensionBool *r_valid);
-
-void godot_variant_set_keyed(
-    GDExtensionVariantPtr p_self,
-    GDExtensionConstVariantPtr p_key,
-    GDExtensionConstVariantPtr p_value,
-    GDExtensionBool *r_valid);
-
-void godot_variant_set_named(
-    GDExtensionVariantPtr p_self,
-    GDExtensionConstStringNamePtr p_key,
-    GDExtensionConstVariantPtr p_value,
-    GDExtensionBool *r_valid);
-
-void godot_variant_set_indexed(
-    GDExtensionVariantPtr p_self,
-    GDExtensionInt p_index,
-    GDExtensionConstVariantPtr p_value,
-    GDExtensionBool *r_valid,
-    GDExtensionBool *r_oob);          // ← 独有 out-of-bounds 标志
-```
-
-**关键差异汇总：**
-- GET 的 `p_self` 为 `Const`；SET 的 `p_self` 为可变。
-- GET 的返回值写入 `GDExtensionUninitializedVariantPtr r_ret`（未初始化输出参数）。
-- SET 的值通过 `GDExtensionConstVariantPtr p_value` 传入。
-- `_indexed` 变体多一个 `GDExtensionBool *r_oob` 输出参数。
-- `_named` 变体的 key 类型为 `GDExtensionConstStringNamePtr`，其余为 `GDExtensionConstVariantPtr` 或 `GDExtensionInt`。
-- 所有操作都通过 `Variant` 指针进行——调用方需确保操作数被 pack 为 Variant。
-
-### 1.4 设计目标
-
-1. 创建 `IndexLoadInsnGen`（处理 4 条 GET 指令）和 `IndexStoreInsnGen`（处理 4 条 SET 指令）。
-2. 遵循现有 `ConstructInsnGen` / `OperatorInsnGen` 的架构模式：直接实现 `CInsnGen<IndexingInstruction>`，使用 `CBodyBuilder` API。
-3. 在 `CCodegen` 中注册两个新生成器。
-4. 编写完整的单元测试。
-5. 核心约束：所有 Variant 操作数需要正确的生命周期管理（pack/unpack/destroy）。
+LIR 侧统一标记接口：`IndexingInstruction extends LirInstruction`。
 
 ---
 
-## 2. 架构设计
+## 2. 外部 API 契约（gdextension-lite）
 
-### 2.1 生成器拆分策略
+### 2.1 GET API 要点
 
-拆分为两个生成器而非一个统一生成器，原因：
+- `godot_variant_get` / `godot_variant_get_keyed`：
+  - `p_self: GDExtensionConstVariantPtr`
+  - `p_key: GDExtensionConstVariantPtr`
+  - `r_ret: GDExtensionUninitializedVariantPtr`
+  - `r_valid: GDExtensionBool*`
+- `godot_variant_get_named`：
+  - key 为 `GDExtensionConstStringNamePtr`
+- `godot_variant_get_indexed`：
+  - index 为 `GDExtensionInt`
+  - 额外输出 `r_oob: GDExtensionBool*`
 
-1. **返回值语义完全不同**：GET 有 `resultId`（REQUIRED），SET 没有（NONE）。
-2. **C API 参数模式不同**：GET 使用未初始化输出参数 `r_ret`；SET 使用输入参数 `p_value`。
-3. **操作数解析逻辑不同**：GET 读取键/索引 + 接收返回值；SET 读取键/索引 + 提供值。
-4. **生命周期管理不对称**：GET 需要管理返回的 Variant 的所有权；SET 需要管理传入的 value 的打包。
+### 2.2 SET API 要点
 
-```
-IndexLoadInsnGen  implements CInsnGen<IndexingInstruction>
-  ├── getInsnOpcodes(): {VARIANT_GET, VARIANT_GET_KEYED, VARIANT_GET_NAMED, VARIANT_GET_INDEXED}
-  └── generateCCode(CBodyBuilder): switch(insn) 分派 4 条 GET 指令
+- `godot_variant_set` / `godot_variant_set_keyed`：
+  - `p_self: GDExtensionVariantPtr`（可变）
+  - `p_key: GDExtensionConstVariantPtr`
+  - `p_value: GDExtensionConstVariantPtr`
+  - `r_valid: GDExtensionBool*`
+- `godot_variant_set_named`：
+  - key 为 `GDExtensionConstStringNamePtr`
+- `godot_variant_set_indexed`：
+  - index 为 `GDExtensionInt`
+  - 额外输出 `r_oob: GDExtensionBool*`
 
-IndexStoreInsnGen implements CInsnGen<IndexingInstruction>
-  ├── getInsnOpcodes(): {VARIANT_SET, VARIANT_SET_KEYED, VARIANT_SET_NAMED, VARIANT_SET_INDEXED}
-  └── generateCCode(CBodyBuilder): switch(insn) 分派 4 条 SET 指令
-```
+### 2.3 统一差异约束
 
-### 2.2 类型策略表（SET 的 self）
+1. GET 的返回值通过未初始化 out 参数 `r_ret` 传出；SET 无返回 Variant。
+2. `_indexed` 指令必须处理 `r_oob`。
+3. 所有调用都基于 Variant 指针语义；非 Variant 操作数需进行 pack/unpack。
 
-`variant_set*` 的关键不是“self 是否是 `GdVariantType`”，而是 **self 运行时 Variant 的可变语义**。  
-在实现层面，按下表对 self 进行分类并选择生成策略：
+---
 
-| self 类别 | 典型类型（gdcc） | 允许策略 | 是否需要 self 回写 |
+## 3. 架构与分工
+
+### 3.1 生成器拆分（长期约定）
+
+按 ReturnKind 拆分为两个生成器：
+
+1. `IndexLoadInsnGen` 负责 4 条 GET。
+2. `IndexStoreInsnGen` 负责 4 条 SET。
+
+拆分原因：
+
+1. 返回值语义不同（GET 必有 result，SET 无 result）。
+2. API 形态不同（GET `r_ret`，SET `p_value`）。
+3. 生命周期关注点不同（GET 管理返回 Variant；SET 管理 value/self pack 与写回）。
+
+### 3.2 注册入口
+
+- `CCodegen` 必须注册 `IndexLoadInsnGen` 与 `IndexStoreInsnGen`。
+- opcode 分发不允许落回默认路径。
+
+### 3.3 关键职责边界
+
+1. 生成器负责指令语义校验与 fail-fast。
+2. `CBodyBuilder` 负责参数渲染、赋值与生命周期通用语义。
+3. 错误分支统一使用 `CBodyBuilder.returnDefault()`，禁止生成器自行拼装默认返回表达式。
+
+---
+
+## 4. 操作数与类型策略（当前实现）
+
+### 4.1 named/indexed 建模约束
+
+1. `variant_get_named` / `variant_set_named` 的 key 必须是 `StringName` 变量。
+2. `variant_get_indexed` / `variant_set_indexed` 的 index 必须是 `int` 变量。
+3. 不再使用 named/indexed 字面量操作数模型，文本 IR 需保持 `$name` / `$idx` 形态。
+
+### 4.2 GET 操作数约束
+
+1. `result` 必须存在且必须是非 ref 变量。
+2. `self`、`key`（或 `name` / `index`）必须存在。
+3. `variant_get` / `variant_get_keyed` 的 `key` 允许任意类型（必要时 pack 为 Variant）。
+4. `variant_get_named` 的 `name` 必须是 `StringName`。
+5. `variant_get_indexed` 的 `index` 必须是 `int`，允许 ref/non-ref。
+
+### 4.3 SET 的 self 分类与回写策略
+
+`variant_set*` 的核心是 self 的语义类别，而非“是否声明为 `Variant`”。
+
+| self 类别 | 典型类型 | 处理策略 | ref 是否允许 |
 |---|---|---|---|
-| 已是 Variant 变量 | `GdVariantType` | 直接传 `&$self` 给 `godot_variant_set*` | 否 |
-| 引用语义容器/对象 | `GdArrayType` / `GdDictionaryType` / `GdObjectType` | 可临时 pack 为 Variant 后调用 set；底层对象共享，修改可见 | 否 |
-| 值语义但支持 set 的类型 | `GdStringType`、向量/颜色/矩阵等值类型、`GdPacked*ArrayType` | 临时 pack 后调用 set；随后必须 unpack 写回原 self 变量 | 是 |
-| 不支持 set 的类型 | `GdIntType`/`GdFloatType`/`GdBoolType`/`GdNilType`/`GdStringNameType`/`GdNodePathType`/`GdRidType`/`GdCallableType`/`GdSignalType`/`GdVoidType` | 编译期 fail-fast | - |
+| Variant | `GdVariantType` | 直接传入 | 允许 |
+| 引用语义 | `GdArrayType` / `GdDictionaryType` / `GdObjectType` | pack 后调用，无需回写 | 允许 |
+| 值语义且支持 set | 由 `resolveSelfStrategy` 判定（例如 `String` / `Vector*` / `Packed*Array` 等） | pack 后调用，必须 unpack 回写 | 仅 non-ref |
+| 不支持 set | 由 `isUnsupportedSetSelfType` 判定 | 编译期 fail-fast | 不适用 |
 
-> 注：`GDExtensionVariantPtr p_self` 仅表示“传入的是可变 Variant 指针”，不等价于“源 IR 变量必须是 `GdVariantType`”。
+补充约束（按指令模式）：
 
-### 2.3 指令能力矩阵（Godot runtime）
+1. `variant_set_keyed`：非 Variant self 必须是 `Object`/`Dictionary`。
+2. `variant_set_named`：非 Variant self 必须命中 named 支持集。
+3. `variant_set_indexed`：非 Variant self 必须命中 indexed 支持集。
+4. `ref` 且需要 writeback 的 self（例如 `ref Packed*Array`）必须 fail-fast。
 
-`variant_set*` 在 Godot 引擎内部并非对所有 Variant 类型都有效，能力如下：
+### 4.4 key/value/index 的 ref 语义（当前实现）
 
-| 指令 | 运行时有效 self（核心） | 说明 |
+1. `materializeVariantOperand` 已允许 key/value 为 ref 或 non-ref。
+2. 非 Variant key/value 在 ref 情况下同样允许 pack。
+3. indexed 的 `index:int` 在 GET/SET 两侧均允许 ref 或 non-ref。
+
+---
+
+## 5. 代码生成与生命周期规范
+
+### 5.1 GET 通用流程
+
+1. 校验 result/self/operand。
+2. 对 non-Variant `self`、`key` 执行 pack（如需）。
+3. 声明未初始化 `r_ret` 与 `r_valid`（indexed 额外 `r_oob`）。
+4. 发射 `godot_variant_get*`。
+5. 先检查 `r_valid`，indexed 再检查 `r_oob`。
+6. 成功路径将 `r_ret` 写回：
+   - `Variant -> Variant`：`godot_new_Variant_with_Variant` 构造拷贝回写。
+   - `Variant -> 非 Variant`：调用对应 unpack 函数回写。
+7. 所有路径必须销毁 `r_ret` 及 pack 临时变量。
+
+### 5.2 SET 通用流程
+
+1. 校验无 `resultId`。
+2. 校验并物化 self（含分类策略）。
+3. 处理 key/index/value（key/value 非 Variant 时 pack）。
+4. 发射 `godot_variant_set*`。
+5. 检查 `r_valid`（indexed 额外检查 `r_oob`）。
+6. 若 self 属于值语义写回路径，执行 unpack 回写。
+7. 所有路径销毁临时变量（value/key/self）。
+
+### 5.3 错误分支与资源销毁约束
+
+1. 失败分支必须先销毁当前已初始化临时变量，再 `returnDefault()`。
+2. 分支返回后需要恢复必要的临时变量初始化状态，避免后续路径析构语义被破坏。
+3. 运行时错误信息必须包含指令名与关键操作数 ID（`self/key/name/index/result/value`）。
+
+### 5.4 `r_ret` 专项约束
+
+1. `r_ret` 使用 `declareUninitializedTempVar` 声明。
+2. `r_valid=false` 路径下，`r_ret` 可能未初始化，需先置 `godot_new_Variant_nil()` 再销毁。
+3. `r_oob=true` 路径下，`r_ret` 已写入，直接销毁。
+
+---
+
+## 6. 运行时能力边界与防线
+
+### 6.1 引擎运行时能力（SET）
+
+| 指令 | 运行时核心适用 self | 说明 |
 |---|---|---|
-| `variant_set` | `Dictionary` / `Object`（keyed）；其余类型依 key 类型分派到 named/indexed | key 为 `StringName`/`String`/`int`/`float` 时可能转入 named/indexed 路径 |
-| `variant_set_keyed` | `Dictionary` / `Object` | 其他类型 `r_valid=false` |
-| `variant_set_named` | 支持命名成员的内建值类型、`Object`、`Dictionary` | 例如向量、颜色、变换、矩形、AABB、Plane 等 |
-| `variant_set_indexed` | 支持索引写入的类型 | 例如 `String`、向量、`Color`、`Transform2D`、`Basis`、`Projection`、`Array`、`Dictionary`、`Packed*Array` |
+| `variant_set` | `Dictionary` / `Object`（keyed）及按 key 分派到 named/indexed 的类型 | 语义由 key 形态与 self 共同决定 |
+| `variant_set_keyed` | `Dictionary` / `Object` | 其他类型通常 `r_valid=false` |
+| `variant_set_named` | 支持命名成员写入的值类型、`Object`、`Dictionary` | 常见如向量、颜色、变换等 |
+| `variant_set_indexed` | 支持索引写入的类型 | 常见如 `String`、`Array`、`Dictionary`、`Packed*Array` 等 |
 
-编译器策略：  
-1. 对“明确不支持 set”的 self 类型做编译期 fail-fast。  
-2. 对“可能支持但需运行时判定”的情况生成 `r_valid`/`r_oob` 检查，运行时兜底报错。
+### 6.2 编译期与运行时双层防线
 
-### 2.4 代码生成模式总览
+1. 编译期：对明确不支持 set 的 self 类型 fail-fast。
+2. 运行时：统一生成 `r_valid` / `r_oob` 检查兜底。
 
-#### 2.4.1 GET 指令通用生成模式
+### 6.3 ref 回写安全反思（长期有效）
 
-```
-1. 校验 resultId 存在且对应非 ref 变量
-2. 校验源 variant 变量存在
-3. 将源 variant 打包为 Variant（如非 Variant 类型）→ 创建临时变量
-4. 准备 key/index 参数
-5. 声明未初始化 Variant 临时变量作为 r_ret
-6. 声明 r_valid (GDExtensionBool)
-7. [仅 _indexed] 声明 r_oob (GDExtensionBool)
-8. 发射 godot_variant_get* 调用
-9. 发射 r_valid 检查 → 失败时打印运行时错误并安全返回
-10. [仅 _indexed] 发射 r_oob 检查 → 失败时打印运行时错误并安全返回
-11. 将 r_ret Variant 拆包到 result 变量（如果 result 不是 Variant 类型）
-12. 销毁 r_ret 临时 Variant
-13. 销毁步骤 3 中的临时打包 Variant（如有）
-```
-
-#### 2.4.2 SET 指令通用生成模式
-
-```
-1. 校验无 resultId（SET 指令 returnKind=NONE）
-2. 校验 self 变量存在，并判定 self 类型策略（直接 Variant / 引用语义 pack / 值语义 pack+回写 / 不支持）
-3. 准备 key/index 参数
-4. 将 value 打包为 Variant（如非 Variant 类型）→ 创建临时变量
-5. 声明 r_valid (GDExtensionBool)
-6. [仅 _indexed] 声明 r_oob (GDExtensionBool)
-7. 发射 godot_variant_set* 调用
-8. 发射 r_valid 检查 → 失败时打印运行时错误并安全返回
-9. [仅 _indexed] 发射 r_oob 检查 → 失败时打印运行时错误并安全返回
-10. 若 self 属于“值语义 pack+回写”策略：将修改后的临时 self Variant unpack 回原 self 变量
-11. 销毁临时 value Variant（如有）
-12. 销毁临时 self Variant（如有）
-```
-
-### 2.5 操作数类型约束
-
-#### GET 指令操作数约束
-
-| 指令 | self 操作数 | key/index 操作数 | result 变量 |
-|---|---|---|---|
-| `variant_get` | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 任意类型（unpack 自 Variant） |
-| `variant_get_keyed` | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 任意类型（unpack 自 Variant） |
-| `variant_get_named` | 任意类型（pack 为 Variant） | `StringName` 类型变量 | 任意类型（unpack 自 Variant） |
-| `variant_get_indexed` | 任意类型（pack 为 Variant） | `int` 类型变量 | 任意类型（unpack 自 Variant） |
-
-#### SET 指令操作数约束
-
-| 指令 | self 操作数 | key/index 操作数 | value 操作数 | 额外规则 |
-|---|---|---|---|---|
-| `variant_set` | `Variant` / 可 pack 且支持 set 的类型 | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 值语义 self 需回写；不支持类型 fail-fast |
-| `variant_set_keyed` | `Variant` / `Object` / `Dictionary`（或可 pack 到这些运行时类型） | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 非 keyed 支持类型 fail-fast |
-| `variant_set_named` | `Variant` / 支持 named-set 的类型 | `StringName` 类型变量 | 任意类型（pack 为 Variant） | 值语义 self 需回写 |
-| `variant_set_indexed` | `Variant` / 支持 indexed-set 的类型 | `int` 类型变量 | 任意类型（pack 为 Variant） | 值语义 self 需回写 |
-
-### 2.6 GET 指令的 Variant 打包/拆包策略
-
-GDExtension 的 variant_get* API 全部通过 Variant 指针操作。当 LIR 操作数不是 Variant 类型时，需要进行 pack/unpack 转换。
-
-**self 操作数 pack 策略（GET 的 p_self 为 const）：**
-- 如果 self 已经是 `GdVariantType`：直接取地址 `&$self`
-- 如果 self 不是 `GdVariantType`：创建临时 Variant，调用 `godot_new_Variant_with_<Type>` pack
-
-**key 操作数 pack 策略（仅 variant_get / variant_get_keyed）：**
-- 如果 key 已经是 `GdVariantType`：直接取地址 `&$key`
-- 如果 key 不是 `GdVariantType`：创建临时 Variant，pack
-
-**result unpack 策略：**
-- 如果 result 变量为 `GdVariantType`：直接通过 `callAssign` 以 `godot_new_Variant_with_Variant` 构造拷贝写回（遵循 OperatorInsnGen 的 Variant 回写规则）
-- 如果 result 变量为非 `GdVariantType`：调用 `godot_new_<Type>_with_Variant` unpack 到目标类型
-
-### 2.7 SET 指令的 self 回写策略
-
-对于 `variant_set*`：
-
-- `self` 为 `GdVariantType`：直接传 `&$self`，无需回写。
-- `self` 为引用语义类型（`Array`/`Dictionary`/`Object`）：可 pack 为临时 Variant，执行 set 后无需回写。
-- `self` 为 `Packed*Array`：按值语义处理，需要 writeback（`pack -> variant_set_indexed -> unpack`）。
-- `self` 为 `ref Packed*Array`：当前实现 fail-fast（需要 writeback，但 ref 目标不可安全回写）。
-- `self` 为值语义但支持 set 的类型（例如 `String`、向量、`Color`、`Transform2D`、`Basis`、`Projection` 等）：执行 set 后必须将临时 self Variant unpack 回原 self 变量。
-- `self` 为不支持 set 的类型：编译期 fail-fast，不生成调用。
-
-### 2.8 错误处理策略
-
-所有 GDExtension variant_get*/set* 调用都返回 `r_valid` 标志。`_indexed` 变体额外返回 `r_oob` 标志。
-
-**错误处理模式**（参照 `OperatorInsnGen` 的 `godot_variant_evaluate` 错误处理）：
-
-```c
-// 示例：variant_get 的错误处理
-godot_Variant __gdcc_tmp_idx_ret_0;
-GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
-godot_variant_get(&$self, &$key, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1);
-if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get failed: self=$self, key=$key, result=$result", __func__, __FILE__, __LINE__);
-    __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();  // 初始化以便安全析构
-    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
-    // 销毁临时 pack 变量...
-    return;  // 或 return 默认值
-}
-// ... 继续 unpack / 赋值
-```
-
-**`_indexed` 变体的额外 OOB 检查：**
-
-```c
-GDExtensionBool __gdcc_tmp_idx_oob_2 = false;
-godot_variant_get_indexed(&$self, index, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
-if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed failed: self=$self, index=$idx, result=$result", __func__, __FILE__, __LINE__);
-    // ... 安全返回
-}
-if (__gdcc_tmp_idx_oob_2) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed index out of bounds: index=$idx", __func__, __FILE__, __LINE__);
-    // ... 安全返回（此时 r_ret 已被写入，需销毁）
-}
-```
-
-**安全返回规则**（与 OperatorInsnGen 一致）：
-- 销毁所有已初始化的临时变量
-- 如果函数返回 void：`goto __finally__`
-- 如果函数返回非 void：`goto __finally__`（通过 `_return_val` 带默认值返回）
+1. Godot `call` 路径会先把参数解包到调用栈局部对象。
+2. 对 ref 值语义对象做直接写回存在不安全风险。
+3. 因此当前策略固定为：
+   - 放行“无需回写”的 ref self（`Variant`/`Array`/`Dictionary`/`Object`）。
+   - 拒绝“需要回写”的 ref self（如 `ref Packed*Array` 等）。
 
 ---
 
-## 3. 分步实施计划
+## 7. 测试基线与回归建议
 
-### 步骤 1：创建 IndexLoadInsnGen
+### 7.1 单元测试事实源
 
-**文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java`
-- 状态：`✅ 已完成（2026-03-04）`
+1. `src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java`
+2. `src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenTest.java`
+3. `src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java`（opcode 注册分发）
 
-**类结构**：
+### 7.2 引擎集成测试事实源
 
-```java
-public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
+`src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenEngineTest.java` 覆盖以下运行时锚点：
 
-    @Override
-    public @NotNull EnumSet<GdInstruction> getInsnOpcodes() {
-        return EnumSet.of(
-            GdInstruction.VARIANT_GET,
-            GdInstruction.VARIANT_GET_KEYED,
-            GdInstruction.VARIANT_GET_NAMED,
-            GdInstruction.VARIANT_GET_INDEXED
-        );
-    }
-
-    @Override
-    public void generateCCode(@NotNull CBodyBuilder bodyBuilder) {
-        var instruction = bodyBuilder.getCurrentInsn(this);
-        switch (instruction) {
-            case VariantGetInsn insn -> emitVariantGet(bodyBuilder, insn);
-            case VariantGetKeyedInsn insn -> emitVariantGetKeyed(bodyBuilder, insn);
-            case VariantGetNamedInsn insn -> emitVariantGetNamed(bodyBuilder, insn);
-            case VariantGetIndexedInsn insn -> emitVariantGetIndexed(bodyBuilder, insn);
-            default -> throw bodyBuilder.invalidInsn("Unsupported index load instruction: "
-                + instruction.getClass().getSimpleName());
-        }
-    }
-}
-```
-
-**实现要点**：
-
-1. **`resolveRequiredResultVariable`**：与 OperatorInsnGen 一致——校验 resultId 非空，变量存在且非 ref。
-2. **`resolveOperandVariable`**：按 variableId 查找操作数变量，不存在则 fail-fast。
-3. **`materializeVariantOperand`**：参照 OperatorInsnGen 的同名方法——如果操作数已是 Variant 则直接引用，否则创建临时 Variant 并 pack。
-4. **`emitVariantGet` / `emitVariantGetKeyed`**：
-   - 两者代码结构几乎相同（API 签名一致），仅 C 函数名不同（`godot_variant_get` vs `godot_variant_get_keyed`）。
-   - 可抽取公共方法 `emitVariantGetCommon(bodyBuilder, cFuncName, selfVar, keyVar, resultVar)`。
-5. **`emitVariantGetNamed`**：
-   - key 为 `StringName` 变量（`nameId`），按变量引用渲染参数（支持普通变量和 ref 变量）。
-   - C 调用为 `godot_variant_get_named(<self_arg>, <name_arg>, &r_ret, &r_valid)`。
-6. **`emitVariantGetIndexed`**：
-   - index 为 `int` 类型变量，使用 `bodyBuilder.renderArgument(...)` 渲染参数后作为 `(GDExtensionInt)<index_expr>` 传入。
-   - 额外声明 `r_oob` 标志并检查。
-7. **result 回写**：
-   - Variant→Variant：构造拷贝（`godot_new_Variant_with_Variant` + `callAssign`）。
-   - Variant→非 Variant：调用 unpack 函数（`bodyBuilder.helper().renderUnpackFunctionName(resultType)`）+ `callAssign`。
-8. **错误返回路径**：统一使用 `CBodyBuilder.returnDefault()`，并在分支代码生成后恢复临时变量初始化状态，保证后续路径仍能正确析构。
-
-#### 验收标准
-
-- [x] 编译通过，无 warning
-- [x] 4 条 GET 指令均可生成正确的 C 代码
-- [x] self 为 Variant 类型时无多余 pack/unpack
-- [x] self 为非 Variant 类型时正确 pack 并在结束后销毁
-- [x] key 为 Variant 类型时无多余 pack
-- [x] result 为 Variant 类型时使用构造拷贝回写
-- [x] result 为非 Variant 类型时正确 unpack
-- [x] r_valid 检查失败时正确打印错误并安全返回
-- [x] variant_get_indexed 的 r_oob 检查失败时正确打印错误并安全返回
-- [x] 所有临时变量在所有路径（正常/错误）上均被正确销毁
+1. ref self：`Array` / `Dictionary` set 后无需回写可读回。
+2. `PackedInt32Array`：局部写回路径正确读回。
+3. ref index/value：`variant_set_indexed` + `variant_get_indexed` 读写一致。
+4. ref key/value：`variant_set` + `variant_get` 读写一致。
+5. ref named：`variant_set_named` + `variant_get_named` 读写一致。
+6. ref String key/value：`variant_set_keyed` + `variant_get_keyed` 读写一致。
 
 ---
 
-### 步骤 2：创建 IndexStoreInsnGen
-
-**文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexStoreInsnGen.java`
-- 状态：`✅ 已完成（2026-03-04）`
-
-**类结构**：
-
-```java
-public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
-
-    @Override
-    public @NotNull EnumSet<GdInstruction> getInsnOpcodes() {
-        return EnumSet.of(
-            GdInstruction.VARIANT_SET,
-            GdInstruction.VARIANT_SET_KEYED,
-            GdInstruction.VARIANT_SET_NAMED,
-            GdInstruction.VARIANT_SET_INDEXED
-        );
-    }
-
-    @Override
-    public void generateCCode(@NotNull CBodyBuilder bodyBuilder) {
-        var instruction = bodyBuilder.getCurrentInsn(this);
-        switch (instruction) {
-            case VariantSetInsn insn -> emitVariantSet(bodyBuilder, insn);
-            case VariantSetKeyedInsn insn -> emitVariantSetKeyed(bodyBuilder, insn);
-            case VariantSetNamedInsn insn -> emitVariantSetNamed(bodyBuilder, insn);
-            case VariantSetIndexedInsn insn -> emitVariantSetIndexed(bodyBuilder, insn);
-            default -> throw bodyBuilder.invalidInsn("Unsupported index store instruction: "
-                + instruction.getClass().getSimpleName());
-        }
-    }
-}
-```
-
-**实现要点**：
-
-1. **self 分类与策略**：按 2.2 的策略将 self 分为：直接 Variant、引用语义 pack、值语义 pack+回写、不支持类型 fail-fast。
-2. **`materializeVariantValue`**：将 value 操作数打包为 Variant（如非 Variant 类型），使用 `renderPackFunctionName` + `callAssign` 到临时变量。
-3. **`emitVariantSet` / `emitVariantSetKeyed`**：
-   - 两者代码结构几乎相同，仅 C 函数名不同。
-   - key 打包策略与 GET 一致。
-   - 可抽取公共方法 `emitVariantSetCommon(bodyBuilder, cFuncName, selfVar, keyVar, valueVar)`。
-4. **`emitVariantSetNamed`**：
-   - key 为 `StringName` 类型变量（`nameId`），通过 `renderArgument` 渲染参数。
-5. **`emitVariantSetIndexed`**：
-   - index 为 `int` 类型变量。
-   - 额外声明并检查 `r_oob` 标志。
-6. **self 回写**：仅当 self 属于“值语义 pack+回写”策略时，将临时 self Variant unpack 回原 self 变量。
-7. **无 result 回写**：SET 指令 `ReturnKind=NONE`，无 resultId。
-8. **错误返回路径**：与 GET 一致。
-
-#### 验收标准
-
-- [x] 编译通过，无 warning
-- [x] 4 条 SET 指令均可生成正确的 C 代码
-- [x] self 分类策略正确：直接 Variant / 引用语义 pack / 值语义 pack+回写 / 不支持类型 fail-fast
-- [x] key 为 Variant 类型时无多余 pack
-- [x] value 为 Variant 类型时无多余 pack
-- [x] value 为非 Variant 类型时正确 pack 并在结束后销毁
-- [x] 值语义 self 在 set 后正确 unpack 回写
-- [x] r_valid 检查失败时正确打印错误并安全返回
-- [x] variant_set_indexed 的 r_oob 检查失败时正确打印错误并安全返回
-- [x] 所有临时变量在所有路径（正常/错误）上均被正确销毁
-- [x] 不意外设置 resultId（SET 不返回值）
-
----
-
-### 步骤 3：注册生成器到 CCodegen
-
-**文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`
-- 状态：`✅ 已完成（2026-03-04，已注册 IndexLoadInsnGen + IndexStoreInsnGen）`
-
-**修改内容**：在 static 块中添加两行注册：
-
-```java
-static {
-    // ... 现有注册 ...
-    registerInsnGen(new LoadStaticInsnGen());
-    registerInsnGen(new StoreStaticInsnGen());
-    // ↓ 新增
-    registerInsnGen(new IndexLoadInsnGen());
-    registerInsnGen(new IndexStoreInsnGen());
-}
-```
-
-**导入**：添加 `import dev.superice.gdcc.backend.c.gen.insn.IndexLoadInsnGen;` 和 `import dev.superice.gdcc.backend.c.gen.insn.IndexStoreInsnGen;`（如未使用通配符导入）。
-
-#### 验收标准
-
-- [x] 编译通过
-- [x] `INSN_GENS` 已包含 `IndexLoadInsnGen` 的 4 条 GET opcode 映射
-- [x] `INSN_GENS` 已包含 `IndexStoreInsnGen` 的 4 条 SET opcode 映射
-- [x] 不影响现有 15 个生成器的注册
-
-**同步单测更新**：
-- 在 `src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java` 新增 `variantGetOpcodeIsRegisteredAndGeneratesBody`，验证 `variant_get` 已通过 `CCodegen` 分发到 `IndexLoadInsnGen`。
-- 在 `src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java` 新增 `variantSetOpcodeIsRegisteredAndGeneratesBody`，验证 `variant_set` 已通过 `CCodegen` 分发到 `IndexStoreInsnGen`。
-
----
-
-### 步骤 4：创建 IndexLoadInsnGen 单元测试
-
-**文件**：`src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java`
-- 状态：`✅ 已完成（2026-03-04）`
-
-**测试类结构**（参照 `COperatorInsnGenTest` / `CConstructInsnGenTest` 模式）：
-
-```java
-class IndexLoadInsnGenTest {
-    // Helper methods: generateBody, newTestClass, newFunction, entry, newBodyBuilder, emptyApi
-    // Record: VariableSpec(String id, GdType type, boolean ref)
-}
-```
-
-**测试用例清单**：
-
-**variant_get 正向用例：**
-1. `variant_get_variant_key_variant_result` — self=Variant, key=Variant, result=Variant → 不需要 pack/unpack，生成 `godot_variant_get` 调用 + 构造拷贝回写
-2. `variant_get_non_variant_self_pack` — self=Array, key=Variant, result=Variant → self 需 pack
-3. `variant_get_non_variant_key_pack` — self=Variant, key=int, result=Variant → key 需 pack
-4. `variant_get_non_variant_result_unpack` — self=Variant, key=Variant, result=int → 需 unpack
-
-**variant_get 错误用例：**
-5. `variant_get_missing_result_fails` — resultId 为 null → `InvalidInsnException`
-6. `variant_get_ref_result_fails` — result 变量为 ref → `InvalidInsnException`
-7. `variant_get_missing_variant_operand_fails` — variantId 不存在 → `InvalidInsnException`
-8. `variant_get_missing_key_operand_fails` — keyId 不存在 → `InvalidInsnException`
-9. `variant_get_indexed_non_int_index_fails` — index 变量不是 int → `InvalidInsnException`
-
-**variant_get_keyed 正向用例：**
-9. `variant_get_keyed_basic` — 类似 variant_get，验证生成 `godot_variant_get_keyed`
-
-**variant_get_named 正向用例：**
-10. `variant_get_named_basic` — self=Variant, name=`$name:StringName`, result=Variant → 生成 `godot_variant_get_named`
-11. `variant_get_named_ref_name_var` — name 为 ref StringName 变量，参数应直接用 `$name_ref`（禁止多余 `&`）
-12. `variant_get_named_non_variant_self` — self=Dictionary, result=int → pack self, unpack result
-
-**variant_get_indexed 正向用例：**
-13. `variant_get_indexed_basic` — self=Variant, index=`$idx:int`, result=Variant → 生成 `godot_variant_get_indexed` + r_oob 检查
-14. `variant_get_indexed_ref_int_index` — self=Variant, index=ref int, result=Variant → index 允许 ref
-15. `variant_get_indexed_non_variant_self` — self=Array, index=`$idx:int`, result=int → pack self, unpack result
-
-**r_valid / r_oob 错误处理验证：**
-16. `variant_get_emits_valid_check` — 验证生成的代码包含 r_valid 检查和 GDCC_PRINT_RUNTIME_ERROR
-17. `variant_get_indexed_emits_oob_check` — 验证生成的代码包含 r_oob 检查
-18. `variant_get_invalid_branch_destroy_order` — 验证无效分支析构顺序（ret → key temp → self temp）
-19. `variant_get_indexed_oob_destroy_order` — 验证 OOB 分支析构顺序（ret → self temp）
-
-**生命周期验证：**
-20. `variant_get_destroys_temp_pack_vars` — 验证临时 pack Variant 被正确析构
-21. `variant_get_destroys_ret_variant` — 验证 r_ret Variant 被正确析构
-
-**否定断言（禁止多余 pack）**：
-22. `variant_get_variant_key_variant_result` — self/key 已是 Variant 时，断言不生成 `idx_self_variant`/`idx_key_variant` 临时 pack
-23. `variant_get_keyed_ref_key_var` — key 为 ref Variant 时，断言不生成 key 临时 pack
-
-#### 验收标准
-
-- [x] 全部测试用例通过
-- [x] 覆盖 4 种 GET 指令
-- [x] 覆盖 Variant/非 Variant self、key、result 组合
-- [x] 覆盖错误路径（缺失变量、ref 变量）
-- [x] 覆盖 r_valid 和 r_oob 检查
-- [x] 覆盖临时变量生命周期
-
----
-
-### 步骤 5：创建 IndexStoreInsnGen 单元测试
-
-**文件**：`src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenTest.java`
-- 状态：`✅ 已完成（2026-03-04）`
-
-**测试用例清单**：
-
-**variant_set 正向用例：**
-1. `variant_set_variant_key_variant_value` — self=Variant, key=Variant, value=Variant → 无 pack 开销
-2. `variant_set_non_variant_key_pack` — self=Variant, key=int, value=Variant → key 需 pack
-3. `variant_set_ref_int_key_pack` — self=Variant, key=ref int, value=Variant → key 允许 ref 并正确 pack
-4. `variant_set_non_variant_value_pack` — self=Variant, key=Variant, value=int → value 需 pack
-5. `variant_set_ref_string_value_pack` — self=Variant, key=Variant, value=ref String → value 允许 ref 并正确 pack
-6. `variant_set_array_self_pack_succeeds` — self=Array, key=int, value=Variant → self 允许 pack 且无需回写
-7. `variant_set_ref_dictionary_self_pack_succeeds_without_writeback` — self=ref Dictionary, key=int, value=Variant → self 允许 ref 且无需回写
-8. `variant_set_value_semantic_self_emits_writeback` — self=Vector3（或 Color），set 后应生成 unpack 回写
-
-**variant_set 错误用例：**
-1. `variant_set_unsupported_self_fails` — self=int（或 bool）→ `InvalidInsnException`
-2. `variant_set_missing_variant_operand_fails` — variantId 不存在 → `InvalidInsnException`
-3. `variant_set_missing_key_operand_fails` — keyId 不存在 → `InvalidInsnException`
-4. `variant_set_missing_value_operand_fails` — valueId 不存在 → `InvalidInsnException`
-
-**variant_set_keyed 正向用例：**
-1. `variant_set_keyed_basic` — 验证生成 `godot_variant_set_keyed`
-
-**variant_set_named 正向用例：**
-1. `variant_set_named_basic` — self=Variant, name=`$name:StringName`, value=Variant → 生成 `godot_variant_set_named`
-2. `variant_set_named_non_variant_value` — value=int → pack value
-
-**variant_set_named 错误用例：**
-1. `variant_set_named_unsupported_self_fails` — self=int（不支持 named-set）→ fail-fast
-
-**variant_set_indexed 正向用例：**
-1. `variant_set_indexed_basic` — self=Variant, index=`$idx:int`, value=Variant → 生成 `godot_variant_set_indexed` + r_oob 检查
-2. `variant_set_indexed_ref_int_index` — self=Variant, index=ref int, value=Variant → index 允许 ref
-3. `variant_set_indexed_non_variant_value` — value=int → pack value
-4. `variant_set_indexed_array_self_pack_succeeds` — self=Array, index=`$idx:int`, value=Variant → 引用语义路径
-5. `variant_set_indexed_ref_array_self_pack_succeeds` — self=ref Array, index=`$idx:int`, value=Variant → 允许 ref 且无需回写
-6. `variant_set_indexed_dictionary_self_pack_succeeds` — self=Dictionary, index=`$idx:int`, value=int → 引用语义路径
-7. `variant_set_indexed_packed_int32_self_writes_back` — self=PackedInt32Array（非 ref），验证 writeback 代码生成
-8. `variant_set_indexed_ref_packed_int32_self_fails` — self=ref PackedInt32Array，验证 fail-fast（requires writeback）
-
-**r_valid / r_oob 错误处理验证：**
-1. `variant_set_emits_valid_check` — 验证 r_valid 检查
-2. `variant_set_indexed_emits_oob_check` — 验证 r_oob 检查
-
-**生命周期验证：**
-1. `variant_set_destroys_temp_pack_vars` — 验证临时 pack 的 key/value Variant 被正确析构
-2. `variant_set_value_semantic_writeback_path_destroys_self_temp` — 验证值语义回写路径中的 self 临时 Variant 被正确析构
-3. `variant_set_ref_array_and_ref_dictionary_no_writeback` — 验证 ref Array/ref Dictionary 均可走“无回写”路径
-
-**引擎集成锚定：**
-1. `IndexStoreInsnGenEngineTest.index store ref semantics should read back correctly in real engine`
-2. 锚定点（ref self）：ref `Array` / ref `Dictionary` 无需回写即可读到更新；`Packed*Array` 采用局部变量 writeback 路径验证正确读回
-3. 锚定点（ref index/value）：`variant_set_indexed` 接收 ref `int` index + ref `int` value，运行时写入并读回一致
-4. 锚定点（ref key/value）：`variant_set` 接收 ref `int` key + ref `int` value，运行时写入并通过 `variant_get` 读回一致
-5. 锚定点（ref named）：`variant_set_named` / `variant_get_named` 在 ref `StringName` key + ref `int` value 下运行时读写一致
-6. 锚定点（ref String key/value）：`variant_set_keyed` / `variant_get_keyed` 在 ref `String` key + ref `String` value 下运行时读写一致
-
-#### 验收标准
-
-- [x] 全部测试用例通过
-- [x] 覆盖 4 种 SET 指令
-- [x] 覆盖 self 分类策略（直接 Variant / 引用语义 / 值语义回写 / 不支持类型）
-- [x] 覆盖 Variant/非 Variant key、value 组合
-- [x] 覆盖 ref key / ref value / ref index 组合（按最新 ref 语义）
-- [x] 覆盖错误路径
-- [x] 覆盖 r_valid 和 r_oob 检查
-- [x] 覆盖临时变量生命周期
-
----
-
-### 步骤 6：编译验证与现有测试回归
-- 状态：`✅ 已完成（2026-03-04，全部命令通过）`
-
-**执行命令**：
-
-```bash
-./gradlew classes --no-daemon --info --console=plain
-./gradlew test --tests IndexLoadInsnGenTest --no-daemon --info --console=plain
-./gradlew test --tests IndexStoreInsnGenTest --no-daemon --info --console=plain
-./gradlew test --tests CCodegenTest --no-daemon --info --console=plain
-./gradlew test --no-daemon --info --console=plain
-```
-
-**本次执行结果（2026-03-04）**：
-- ✅ `./gradlew classes --no-daemon --info --console=plain`
-- ✅ `./gradlew test --tests IndexLoadInsnGenTest --no-daemon --info --console=plain`
-- ✅ `./gradlew test --tests IndexStoreInsnGenTest --no-daemon --info --console=plain`
-- ✅ `./gradlew test --tests CCodegenTest --no-daemon --info --console=plain`
-- ✅ `./gradlew test --no-daemon --info --console=plain`
-
-**本轮补充验证（2026-03-04，ref 语义对齐）**：
-- ✅ `./gradlew test --tests IndexStoreInsnGenTest --no-daemon --info --console=plain`
-- ✅ `./gradlew test --tests IndexLoadInsnGenTest --no-daemon --info --console=plain`
-- ✅ `./gradlew test --tests IndexStoreInsnGenEngineTest --no-daemon --info --console=plain`
-- ✅ `./gradlew test --tests CCodegenTest --no-daemon --info --console=plain`
-- ✅ `./gradlew classes --no-daemon --info --console=plain`
-
-#### 验收标准
-
-- [x] 编译无错误
-- [x] 新增测试全部通过
-- [x] 现有测试无回归
-
----
-
-## 4. 生成的 C 代码示例
-
-### 4.1 variant_get（self=Variant, key=Variant, result=Variant）
-
-LIR:
-```
-$result = variant_get $dict $key
-```
-
-生成 C 代码：
-```c
-godot_Variant __gdcc_tmp_idx_ret_0;
-GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
-godot_variant_get(&$dict, &$key, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1);
-if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get failed", __func__, __FILE__, __LINE__);
-    __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();
-    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
-    goto __finally__;
-}
-$result = godot_new_Variant_with_Variant(&__gdcc_tmp_idx_ret_0);
-godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
-```
-
-### 4.2 variant_get（self=Array, key=int, result=String）
-
-LIR:
-```
-$result = variant_get $arr $idx
-```
-
-生成 C 代码：
-```c
-godot_Variant __gdcc_tmp_idx_self_0 = godot_new_Variant_with_Array(&$arr);
-godot_Variant __gdcc_tmp_idx_key_1 = godot_new_Variant_with_int($idx);
-godot_Variant __gdcc_tmp_idx_ret_2;
-GDExtensionBool __gdcc_tmp_idx_valid_3 = false;
-godot_variant_get(&__gdcc_tmp_idx_self_0, &__gdcc_tmp_idx_key_1, &__gdcc_tmp_idx_ret_2, &__gdcc_tmp_idx_valid_3);
-if (!__gdcc_tmp_idx_valid_3) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get failed", __func__, __FILE__, __LINE__);
-    __gdcc_tmp_idx_ret_2 = godot_new_Variant_nil();
-    godot_variant_destroy(&__gdcc_tmp_idx_ret_2);
-    godot_variant_destroy(&__gdcc_tmp_idx_key_1);
-    godot_variant_destroy(&__gdcc_tmp_idx_self_0);
-    goto __finally__;
-}
-$result = godot_new_String_with_Variant(&__gdcc_tmp_idx_ret_2);
-godot_variant_destroy(&__gdcc_tmp_idx_ret_2);
-godot_variant_destroy(&__gdcc_tmp_idx_key_1);
-godot_variant_destroy(&__gdcc_tmp_idx_self_0);
-```
-
-### 4.3 variant_get_named（self=Variant, name=$name:StringName, result=Vector3）
-
-LIR:
-```
-$result = variant_get_named $obj $name
-```
-
-生成 C 代码：
-```c
-godot_Variant __gdcc_tmp_idx_ret_0;
-GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
-godot_variant_get_named(&$obj, &$name, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1);
-if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_named failed: self=$obj, name=$name, result=$result", __func__, __FILE__, __LINE__);
-    __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();
-    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
-    goto __finally__;
-}
-$result = godot_new_Vector3_with_Variant(&__gdcc_tmp_idx_ret_0);
-godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
-```
-
-### 4.4 variant_get_indexed（self=Variant, index=$idx:int, result=Variant）
-
-LIR:
-```
-$result = variant_get_indexed $arr $idx
-```
-
-生成 C 代码：
-```c
-godot_Variant __gdcc_tmp_idx_ret_0;
-GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
-GDExtensionBool __gdcc_tmp_idx_oob_2 = false;
-godot_variant_get_indexed(&$arr, (GDExtensionInt)$idx, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
-if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed failed: self=$arr, index=$idx, result=$result", __func__, __FILE__, __LINE__);
-    __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();
-    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
-    goto __finally__;
-}
-if (__gdcc_tmp_idx_oob_2) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed index out of bounds: index=$idx", __func__, __FILE__, __LINE__);
-    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
-    goto __finally__;
-}
-$result = godot_new_Variant_with_Variant(&__gdcc_tmp_idx_ret_0);
-godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
-```
-
-### 4.5 variant_set（self=Variant, key=Variant, value=Variant）
-
-LIR:
-```
-variant_set $dict $key $value
-```
-
-生成 C 代码：
-```c
-GDExtensionBool __gdcc_tmp_idx_valid_0 = false;
-godot_variant_set(&$dict, &$key, &$value, &__gdcc_tmp_idx_valid_0);
-if (!__gdcc_tmp_idx_valid_0) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_set failed", __func__, __FILE__, __LINE__);
-    goto __finally__;
-}
-```
-
-### 4.6 variant_set_named（self=Variant, name=$name:StringName, value=int）
-
-LIR:
-```
-variant_set_named $obj $name $hp
-```
-
-生成 C 代码：
-```c
-godot_Variant __gdcc_tmp_idx_val_0 = godot_new_Variant_with_int($hp);
-GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
-godot_variant_set_named(&$obj, &$name, &__gdcc_tmp_idx_val_0, &__gdcc_tmp_idx_valid_1);
-if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_set_named failed: self=$obj, name=$name, value=$hp", __func__, __FILE__, __LINE__);
-    godot_variant_destroy(&__gdcc_tmp_idx_val_0);
-    goto __finally__;
-}
-godot_variant_destroy(&__gdcc_tmp_idx_val_0);
-```
-
-### 4.7 variant_set_indexed（self=Variant, index=$idx:int, value=int）
-
-LIR:
-```
-variant_set_indexed $arr $idx $val
-```
-
-生成 C 代码：
-```c
-godot_Variant __gdcc_tmp_idx_val_0 = godot_new_Variant_with_int($val);
-GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
-GDExtensionBool __gdcc_tmp_idx_oob_2 = false;
-godot_variant_set_indexed(&$arr, (GDExtensionInt)$idx, &__gdcc_tmp_idx_val_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
-if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_set_indexed failed: self=$arr, index=$idx, value=$val", __func__, __FILE__, __LINE__);
-    godot_variant_destroy(&__gdcc_tmp_idx_val_0);
-    goto __finally__;
-}
-if (__gdcc_tmp_idx_oob_2) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_set_indexed index out of bounds: index=$idx", __func__, __FILE__, __LINE__);
-    godot_variant_destroy(&__gdcc_tmp_idx_val_0);
-    goto __finally__;
-}
-godot_variant_destroy(&__gdcc_tmp_idx_val_0);
-```
-
----
-
-## 5. 关键实现锚点
+## 8. 关键实现锚点
 
 | 用途 | 文件路径 |
 |---|---|
 | CInsnGen 接口 | `src/main/java/dev/superice/gdcc/backend/c/gen/CInsnGen.java` |
-| CBodyBuilder（代码构建器） | `src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java` |
-| CGenHelper（类型渲染/pack-unpack 函数名） | `src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java` |
-| CCodegen（注册入口） | `src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java` |
-| IndexingInstruction 接口 | `src/main/java/dev/superice/gdcc/lir/insn/IndexingInstruction.java` |
-| GdInstruction 枚举 | `src/main/java/dev/superice/gdcc/enums/GdInstruction.java` |
-| OperatorInsnGen（参考：Variant evaluate 模式） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/OperatorInsnGen.java` |
-| ConstructInsnGen（参考：pattern match 分派） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java` |
-| C helper 头文件 | `src/main/c/codegen/include_451/gdcc/gdcc_helper.h` |
-| GDExtension C API 声明（gdextension-lite） | `tmp/inspect_gdlite/generated/extension_interface.h` |
+| CBodyBuilder | `src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java` |
+| CGenHelper | `src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java` |
+| CCodegen 注册入口 | `src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java` |
+| GET 生成器 | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java` |
+| SET 生成器 | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexStoreInsnGen.java` |
+| IndexingInstruction | `src/main/java/dev/superice/gdcc/lir/insn/IndexingInstruction.java` |
+| GdInstruction | `src/main/java/dev/superice/gdcc/enums/GdInstruction.java` |
+| 参考实现（Operator） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/OperatorInsnGen.java` |
+| 参考实现（Construct） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java` |
+| C Helper 头文件 | `src/main/c/codegen/include_451/gdcc/gdcc_helper.h` |
+| GDExtension 声明 | `tmp/inspect_gdlite/generated/extension_interface.h` |
 
 ---
 
-## 6. 关键 CBodyBuilder API 使用指南
+## 9. 非目标（当前不做）
 
-### 6.1 用于 GET 指令的核心 API
-
-```java
-// 获取当前指令（类型安全）
-var insn = bodyBuilder.getCurrentInsn(this);
-
-// 解析变量
-var resultVar = bodyBuilder.func().getVariableById(resultId);
-var selfVar = bodyBuilder.func().getVariableById(variantId);
-
-// 创建变量引用
-bodyBuilder.valueOfVar(variable)           // 读取变量值
-bodyBuilder.targetOfVar(variable)          // 写入目标
-
-// 临时变量（未初始化，用于 r_ret 输出参数）
-var retTemp = bodyBuilder.newTempVariable("idx_ret", GdVariantType.VARIANT);
-bodyBuilder.declareUninitializedTempVar(retTemp);
-
-// 临时变量（初始化，用于 r_valid 标志）
-var validTemp = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
-bodyBuilder.declareTempVar(validTemp);
-
-// Pack 操作（通过 callAssign 到临时变量）
-var packFunc = bodyBuilder.helper().renderPackFunctionName(selfVar.type());
-bodyBuilder.callAssign(selfTemp, packFunc, GdVariantType.VARIANT, List.of(bodyBuilder.valueOfVar(selfVar)));
-
-// Unpack 操作（通过 callAssign 到 result 目标）
-var unpackFunc = bodyBuilder.helper().renderUnpackFunctionName(resultVar.type());
-bodyBuilder.callAssign(bodyBuilder.targetOfVar(resultVar), unpackFunc, resultVar.type(), List.of(retTemp));
-
-// Variant 回写（构造拷贝）
-bodyBuilder.callAssign(bodyBuilder.targetOfVar(resultVar), "godot_new_Variant_with_Variant",
-    GdVariantType.VARIANT, List.of(retTemp));
-
-// 销毁临时变量
-bodyBuilder.destroyTempVar(retTemp);
-
-// StringName 变量参数
-var nameVarRef = bodyBuilder.valueOfVar(nameVar);
-
-// 统一参数渲染（避免在生成器中分散实现 & / ref / ptr 逻辑）
-var renderedArg = bodyBuilder.renderArgument(bodyBuilder.valueOfVar(selfVar), false);
-var selfArgCode = renderedArg.code();
-var renderedNameArg = bodyBuilder.renderArgument(nameVarRef, false);
-var nameArgCode = renderedNameArg.code();
-
-// 手动行发射（用于低级 C 调用和条件检查）
-bodyBuilder.appendLine("godot_variant_get(&..., &..., &..., &...);");
-bodyBuilder.appendLine("if (!__gdcc_tmp_idx_valid_0) {");
-
-// 错误报告
-bodyBuilder.appendLine("GDCC_PRINT_RUNTIME_ERROR(\"...\", __func__, __FILE__, __LINE__);");
-
-// 安全返回（统一）
-bodyBuilder.returnDefault();
-```
-
-### 6.2 `renderStaticStringNameLiteral` 用法
-
-```java
-// 在 CBodyBuilder 上有静态方法
-CBodyBuilder.renderStaticStringNameLiteral("property_name")
-// → GD_STATIC_SN(u8"property_name")
-```
-
-> 说明：Indexing 指令中的 `_named` 变体已改为 `StringName` 变量操作数，不再在生成器中使用静态字面量路径。
+1. 不新增或重构除 indexing 指令外的其他 LIR record。
+2. 不改动 `IndexingInstruction` 接口与 unrelated 枚举语义。
+3. 不在 `gdcc_helper.h` 新增 index 专用 C helper 包装（保持直接调用 gdextension-lite API）。
+4. 不在本轮扩展到 indexed/named 失败分支（`r_valid=false`/`r_oob=true`）的引擎级故障注入测试。
+5. 不引入 variant_get/set 结果类型的额外编译期强类型约束（依赖运行时 `r_valid` 与类型检查链路）。
 
 ---
 
-## 7. 风险与防线
+## 10. 工程反思（长期保留）
 
-### 7.1 风险：Variant 生命周期泄漏
-
-- **描述**：GET 指令的 `r_ret` 是未初始化 Variant 输出参数，GDExtension API 会写入一个新的 Variant。如果不在所有路径上销毁，会导致内存泄漏。
-- **防线**：
-  1. 正常路径：unpack 后立即销毁 `r_ret`。
-  2. 错误路径（r_valid=false）：先将 `r_ret` 赋为 `godot_new_Variant_nil()` 使其安全可析构，再销毁。
-  3. 错误路径（r_oob=true）：此时 `r_ret` 已被 API 写入有效值，直接销毁。
-  4. 单元测试显式验证生成代码中包含 `godot_variant_destroy` 调用。
-
-### 7.2 风险：SET 指令的 self 类型误用
-
-- **描述**：若不区分 self 的语义类别，容易出现两类问题：
-  1. 把不支持 set 的类型放进 `variant_set*`，导致运行时 `r_valid=false`；
-  2. 对值语义类型执行 set 后未回写，导致修改丢失。
-- **防线**：
-  1. IndexStoreInsnGen 在生成代码前执行 self 分类（Variant / 引用语义 / 值语义 / 不支持）。
-  2. 不支持类型编译期 fail-fast 并给出清晰错误信息。
-  3. 值语义路径强制执行 unpack 回写，并通过单元测试覆盖。
-
-### 7.5 风险：ref 参数在 call 路径下的回写安全性
-
-- **描述**：Godot `call` 路径会把参数解包到局部临时对象再传给绑定函数。对 `ref` 值语义类型直接写回会触发未定义行为风险（历史上对 `ref Packed*Array` 的直接回写出现过崩溃）。
-- **防线**：
-  1. 仅放行“无需回写”的 `ref self` 类型（`Variant` / `Array` / `Dictionary` / `Object`）。
-  2. 对“需要回写”的 `ref self`（例如 `ref Packed*Array`、`ref String`、`ref Vector*`）维持编译期 fail-fast。
-  3. 通过 `IndexStoreInsnGenEngineTest` 锚定运行时行为，避免回归到不安全路径。
-
-### 7.3 风险：`variant_get_indexed` / `variant_set_indexed` 的 r_oob 语义
-
-- **描述**：`_indexed` 变体在 r_valid=true 但 r_oob=true 时的行为需要明确。Godot 引擎在 OOB 时仍会写入 `r_ret`（对 GET 来说是默认值）。
-- **防线**：
-  1. 先检查 `r_valid`，再检查 `r_oob`，保持与 Godot 内部检查顺序一致。
-  2. OOB 时打印运行时错误并安全返回。
-  3. OOB 路径销毁 `r_ret`（因为 API 已写入值）。
-
-### 7.4 风险：与 OperatorInsnGen 的 Variant 回写策略不一致
-
-- **描述**：GET 指令的 result 回写必须与 OperatorInsnGen 的 `variant_evaluate` result 回写保持一致：Variant→Variant 使用构造拷贝，Variant→非 Variant 使用 unpack。
-- **防线**：
-  1. 实现代码直接参照 OperatorInsnGen 的 `emitBinaryVariantEvaluate` 中的回写模式。
-  2. 单元测试验证 Variant→Variant 路径生成 `godot_new_Variant_with_Variant`。
-
----
-
-## 8. 长期约定（实现后必须保持）
-
-### 8.1 SET 指令的 self 类型约束
-
-- `variant_set*` 指令的 self 按策略分类处理：`GdVariantType` 直传、引用语义类型可 pack、值语义类型 pack+回写。
-- `ref self` 仅允许“无需回写”类型（`Variant` / `Array` / `Dictionary` / `Object`）。
-- 所有非 ref self 均允许按策略生成（包含值语义 writeback 路径）。
-- `Packed*Array` 当前归类为“值语义 + 需要回写”；`ref Packed*Array` 编译期 fail-fast。
-- 对不支持 set 的类型保持编译期 fail-fast。
-- 该约定优先于“self 必须是 Variant”这一旧规则。
-
-### 8.2 GET 指令的 r_ret 生命周期
-
-- `r_ret` 使用 `declareUninitializedTempVar` 声明。
-- 所有代码路径（正常/错误）必须在退出前销毁 `r_ret`。
-- 错误路径中如果 `r_ret` 未被 API 写入（r_valid=false 时，Godot 可能未初始化 r_ret），需要先赋 `godot_new_Variant_nil()` 再销毁。
-
-### 8.3 生成器拆分维护
-
-- GET 和 SET 分属两个独立生成器（`IndexLoadInsnGen` / `IndexStoreInsnGen`）。
-- 如果未来增加新的 indexing 指令，按 ReturnKind（REQUIRED/NONE）分配到对应生成器。
-
-### 8.4 named/indexed 操作数建模
-
-- `variant_get_named` / `variant_set_named` 的 key 操作数必须是 `StringName` 变量（`VARIABLE`），不再使用字符串字面量操作数。
-- `variant_get_indexed` / `variant_set_indexed` 的 index 操作数必须是 `int` 变量（`VARIABLE`），不再使用整数字面量操作数。
-- 解析器与序列化器需保持该模型一致性，文本 IR 形态为 `$name` / `$idx`。
-
-### 8.5 运行时错误诊断信息
-
-- `GDCC_PRINT_RUNTIME_ERROR` 的消息必须包含足够上下文，至少带上指令名和关键操作数 ID（如 self/key/name/index/result/value）。
-- 禁止仅输出泛化字符串（如仅 `"... failed"`），避免诊断信息不足。
-
-### 8.6 默认返回策略
-
-- 生成器中的失败分支统一调用 `CBodyBuilder.returnDefault()`，禁止在生成器中重复拼装 `renderDefaultValueExpr(...)` 逻辑。
-- 若失败分支会临时析构变量，需要保证分支代码生成后不破坏后续路径的临时变量初始化状态。
-
----
-
-## 9. 回归测试基线
-
-### 9.1 新增测试文件
-
-- `src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java`
-- `src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenTest.java`
-- `src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenEngineTest.java`
-
-### 9.2 建议执行命令
-
-```bash
-# 编译
-./gradlew classes --no-daemon --info --console=plain
-
-# 新增测试
-./gradlew test --tests IndexLoadInsnGenTest --no-daemon --info --console=plain
-./gradlew test --tests IndexStoreInsnGenTest --no-daemon --info --console=plain
-
-# 回归测试
-./gradlew test --tests CCodegenTest --no-daemon --info --console=plain
-./gradlew test --tests COperatorInsnGenTest --no-daemon --info --console=plain
-./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain
-
-# 全量测试
-./gradlew test --no-daemon --info --console=plain
-```
-
----
-
-## 10. 非目标（当前不做）
-
-- 不新增/重构除 named/indexed 操作数建模修正外的其他 LIR `IndexingInstruction` record。
-- 不修改除 named/indexed operand pattern 修正外的其他 `GdInstruction` 枚举定义。
-- 不修改 `IndexingInstruction` 接口。
-- 不在 `gdcc_helper.h` 中添加 C helper 包装函数（直接使用 gdextension-lite 提供的 API）。
-- 不在本轮扩展到“所有 indexed/named 失败分支（如 `r_valid=false`/`r_oob=true`）的引擎级故障注入测试”；当前引擎集成测试以 ref 语义主路径正确性锚定为目标。
-- 不处理 variant_get*/set* 结果类型的编译期类型检查（运行时 r_valid 检查已足够）。
+1. Indexing 指令最容易出错的点不是调用语句本身，而是 Variant 生命周期与错误分支析构对称性。
+2. `ref` 语义与“是否需要 writeback”必须分离看待：ref 并不自动等价可安全回写。
+3. named/indexed 必须坚持变量操作数模型，避免字面量模型与解析器/序列化器再次漂移。
+4. 文档应长期保持“当前事实 + 长期约定 + 风险边界”，不再回填实施流水，避免事实源失真。

--- a/doc/module_impl/index_insn_implementation.md
+++ b/doc/module_impl/index_insn_implementation.md
@@ -4,10 +4,11 @@
 
 ## 文档状态
 
-- 状态：`Plan / Pending`
+- 状态：`Plan / In Progress`
 - 文档类型：`实施计划`
 - 创建时间：`2026-03-04`
 - 适用范围：`backend.c` 中 8 条 `variant_get*` / `variant_set*` 指令的 C 代码生成
+- 当前进度：`✅ 步骤 1 已完成；✅ 步骤 3 已完成（IndexLoad 注册）；✅ 步骤 4 已完成；✅ named/indexed 操作数模型修正（字面量 → VARIABLE）已完成；✅ returnDefault 抽取与调用点替换已完成；步骤 2/5/6 待执行`
 
 ## 1. 背景与目标
 
@@ -19,12 +20,12 @@ Indexing Instructions 分类包含 8 条指令，分为 Load（4 条 GET）和 S
 |---|---|---|---|---|
 | `variant_get` | `VARIANT_GET` | REQUIRED | `(VARIABLE, VARIABLE)` | 通用 Variant 键读取 |
 | `variant_get_keyed` | `VARIANT_GET_KEYED` | REQUIRED | `(VARIABLE, VARIABLE)` | 字典式键读取 |
-| `variant_get_named` | `VARIANT_GET_NAMED` | REQUIRED | `(VARIABLE, STRING)` | 属性名读取（StringName） |
-| `variant_get_indexed` | `VARIANT_GET_INDEXED` | REQUIRED | `(VARIABLE, INT)` | 整数索引读取 |
+| `variant_get_named` | `VARIANT_GET_NAMED` | REQUIRED | `(VARIABLE, VARIABLE)` | 属性名读取（StringName 变量） |
+| `variant_get_indexed` | `VARIANT_GET_INDEXED` | REQUIRED | `(VARIABLE, VARIABLE)` | 整数索引读取（index 变量） |
 | `variant_set` | `VARIANT_SET` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 通用 Variant 键写入 |
 | `variant_set_keyed` | `VARIANT_SET_KEYED` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 字典式键写入 |
-| `variant_set_named` | `VARIANT_SET_NAMED` | NONE | `(VARIABLE, STRING, VARIABLE)` | 属性名写入（StringName） |
-| `variant_set_indexed` | `VARIANT_SET_INDEXED` | NONE | `(VARIABLE, INT, VARIABLE)` | 整数索引写入 |
+| `variant_set_named` | `VARIANT_SET_NAMED` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 属性名写入（StringName 变量） |
+| `variant_set_indexed` | `VARIANT_SET_INDEXED` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 整数索引写入（index 变量） |
 
 ### 1.2 LIR 指令类（已实现）
 
@@ -32,12 +33,12 @@ Indexing Instructions 分类包含 8 条指令，分为 Load（4 条 GET）和 S
 
 - `VariantGetInsn(resultId, variantId, keyId)` → `IndexingInstruction`
 - `VariantGetKeyedInsn(resultId, keyedVariantId, keyId)` → `IndexingInstruction`
-- `VariantGetNamedInsn(resultId, namedVariantId, name)` → `IndexingInstruction`
-- `VariantGetIndexedInsn(resultId, variantId, index)` → `IndexingInstruction`
+- `VariantGetNamedInsn(resultId, namedVariantId, nameId)` → `IndexingInstruction`
+- `VariantGetIndexedInsn(resultId, variantId, indexId)` → `IndexingInstruction`
 - `VariantSetInsn(variantId, keyId, valueId)` → `IndexingInstruction`
 - `VariantSetKeyedInsn(keyedVariantId, keyId, valueId)` → `IndexingInstruction`
-- `VariantSetNamedInsn(namedVariantId, name, valueId)` → `IndexingInstruction`
-- `VariantSetIndexedInsn(variantId, index, valueId)` → `IndexingInstruction`
+- `VariantSetNamedInsn(namedVariantId, nameId, valueId)` → `IndexingInstruction`
+- `VariantSetIndexedInsn(variantId, indexId, valueId)` → `IndexingInstruction`
 
 公共标记接口：`IndexingInstruction extends LirInstruction`。
 
@@ -217,8 +218,8 @@ IndexStoreInsnGen implements CInsnGen<IndexingInstruction>
 |---|---|---|---|
 | `variant_get` | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 任意类型（unpack 自 Variant） |
 | `variant_get_keyed` | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 任意类型（unpack 自 Variant） |
-| `variant_get_named` | 任意类型（pack 为 Variant） | STRING 字面量 → StringName | 任意类型（unpack 自 Variant） |
-| `variant_get_indexed` | 任意类型（pack 为 Variant） | INT 字面量 | 任意类型（unpack 自 Variant） |
+| `variant_get_named` | 任意类型（pack 为 Variant） | `StringName` 类型变量 | 任意类型（unpack 自 Variant） |
+| `variant_get_indexed` | 任意类型（pack 为 Variant） | `int` 类型变量 | 任意类型（unpack 自 Variant） |
 
 #### SET 指令操作数约束
 
@@ -226,8 +227,8 @@ IndexStoreInsnGen implements CInsnGen<IndexingInstruction>
 |---|---|---|---|---|
 | `variant_set` | `Variant` / 可 pack 且支持 set 的类型 | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 值语义 self 需回写；不支持类型 fail-fast |
 | `variant_set_keyed` | `Variant` / `Object` / `Dictionary`（或可 pack 到这些运行时类型） | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 非 keyed 支持类型 fail-fast |
-| `variant_set_named` | `Variant` / 支持 named-set 的类型 | STRING 字面量 → StringName | 任意类型（pack 为 Variant） | 值语义 self 需回写 |
-| `variant_set_indexed` | `Variant` / 支持 indexed-set 的类型 | INT 字面量 | 任意类型（pack 为 Variant） | 值语义 self 需回写 |
+| `variant_set_named` | `Variant` / 支持 named-set 的类型 | `StringName` 类型变量 | 任意类型（pack 为 Variant） | 值语义 self 需回写 |
+| `variant_set_indexed` | `Variant` / 支持 indexed-set 的类型 | `int` 类型变量 | 任意类型（pack 为 Variant） | 值语义 self 需回写 |
 
 ### 2.6 GET 指令的 Variant 打包/拆包策略
 
@@ -266,7 +267,7 @@ godot_Variant __gdcc_tmp_idx_ret_0;
 GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
 godot_variant_get(&$self, &$key, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1);
 if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get failed", __func__, __FILE__, __LINE__);
+    GDCC_PRINT_RUNTIME_ERROR("variant_get failed: self=$self, key=$key, result=$result", __func__, __FILE__, __LINE__);
     __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();  // 初始化以便安全析构
     godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
     // 销毁临时 pack 变量...
@@ -281,11 +282,11 @@ if (!__gdcc_tmp_idx_valid_1) {
 GDExtensionBool __gdcc_tmp_idx_oob_2 = false;
 godot_variant_get_indexed(&$self, index, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
 if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed failed", __func__, __FILE__, __LINE__);
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed failed: self=$self, index=$idx, result=$result", __func__, __FILE__, __LINE__);
     // ... 安全返回
 }
 if (__gdcc_tmp_idx_oob_2) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed: index out of bounds", __func__, __FILE__, __LINE__);
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed index out of bounds: index=$idx", __func__, __FILE__, __LINE__);
     // ... 安全返回（此时 r_ret 已被写入，需销毁）
 }
 ```
@@ -302,6 +303,7 @@ if (__gdcc_tmp_idx_oob_2) {
 ### 步骤 1：创建 IndexLoadInsnGen
 
 **文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java`
+- 状态：`✅ 已完成（2026-03-04）`
 
 **类结构**：
 
@@ -342,28 +344,28 @@ public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
    - 两者代码结构几乎相同（API 签名一致），仅 C 函数名不同（`godot_variant_get` vs `godot_variant_get_keyed`）。
    - 可抽取公共方法 `emitVariantGetCommon(bodyBuilder, cFuncName, selfVar, keyVar, resultVar)`。
 5. **`emitVariantGetNamed`**：
-   - key 为 STRING 字面量，使用 `bodyBuilder.valueOfStringNamePtrLiteral(name)` 生成静态 StringName 指针。
-   - C 调用为 `godot_variant_get_named(&self_variant, GD_STATIC_SN(u8"name"), &r_ret, &r_valid)`。
+   - key 为 `StringName` 变量（`nameId`），按变量引用渲染参数（支持普通变量和 ref 变量）。
+   - C 调用为 `godot_variant_get_named(<self_arg>, <name_arg>, &r_ret, &r_valid)`。
 6. **`emitVariantGetIndexed`**：
-   - index 为 INT 字面量，直接作为 `(GDExtensionInt)index` 传入。
+   - index 为 `int` 类型变量，使用 `bodyBuilder.renderArgument(...)` 渲染参数后作为 `(GDExtensionInt)<index_expr>` 传入。
    - 额外声明 `r_oob` 标志并检查。
 7. **result 回写**：
    - Variant→Variant：构造拷贝（`godot_new_Variant_with_Variant` + `callAssign`）。
    - Variant→非 Variant：调用 unpack 函数（`bodyBuilder.helper().renderUnpackFunctionName(resultType)`）+ `callAssign`。
-8. **错误返回路径**：使用与 OperatorInsnGen 一致的模式——销毁临时变量后 return void 或 return 默认值。
+8. **错误返回路径**：统一使用 `CBodyBuilder.returnDefault()`，并在分支代码生成后恢复临时变量初始化状态，保证后续路径仍能正确析构。
 
 #### 验收标准
 
-- [ ] 编译通过，无 warning
-- [ ] 4 条 GET 指令均可生成正确的 C 代码
-- [ ] self 为 Variant 类型时无多余 pack/unpack
-- [ ] self 为非 Variant 类型时正确 pack 并在结束后销毁
-- [ ] key 为 Variant 类型时无多余 pack
-- [ ] result 为 Variant 类型时使用构造拷贝回写
-- [ ] result 为非 Variant 类型时正确 unpack
-- [ ] r_valid 检查失败时正确打印错误并安全返回
-- [ ] variant_get_indexed 的 r_oob 检查失败时正确打印错误并安全返回
-- [ ] 所有临时变量在所有路径（正常/错误）上均被正确销毁
+- [x] 编译通过，无 warning
+- [x] 4 条 GET 指令均可生成正确的 C 代码
+- [x] self 为 Variant 类型时无多余 pack/unpack
+- [x] self 为非 Variant 类型时正确 pack 并在结束后销毁
+- [x] key 为 Variant 类型时无多余 pack
+- [x] result 为 Variant 类型时使用构造拷贝回写
+- [x] result 为非 Variant 类型时正确 unpack
+- [x] r_valid 检查失败时正确打印错误并安全返回
+- [x] variant_get_indexed 的 r_oob 检查失败时正确打印错误并安全返回
+- [x] 所有临时变量在所有路径（正常/错误）上均被正确销毁
 
 ---
 
@@ -410,9 +412,9 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
    - key 打包策略与 GET 一致。
    - 可抽取公共方法 `emitVariantSetCommon(bodyBuilder, cFuncName, selfVar, keyVar, valueVar)`。
 4. **`emitVariantSetNamed`**：
-   - key 为 STRING 字面量，生成静态 StringName 指针。
+   - key 为 `StringName` 类型变量（`nameId`），通过 `renderArgument` 渲染参数。
 5. **`emitVariantSetIndexed`**：
-   - index 为 INT 字面量。
+   - index 为 `int` 类型变量。
    - 额外声明并检查 `r_oob` 标志。
 6. **self 回写**：仅当 self 属于“值语义 pack+回写”策略时，将临时 self Variant unpack 回原 self 变量。
 7. **无 result 回写**：SET 指令 `ReturnKind=NONE`，无 resultId。
@@ -437,6 +439,7 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
 ### 步骤 3：注册生成器到 CCodegen
 
 **文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`
+- 状态：`✅ 已完成（2026-03-04，已注册 IndexLoadInsnGen）`
 
 **修改内容**：在 static 块中添加两行注册：
 
@@ -455,21 +458,27 @@ static {
 
 #### 验收标准
 
-- [ ] 编译通过
-- [ ] `INSN_GENS` 包含 8 条新的 opcode → generator 映射
-- [ ] 不影响现有 15 个生成器的注册
+- [x] 编译通过
+- [x] `INSN_GENS` 已包含 `IndexLoadInsnGen` 的 4 条 GET opcode 映射
+- [x] 不影响现有 15 个生成器的注册
+
+> 注：`IndexStoreInsnGen` 的注册将在步骤 2 完成后补充。
+
+**同步单测更新**：
+- 在 `src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java` 新增 `variantGetOpcodeIsRegisteredAndGeneratesBody`，验证 `variant_get` 已通过 `CCodegen` 分发到 `IndexLoadInsnGen`。
 
 ---
 
 ### 步骤 4：创建 IndexLoadInsnGen 单元测试
 
 **文件**：`src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java`
+- 状态：`✅ 已完成（2026-03-04）`
 
 **测试类结构**（参照 `COperatorInsnGenTest` / `CConstructInsnGenTest` 模式）：
 
 ```java
 class IndexLoadInsnGenTest {
-    // Helper methods: generateBody, newTestClass, newFunction, entry, newCodegen, emptyApi
+    // Helper methods: generateBody, newTestClass, newFunction, entry, newBodyBuilder, emptyApi
     // Record: VariableSpec(String id, GdType type, boolean ref)
 }
 ```
@@ -487,34 +496,42 @@ class IndexLoadInsnGenTest {
 6. `variant_get_ref_result_fails` — result 变量为 ref → `InvalidInsnException`
 7. `variant_get_missing_variant_operand_fails` — variantId 不存在 → `InvalidInsnException`
 8. `variant_get_missing_key_operand_fails` — keyId 不存在 → `InvalidInsnException`
+9. `variant_get_indexed_non_int_index_fails` — index 变量不是 int → `InvalidInsnException`
 
 **variant_get_keyed 正向用例：**
 9. `variant_get_keyed_basic` — 类似 variant_get，验证生成 `godot_variant_get_keyed`
 
 **variant_get_named 正向用例：**
-10. `variant_get_named_basic` — self=Variant, name="property", result=Variant → 生成 `godot_variant_get_named` + `GD_STATIC_SN`
-11. `variant_get_named_non_variant_self` — self=Dictionary, result=int → pack self, unpack result
+10. `variant_get_named_basic` — self=Variant, name=`$name:StringName`, result=Variant → 生成 `godot_variant_get_named`
+11. `variant_get_named_ref_name_var` — name 为 ref StringName 变量，参数应直接用 `$name_ref`（禁止多余 `&`）
+12. `variant_get_named_non_variant_self` — self=Dictionary, result=int → pack self, unpack result
 
 **variant_get_indexed 正向用例：**
-12. `variant_get_indexed_basic` — self=Variant, index=0, result=Variant → 生成 `godot_variant_get_indexed` + r_oob 检查
-13. `variant_get_indexed_non_variant_self` — self=Array, index=2, result=int → pack self, unpack result
+13. `variant_get_indexed_basic` — self=Variant, index=`$idx:int`, result=Variant → 生成 `godot_variant_get_indexed` + r_oob 检查
+14. `variant_get_indexed_non_variant_self` — self=Array, index=`$idx:int`, result=int → pack self, unpack result
 
 **r_valid / r_oob 错误处理验证：**
-14. `variant_get_emits_valid_check` — 验证生成的代码包含 r_valid 检查和 GDCC_PRINT_RUNTIME_ERROR
-15. `variant_get_indexed_emits_oob_check` — 验证生成的代码包含 r_oob 检查
+15. `variant_get_emits_valid_check` — 验证生成的代码包含 r_valid 检查和 GDCC_PRINT_RUNTIME_ERROR
+16. `variant_get_indexed_emits_oob_check` — 验证生成的代码包含 r_oob 检查
+17. `variant_get_invalid_branch_destroy_order` — 验证无效分支析构顺序（ret → key temp → self temp）
+18. `variant_get_indexed_oob_destroy_order` — 验证 OOB 分支析构顺序（ret → self temp）
 
 **生命周期验证：**
-16. `variant_get_destroys_temp_pack_vars` — 验证临时 pack Variant 被正确析构
-17. `variant_get_destroys_ret_variant` — 验证 r_ret Variant 被正确析构
+19. `variant_get_destroys_temp_pack_vars` — 验证临时 pack Variant 被正确析构
+20. `variant_get_destroys_ret_variant` — 验证 r_ret Variant 被正确析构
+
+**否定断言（禁止多余 pack）**：
+21. `variant_get_variant_key_variant_result` — self/key 已是 Variant 时，断言不生成 `idx_self_variant`/`idx_key_variant` 临时 pack
+22. `variant_get_keyed_ref_key_var` — key 为 ref Variant 时，断言不生成 key 临时 pack
 
 #### 验收标准
 
-- [ ] 全部测试用例通过
-- [ ] 覆盖 4 种 GET 指令
-- [ ] 覆盖 Variant/非 Variant self、key、result 组合
-- [ ] 覆盖错误路径（缺失变量、ref 变量）
-- [ ] 覆盖 r_valid 和 r_oob 检查
-- [ ] 覆盖临时变量生命周期
+- [x] 全部测试用例通过
+- [x] 覆盖 4 种 GET 指令
+- [x] 覆盖 Variant/非 Variant self、key、result 组合
+- [x] 覆盖错误路径（缺失变量、ref 变量）
+- [x] 覆盖 r_valid 和 r_oob 检查
+- [x] 覆盖临时变量生命周期
 
 ---
 
@@ -541,16 +558,16 @@ class IndexLoadInsnGenTest {
 1. `variant_set_keyed_basic` — 验证生成 `godot_variant_set_keyed`
 
 **variant_set_named 正向用例：**
-1. `variant_set_named_basic` — self=Variant, name="property", value=Variant → 生成 `godot_variant_set_named` + `GD_STATIC_SN`
+1. `variant_set_named_basic` — self=Variant, name=`$name:StringName`, value=Variant → 生成 `godot_variant_set_named`
 2. `variant_set_named_non_variant_value` — value=int → pack value
 
 **variant_set_named 错误用例：**
 1. `variant_set_named_unsupported_self_fails` — self=int（不支持 named-set）→ fail-fast
 
 **variant_set_indexed 正向用例：**
-1. `variant_set_indexed_basic` — self=Variant, index=0, value=Variant → 生成 `godot_variant_set_indexed` + r_oob 检查
+1. `variant_set_indexed_basic` — self=Variant, index=`$idx:int`, value=Variant → 生成 `godot_variant_set_indexed` + r_oob 检查
 2. `variant_set_indexed_non_variant_value` — value=int → pack value
-3. `variant_set_indexed_array_self_pack_succeeds` — self=Array, index=0, value=Variant → 引用语义路径
+3. `variant_set_indexed_array_self_pack_succeeds` — self=Array, index=`$idx:int`, value=Variant → 引用语义路径
 
 **r_valid / r_oob 错误处理验证：**
 1. `variant_set_emits_valid_check` — 验证 r_valid 检查
@@ -644,20 +661,20 @@ godot_variant_destroy(&__gdcc_tmp_idx_key_1);
 godot_variant_destroy(&__gdcc_tmp_idx_self_0);
 ```
 
-### 4.3 variant_get_named（self=Variant, name="position", result=Vector3）
+### 4.3 variant_get_named（self=Variant, name=$name:StringName, result=Vector3）
 
 LIR:
 ```
-$result = variant_get_named $obj "position"
+$result = variant_get_named $obj $name
 ```
 
 生成 C 代码：
 ```c
 godot_Variant __gdcc_tmp_idx_ret_0;
 GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
-godot_variant_get_named(&$obj, GD_STATIC_SN(u8"position"), &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1);
+godot_variant_get_named(&$obj, &$name, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1);
 if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_named 'position' failed", __func__, __FILE__, __LINE__);
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_named failed: self=$obj, name=$name, result=$result", __func__, __FILE__, __LINE__);
     __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();
     godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
     goto __finally__;
@@ -666,11 +683,11 @@ $result = godot_new_Vector3_with_Variant(&__gdcc_tmp_idx_ret_0);
 godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
 ```
 
-### 4.4 variant_get_indexed（self=Variant, index=2, result=Variant）
+### 4.4 variant_get_indexed（self=Variant, index=$idx:int, result=Variant）
 
 LIR:
 ```
-$result = variant_get_indexed $arr 2
+$result = variant_get_indexed $arr $idx
 ```
 
 生成 C 代码：
@@ -678,15 +695,15 @@ $result = variant_get_indexed $arr 2
 godot_Variant __gdcc_tmp_idx_ret_0;
 GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
 GDExtensionBool __gdcc_tmp_idx_oob_2 = false;
-godot_variant_get_indexed(&$arr, (GDExtensionInt)2, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
+godot_variant_get_indexed(&$arr, (GDExtensionInt)$idx, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
 if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed failed", __func__, __FILE__, __LINE__);
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed failed: self=$arr, index=$idx, result=$result", __func__, __FILE__, __LINE__);
     __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();
     godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
     goto __finally__;
 }
 if (__gdcc_tmp_idx_oob_2) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed: index out of bounds", __func__, __FILE__, __LINE__);
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed index out of bounds: index=$idx", __func__, __FILE__, __LINE__);
     godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
     goto __finally__;
 }
@@ -711,31 +728,31 @@ if (!__gdcc_tmp_idx_valid_0) {
 }
 ```
 
-### 4.6 variant_set_named（self=Variant, name="health", value=int）
+### 4.6 variant_set_named（self=Variant, name=$name:StringName, value=int）
 
 LIR:
 ```
-variant_set_named $obj "health" $hp
+variant_set_named $obj $name $hp
 ```
 
 生成 C 代码：
 ```c
 godot_Variant __gdcc_tmp_idx_val_0 = godot_new_Variant_with_int($hp);
 GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
-godot_variant_set_named(&$obj, GD_STATIC_SN(u8"health"), &__gdcc_tmp_idx_val_0, &__gdcc_tmp_idx_valid_1);
+godot_variant_set_named(&$obj, &$name, &__gdcc_tmp_idx_val_0, &__gdcc_tmp_idx_valid_1);
 if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_set_named 'health' failed", __func__, __FILE__, __LINE__);
+    GDCC_PRINT_RUNTIME_ERROR("variant_set_named failed: self=$obj, name=$name, value=$hp", __func__, __FILE__, __LINE__);
     godot_variant_destroy(&__gdcc_tmp_idx_val_0);
     goto __finally__;
 }
 godot_variant_destroy(&__gdcc_tmp_idx_val_0);
 ```
 
-### 4.7 variant_set_indexed（self=Variant, index=0, value=int）
+### 4.7 variant_set_indexed（self=Variant, index=$idx:int, value=int）
 
 LIR:
 ```
-variant_set_indexed $arr 0 $val
+variant_set_indexed $arr $idx $val
 ```
 
 生成 C 代码：
@@ -743,14 +760,14 @@ variant_set_indexed $arr 0 $val
 godot_Variant __gdcc_tmp_idx_val_0 = godot_new_Variant_with_int($val);
 GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
 GDExtensionBool __gdcc_tmp_idx_oob_2 = false;
-godot_variant_set_indexed(&$arr, (GDExtensionInt)0, &__gdcc_tmp_idx_val_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
+godot_variant_set_indexed(&$arr, (GDExtensionInt)$idx, &__gdcc_tmp_idx_val_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
 if (!__gdcc_tmp_idx_valid_1) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_set_indexed failed", __func__, __FILE__, __LINE__);
+    GDCC_PRINT_RUNTIME_ERROR("variant_set_indexed failed: self=$arr, index=$idx, value=$val", __func__, __FILE__, __LINE__);
     godot_variant_destroy(&__gdcc_tmp_idx_val_0);
     goto __finally__;
 }
 if (__gdcc_tmp_idx_oob_2) {
-    GDCC_PRINT_RUNTIME_ERROR("variant_set_indexed: index out of bounds", __func__, __FILE__, __LINE__);
+    GDCC_PRINT_RUNTIME_ERROR("variant_set_indexed index out of bounds: index=$idx", __func__, __FILE__, __LINE__);
     godot_variant_destroy(&__gdcc_tmp_idx_val_0);
     goto __finally__;
 }
@@ -815,9 +832,14 @@ bodyBuilder.callAssign(bodyBuilder.targetOfVar(resultVar), "godot_new_Variant_wi
 // 销毁临时变量
 bodyBuilder.destroyTempVar(retTemp);
 
-// StringName 字面量
-bodyBuilder.valueOfStringNamePtrLiteral("property_name")
-// 渲染为 GD_STATIC_SN(u8"property_name")
+// StringName 变量参数
+var nameVarRef = bodyBuilder.valueOfVar(nameVar);
+
+// 统一参数渲染（避免在生成器中分散实现 & / ref / ptr 逻辑）
+var renderedArg = bodyBuilder.renderArgument(bodyBuilder.valueOfVar(selfVar), false);
+var selfArgCode = renderedArg.code();
+var renderedNameArg = bodyBuilder.renderArgument(nameVarRef, false);
+var nameArgCode = renderedNameArg.code();
 
 // 手动行发射（用于低级 C 调用和条件检查）
 bodyBuilder.appendLine("godot_variant_get(&..., &..., &..., &...);");
@@ -826,9 +848,8 @@ bodyBuilder.appendLine("if (!__gdcc_tmp_idx_valid_0) {");
 // 错误报告
 bodyBuilder.appendLine("GDCC_PRINT_RUNTIME_ERROR(\"...\", __func__, __FILE__, __LINE__);");
 
-// 安全返回
-bodyBuilder.returnVoid();  // void 函数
-bodyBuilder.returnValue(bodyBuilder.valueOfExpr(CBodyBuilder.renderDefaultValueExpr(returnType), returnType));
+// 安全返回（统一）
+bodyBuilder.returnDefault();
 ```
 
 ### 6.2 `renderStaticStringNameLiteral` 用法
@@ -838,6 +859,8 @@ bodyBuilder.returnValue(bodyBuilder.valueOfExpr(CBodyBuilder.renderDefaultValueE
 CBodyBuilder.renderStaticStringNameLiteral("property_name")
 // → GD_STATIC_SN(u8"property_name")
 ```
+
+> 说明：Indexing 指令中的 `_named` 变体已改为 `StringName` 变量操作数，不再在生成器中使用静态字面量路径。
 
 ---
 
@@ -898,6 +921,22 @@ CBodyBuilder.renderStaticStringNameLiteral("property_name")
 - GET 和 SET 分属两个独立生成器（`IndexLoadInsnGen` / `IndexStoreInsnGen`）。
 - 如果未来增加新的 indexing 指令，按 ReturnKind（REQUIRED/NONE）分配到对应生成器。
 
+### 8.4 named/indexed 操作数建模
+
+- `variant_get_named` / `variant_set_named` 的 key 操作数必须是 `StringName` 变量（`VARIABLE`），不再使用字符串字面量操作数。
+- `variant_get_indexed` / `variant_set_indexed` 的 index 操作数必须是 `int` 变量（`VARIABLE`），不再使用整数字面量操作数。
+- 解析器与序列化器需保持该模型一致性，文本 IR 形态为 `$name` / `$idx`。
+
+### 8.5 运行时错误诊断信息
+
+- `GDCC_PRINT_RUNTIME_ERROR` 的消息必须包含足够上下文，至少带上指令名和关键操作数 ID（如 self/key/name/index/result/value）。
+- 禁止仅输出泛化字符串（如仅 `"... failed"`），避免诊断信息不足。
+
+### 8.6 默认返回策略
+
+- 生成器中的失败分支统一调用 `CBodyBuilder.returnDefault()`，禁止在生成器中重复拼装 `renderDefaultValueExpr(...)` 逻辑。
+- 若失败分支会临时析构变量，需要保证分支代码生成后不破坏后续路径的临时变量初始化状态。
+
 ---
 
 ## 9. 回归测试基线
@@ -930,8 +969,8 @@ CBodyBuilder.renderStaticStringNameLiteral("property_name")
 
 ## 10. 非目标（当前不做）
 
-- 不修改现有 8 个 LIR `IndexingInstruction` record 类。
-- 不修改 `GdInstruction` 枚举定义。
+- 不新增/重构除 named/indexed 操作数建模修正外的其他 LIR `IndexingInstruction` record。
+- 不修改除 named/indexed operand pattern 修正外的其他 `GdInstruction` 枚举定义。
 - 不修改 `IndexingInstruction` 接口。
 - 不在 `gdcc_helper.h` 中添加 C helper 包装函数（直接使用 gdextension-lite 提供的 API）。
 - 不添加引擎集成测试（本计划仅覆盖单元测试；引擎集成测试作为后续单独任务）。

--- a/doc/module_impl/index_insn_implementation.md
+++ b/doc/module_impl/index_insn_implementation.md
@@ -4,11 +4,11 @@
 
 ## 文档状态
 
-- 状态：`Plan / In Progress`
+- 状态：`Completed`
 - 文档类型：`实施计划`
 - 创建时间：`2026-03-04`
 - 适用范围：`backend.c` 中 8 条 `variant_get*` / `variant_set*` 指令的 C 代码生成
-- 当前进度：`✅ 步骤 1 已完成；✅ 步骤 3 已完成（IndexLoad 注册）；✅ 步骤 4 已完成；✅ named/indexed 操作数模型修正（字面量 → VARIABLE）已完成；✅ returnDefault 抽取与调用点替换已完成；步骤 2/5/6 待执行`
+- 当前进度：`✅ 步骤 1 已完成；✅ 步骤 2 已完成（IndexStoreInsnGen）；✅ 步骤 3 已完成（IndexLoad + IndexStore 注册）；✅ 步骤 4 已完成；✅ 步骤 5 已完成（IndexStoreInsnGenTest + 引擎锚定测试）；✅ 步骤 6 已完成（编译与回归验证）；✅ named/indexed 操作数模型修正（字面量 → VARIABLE）已完成；✅ returnDefault 抽取与调用点替换已完成；✅ ref self 放行策略已收敛（仅放行无需回写类型）；✅ ref key/value/index 约束已按最新语义放开并补齐回归测试`
 
 ## 1. 背景与目标
 
@@ -152,8 +152,8 @@ IndexStoreInsnGen implements CInsnGen<IndexingInstruction>
 | self 类别 | 典型类型（gdcc） | 允许策略 | 是否需要 self 回写 |
 |---|---|---|---|
 | 已是 Variant 变量 | `GdVariantType` | 直接传 `&$self` 给 `godot_variant_set*` | 否 |
-| 引用语义容器/对象 | `GdArrayType` / `GdDictionaryType` / `GdPacked*ArrayType` / `GdObjectType` | 可临时 pack 为 Variant 后调用 set；底层对象共享，修改可见 | 否 |
-| 值语义但支持 set 的类型 | `GdStringType`、向量/颜色/矩阵等值类型 | 临时 pack 后调用 set；随后必须 unpack 写回原 self 变量 | 是 |
+| 引用语义容器/对象 | `GdArrayType` / `GdDictionaryType` / `GdObjectType` | 可临时 pack 为 Variant 后调用 set；底层对象共享，修改可见 | 否 |
+| 值语义但支持 set 的类型 | `GdStringType`、向量/颜色/矩阵等值类型、`GdPacked*ArrayType` | 临时 pack 后调用 set；随后必须 unpack 写回原 self 变量 | 是 |
 | 不支持 set 的类型 | `GdIntType`/`GdFloatType`/`GdBoolType`/`GdNilType`/`GdStringNameType`/`GdNodePathType`/`GdRidType`/`GdCallableType`/`GdSignalType`/`GdVoidType` | 编译期 fail-fast | - |
 
 > 注：`GDExtensionVariantPtr p_self` 仅表示“传入的是可变 Variant 指针”，不等价于“源 IR 变量必须是 `GdVariantType`”。
@@ -251,7 +251,9 @@ GDExtension 的 variant_get* API 全部通过 Variant 指针操作。当 LIR 操
 对于 `variant_set*`：
 
 - `self` 为 `GdVariantType`：直接传 `&$self`，无需回写。
-- `self` 为引用语义类型（`Array`/`Dictionary`/`Packed*Array`/`Object`）：可 pack 为临时 Variant，执行 set 后无需回写。
+- `self` 为引用语义类型（`Array`/`Dictionary`/`Object`）：可 pack 为临时 Variant，执行 set 后无需回写。
+- `self` 为 `Packed*Array`：按值语义处理，需要 writeback（`pack -> variant_set_indexed -> unpack`）。
+- `self` 为 `ref Packed*Array`：当前实现 fail-fast（需要 writeback，但 ref 目标不可安全回写）。
 - `self` 为值语义但支持 set 的类型（例如 `String`、向量、`Color`、`Transform2D`、`Basis`、`Projection` 等）：执行 set 后必须将临时 self Variant unpack 回原 self 变量。
 - `self` 为不支持 set 的类型：编译期 fail-fast，不生成调用。
 
@@ -372,6 +374,7 @@ public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
 ### 步骤 2：创建 IndexStoreInsnGen
 
 **文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexStoreInsnGen.java`
+- 状态：`✅ 已完成（2026-03-04）`
 
 **类结构**：
 
@@ -422,24 +425,24 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
 
 #### 验收标准
 
-- [ ] 编译通过，无 warning
-- [ ] 4 条 SET 指令均可生成正确的 C 代码
-- [ ] self 分类策略正确：直接 Variant / 引用语义 pack / 值语义 pack+回写 / 不支持类型 fail-fast
-- [ ] key 为 Variant 类型时无多余 pack
-- [ ] value 为 Variant 类型时无多余 pack
-- [ ] value 为非 Variant 类型时正确 pack 并在结束后销毁
-- [ ] 值语义 self 在 set 后正确 unpack 回写
-- [ ] r_valid 检查失败时正确打印错误并安全返回
-- [ ] variant_set_indexed 的 r_oob 检查失败时正确打印错误并安全返回
-- [ ] 所有临时变量在所有路径（正常/错误）上均被正确销毁
-- [ ] 不意外设置 resultId（SET 不返回值）
+- [x] 编译通过，无 warning
+- [x] 4 条 SET 指令均可生成正确的 C 代码
+- [x] self 分类策略正确：直接 Variant / 引用语义 pack / 值语义 pack+回写 / 不支持类型 fail-fast
+- [x] key 为 Variant 类型时无多余 pack
+- [x] value 为 Variant 类型时无多余 pack
+- [x] value 为非 Variant 类型时正确 pack 并在结束后销毁
+- [x] 值语义 self 在 set 后正确 unpack 回写
+- [x] r_valid 检查失败时正确打印错误并安全返回
+- [x] variant_set_indexed 的 r_oob 检查失败时正确打印错误并安全返回
+- [x] 所有临时变量在所有路径（正常/错误）上均被正确销毁
+- [x] 不意外设置 resultId（SET 不返回值）
 
 ---
 
 ### 步骤 3：注册生成器到 CCodegen
 
 **文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`
-- 状态：`✅ 已完成（2026-03-04，已注册 IndexLoadInsnGen）`
+- 状态：`✅ 已完成（2026-03-04，已注册 IndexLoadInsnGen + IndexStoreInsnGen）`
 
 **修改内容**：在 static 块中添加两行注册：
 
@@ -460,12 +463,12 @@ static {
 
 - [x] 编译通过
 - [x] `INSN_GENS` 已包含 `IndexLoadInsnGen` 的 4 条 GET opcode 映射
+- [x] `INSN_GENS` 已包含 `IndexStoreInsnGen` 的 4 条 SET opcode 映射
 - [x] 不影响现有 15 个生成器的注册
-
-> 注：`IndexStoreInsnGen` 的注册将在步骤 2 完成后补充。
 
 **同步单测更新**：
 - 在 `src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java` 新增 `variantGetOpcodeIsRegisteredAndGeneratesBody`，验证 `variant_get` 已通过 `CCodegen` 分发到 `IndexLoadInsnGen`。
+- 在 `src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java` 新增 `variantSetOpcodeIsRegisteredAndGeneratesBody`，验证 `variant_set` 已通过 `CCodegen` 分发到 `IndexStoreInsnGen`。
 
 ---
 
@@ -508,21 +511,22 @@ class IndexLoadInsnGenTest {
 
 **variant_get_indexed 正向用例：**
 13. `variant_get_indexed_basic` — self=Variant, index=`$idx:int`, result=Variant → 生成 `godot_variant_get_indexed` + r_oob 检查
-14. `variant_get_indexed_non_variant_self` — self=Array, index=`$idx:int`, result=int → pack self, unpack result
+14. `variant_get_indexed_ref_int_index` — self=Variant, index=ref int, result=Variant → index 允许 ref
+15. `variant_get_indexed_non_variant_self` — self=Array, index=`$idx:int`, result=int → pack self, unpack result
 
 **r_valid / r_oob 错误处理验证：**
-15. `variant_get_emits_valid_check` — 验证生成的代码包含 r_valid 检查和 GDCC_PRINT_RUNTIME_ERROR
-16. `variant_get_indexed_emits_oob_check` — 验证生成的代码包含 r_oob 检查
-17. `variant_get_invalid_branch_destroy_order` — 验证无效分支析构顺序（ret → key temp → self temp）
-18. `variant_get_indexed_oob_destroy_order` — 验证 OOB 分支析构顺序（ret → self temp）
+16. `variant_get_emits_valid_check` — 验证生成的代码包含 r_valid 检查和 GDCC_PRINT_RUNTIME_ERROR
+17. `variant_get_indexed_emits_oob_check` — 验证生成的代码包含 r_oob 检查
+18. `variant_get_invalid_branch_destroy_order` — 验证无效分支析构顺序（ret → key temp → self temp）
+19. `variant_get_indexed_oob_destroy_order` — 验证 OOB 分支析构顺序（ret → self temp）
 
 **生命周期验证：**
-19. `variant_get_destroys_temp_pack_vars` — 验证临时 pack Variant 被正确析构
-20. `variant_get_destroys_ret_variant` — 验证 r_ret Variant 被正确析构
+20. `variant_get_destroys_temp_pack_vars` — 验证临时 pack Variant 被正确析构
+21. `variant_get_destroys_ret_variant` — 验证 r_ret Variant 被正确析构
 
 **否定断言（禁止多余 pack）**：
-21. `variant_get_variant_key_variant_result` — self/key 已是 Variant 时，断言不生成 `idx_self_variant`/`idx_key_variant` 临时 pack
-22. `variant_get_keyed_ref_key_var` — key 为 ref Variant 时，断言不生成 key 临时 pack
+22. `variant_get_variant_key_variant_result` — self/key 已是 Variant 时，断言不生成 `idx_self_variant`/`idx_key_variant` 临时 pack
+23. `variant_get_keyed_ref_key_var` — key 为 ref Variant 时，断言不生成 key 临时 pack
 
 #### 验收标准
 
@@ -538,15 +542,19 @@ class IndexLoadInsnGenTest {
 ### 步骤 5：创建 IndexStoreInsnGen 单元测试
 
 **文件**：`src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenTest.java`
+- 状态：`✅ 已完成（2026-03-04）`
 
 **测试用例清单**：
 
 **variant_set 正向用例：**
 1. `variant_set_variant_key_variant_value` — self=Variant, key=Variant, value=Variant → 无 pack 开销
 2. `variant_set_non_variant_key_pack` — self=Variant, key=int, value=Variant → key 需 pack
-3. `variant_set_non_variant_value_pack` — self=Variant, key=Variant, value=int → value 需 pack
-4. `variant_set_array_self_pack_succeeds` — self=Array, key=int, value=Variant → self 允许 pack 且无需回写
-5. `variant_set_value_semantic_self_emits_writeback` — self=Vector3（或 Color），set 后应生成 unpack 回写
+3. `variant_set_ref_int_key_pack` — self=Variant, key=ref int, value=Variant → key 允许 ref 并正确 pack
+4. `variant_set_non_variant_value_pack` — self=Variant, key=Variant, value=int → value 需 pack
+5. `variant_set_ref_string_value_pack` — self=Variant, key=Variant, value=ref String → value 允许 ref 并正确 pack
+6. `variant_set_array_self_pack_succeeds` — self=Array, key=int, value=Variant → self 允许 pack 且无需回写
+7. `variant_set_ref_dictionary_self_pack_succeeds_without_writeback` — self=ref Dictionary, key=int, value=Variant → self 允许 ref 且无需回写
+8. `variant_set_value_semantic_self_emits_writeback` — self=Vector3（或 Color），set 后应生成 unpack 回写
 
 **variant_set 错误用例：**
 1. `variant_set_unsupported_self_fails` — self=int（或 bool）→ `InvalidInsnException`
@@ -566,8 +574,13 @@ class IndexLoadInsnGenTest {
 
 **variant_set_indexed 正向用例：**
 1. `variant_set_indexed_basic` — self=Variant, index=`$idx:int`, value=Variant → 生成 `godot_variant_set_indexed` + r_oob 检查
-2. `variant_set_indexed_non_variant_value` — value=int → pack value
-3. `variant_set_indexed_array_self_pack_succeeds` — self=Array, index=`$idx:int`, value=Variant → 引用语义路径
+2. `variant_set_indexed_ref_int_index` — self=Variant, index=ref int, value=Variant → index 允许 ref
+3. `variant_set_indexed_non_variant_value` — value=int → pack value
+4. `variant_set_indexed_array_self_pack_succeeds` — self=Array, index=`$idx:int`, value=Variant → 引用语义路径
+5. `variant_set_indexed_ref_array_self_pack_succeeds` — self=ref Array, index=`$idx:int`, value=Variant → 允许 ref 且无需回写
+6. `variant_set_indexed_dictionary_self_pack_succeeds` — self=Dictionary, index=`$idx:int`, value=int → 引用语义路径
+7. `variant_set_indexed_packed_int32_self_writes_back` — self=PackedInt32Array（非 ref），验证 writeback 代码生成
+8. `variant_set_indexed_ref_packed_int32_self_fails` — self=ref PackedInt32Array，验证 fail-fast（requires writeback）
 
 **r_valid / r_oob 错误处理验证：**
 1. `variant_set_emits_valid_check` — 验证 r_valid 检查
@@ -576,20 +589,31 @@ class IndexLoadInsnGenTest {
 **生命周期验证：**
 1. `variant_set_destroys_temp_pack_vars` — 验证临时 pack 的 key/value Variant 被正确析构
 2. `variant_set_value_semantic_writeback_path_destroys_self_temp` — 验证值语义回写路径中的 self 临时 Variant 被正确析构
+3. `variant_set_ref_array_and_ref_dictionary_no_writeback` — 验证 ref Array/ref Dictionary 均可走“无回写”路径
+
+**引擎集成锚定：**
+1. `IndexStoreInsnGenEngineTest.index store ref semantics should read back correctly in real engine`
+2. 锚定点（ref self）：ref `Array` / ref `Dictionary` 无需回写即可读到更新；`Packed*Array` 采用局部变量 writeback 路径验证正确读回
+3. 锚定点（ref index/value）：`variant_set_indexed` 接收 ref `int` index + ref `int` value，运行时写入并读回一致
+4. 锚定点（ref key/value）：`variant_set` 接收 ref `int` key + ref `int` value，运行时写入并通过 `variant_get` 读回一致
+5. 锚定点（ref named）：`variant_set_named` / `variant_get_named` 在 ref `StringName` key + ref `int` value 下运行时读写一致
+6. 锚定点（ref String key/value）：`variant_set_keyed` / `variant_get_keyed` 在 ref `String` key + ref `String` value 下运行时读写一致
 
 #### 验收标准
 
-- [ ] 全部测试用例通过
-- [ ] 覆盖 4 种 SET 指令
-- [ ] 覆盖 self 分类策略（直接 Variant / 引用语义 / 值语义回写 / 不支持类型）
-- [ ] 覆盖 Variant/非 Variant key、value 组合
-- [ ] 覆盖错误路径
-- [ ] 覆盖 r_valid 和 r_oob 检查
-- [ ] 覆盖临时变量生命周期
+- [x] 全部测试用例通过
+- [x] 覆盖 4 种 SET 指令
+- [x] 覆盖 self 分类策略（直接 Variant / 引用语义 / 值语义回写 / 不支持类型）
+- [x] 覆盖 Variant/非 Variant key、value 组合
+- [x] 覆盖 ref key / ref value / ref index 组合（按最新 ref 语义）
+- [x] 覆盖错误路径
+- [x] 覆盖 r_valid 和 r_oob 检查
+- [x] 覆盖临时变量生命周期
 
 ---
 
 ### 步骤 6：编译验证与现有测试回归
+- 状态：`✅ 已完成（2026-03-04，全部命令通过）`
 
 **执行命令**：
 
@@ -601,11 +625,25 @@ class IndexLoadInsnGenTest {
 ./gradlew test --no-daemon --info --console=plain
 ```
 
+**本次执行结果（2026-03-04）**：
+- ✅ `./gradlew classes --no-daemon --info --console=plain`
+- ✅ `./gradlew test --tests IndexLoadInsnGenTest --no-daemon --info --console=plain`
+- ✅ `./gradlew test --tests IndexStoreInsnGenTest --no-daemon --info --console=plain`
+- ✅ `./gradlew test --tests CCodegenTest --no-daemon --info --console=plain`
+- ✅ `./gradlew test --no-daemon --info --console=plain`
+
+**本轮补充验证（2026-03-04，ref 语义对齐）**：
+- ✅ `./gradlew test --tests IndexStoreInsnGenTest --no-daemon --info --console=plain`
+- ✅ `./gradlew test --tests IndexLoadInsnGenTest --no-daemon --info --console=plain`
+- ✅ `./gradlew test --tests IndexStoreInsnGenEngineTest --no-daemon --info --console=plain`
+- ✅ `./gradlew test --tests CCodegenTest --no-daemon --info --console=plain`
+- ✅ `./gradlew classes --no-daemon --info --console=plain`
+
 #### 验收标准
 
-- [ ] 编译无错误
-- [ ] 新增测试全部通过
-- [ ] 现有测试无回归
+- [x] 编译无错误
+- [x] 新增测试全部通过
+- [x] 现有测试无回归
 
 ---
 
@@ -885,6 +923,14 @@ CBodyBuilder.renderStaticStringNameLiteral("property_name")
   2. 不支持类型编译期 fail-fast 并给出清晰错误信息。
   3. 值语义路径强制执行 unpack 回写，并通过单元测试覆盖。
 
+### 7.5 风险：ref 参数在 call 路径下的回写安全性
+
+- **描述**：Godot `call` 路径会把参数解包到局部临时对象再传给绑定函数。对 `ref` 值语义类型直接写回会触发未定义行为风险（历史上对 `ref Packed*Array` 的直接回写出现过崩溃）。
+- **防线**：
+  1. 仅放行“无需回写”的 `ref self` 类型（`Variant` / `Array` / `Dictionary` / `Object`）。
+  2. 对“需要回写”的 `ref self`（例如 `ref Packed*Array`、`ref String`、`ref Vector*`）维持编译期 fail-fast。
+  3. 通过 `IndexStoreInsnGenEngineTest` 锚定运行时行为，避免回归到不安全路径。
+
 ### 7.3 风险：`variant_get_indexed` / `variant_set_indexed` 的 r_oob 语义
 
 - **描述**：`_indexed` 变体在 r_valid=true 但 r_oob=true 时的行为需要明确。Godot 引擎在 OOB 时仍会写入 `r_ret`（对 GET 来说是默认值）。
@@ -907,6 +953,9 @@ CBodyBuilder.renderStaticStringNameLiteral("property_name")
 ### 8.1 SET 指令的 self 类型约束
 
 - `variant_set*` 指令的 self 按策略分类处理：`GdVariantType` 直传、引用语义类型可 pack、值语义类型 pack+回写。
+- `ref self` 仅允许“无需回写”类型（`Variant` / `Array` / `Dictionary` / `Object`）。
+- 所有非 ref self 均允许按策略生成（包含值语义 writeback 路径）。
+- `Packed*Array` 当前归类为“值语义 + 需要回写”；`ref Packed*Array` 编译期 fail-fast。
 - 对不支持 set 的类型保持编译期 fail-fast。
 - 该约定优先于“self 必须是 Variant”这一旧规则。
 
@@ -945,6 +994,7 @@ CBodyBuilder.renderStaticStringNameLiteral("property_name")
 
 - `src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java`
 - `src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenTest.java`
+- `src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenEngineTest.java`
 
 ### 9.2 建议执行命令
 
@@ -973,5 +1023,5 @@ CBodyBuilder.renderStaticStringNameLiteral("property_name")
 - 不修改除 named/indexed operand pattern 修正外的其他 `GdInstruction` 枚举定义。
 - 不修改 `IndexingInstruction` 接口。
 - 不在 `gdcc_helper.h` 中添加 C helper 包装函数（直接使用 gdextension-lite 提供的 API）。
-- 不添加引擎集成测试（本计划仅覆盖单元测试；引擎集成测试作为后续单独任务）。
+- 不在本轮扩展到“所有 indexed/named 失败分支（如 `r_valid=false`/`r_oob=true`）的引擎级故障注入测试”；当前引擎集成测试以 ref 语义主路径正确性锚定为目标。
 - 不处理 variant_get*/set* 结果类型的编译期类型检查（运行时 r_valid 检查已足够）。

--- a/doc/module_impl/index_insn_implementation.md
+++ b/doc/module_impl/index_insn_implementation.md
@@ -1,0 +1,938 @@
+# IndexLoadInsnGen / IndexStoreInsnGen 实现计划
+
+> 本文档为 Indexing Instructions 分类下 8 条 LIR 指令的 C Backend 代码生成器实施计划。
+
+## 文档状态
+
+- 状态：`Plan / Pending`
+- 文档类型：`实施计划`
+- 创建时间：`2026-03-04`
+- 适用范围：`backend.c` 中 8 条 `variant_get*` / `variant_set*` 指令的 C 代码生成
+
+## 1. 背景与目标
+
+### 1.1 覆盖指令
+
+Indexing Instructions 分类包含 8 条指令，分为 Load（4 条 GET）和 Store（4 条 SET）两组：
+
+| LIR 指令 | GdInstruction 枚举 | ReturnKind | 操作数签名 | 语义 |
+|---|---|---|---|---|
+| `variant_get` | `VARIANT_GET` | REQUIRED | `(VARIABLE, VARIABLE)` | 通用 Variant 键读取 |
+| `variant_get_keyed` | `VARIANT_GET_KEYED` | REQUIRED | `(VARIABLE, VARIABLE)` | 字典式键读取 |
+| `variant_get_named` | `VARIANT_GET_NAMED` | REQUIRED | `(VARIABLE, STRING)` | 属性名读取（StringName） |
+| `variant_get_indexed` | `VARIANT_GET_INDEXED` | REQUIRED | `(VARIABLE, INT)` | 整数索引读取 |
+| `variant_set` | `VARIANT_SET` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 通用 Variant 键写入 |
+| `variant_set_keyed` | `VARIANT_SET_KEYED` | NONE | `(VARIABLE, VARIABLE, VARIABLE)` | 字典式键写入 |
+| `variant_set_named` | `VARIANT_SET_NAMED` | NONE | `(VARIABLE, STRING, VARIABLE)` | 属性名写入（StringName） |
+| `variant_set_indexed` | `VARIANT_SET_INDEXED` | NONE | `(VARIABLE, INT, VARIABLE)` | 整数索引写入 |
+
+### 1.2 LIR 指令类（已实现）
+
+所有 8 个 LIR 指令 record 类均已定义在 `src/main/java/dev/superice/gdcc/lir/insn/` 下：
+
+- `VariantGetInsn(resultId, variantId, keyId)` → `IndexingInstruction`
+- `VariantGetKeyedInsn(resultId, keyedVariantId, keyId)` → `IndexingInstruction`
+- `VariantGetNamedInsn(resultId, namedVariantId, name)` → `IndexingInstruction`
+- `VariantGetIndexedInsn(resultId, variantId, index)` → `IndexingInstruction`
+- `VariantSetInsn(variantId, keyId, valueId)` → `IndexingInstruction`
+- `VariantSetKeyedInsn(keyedVariantId, keyId, valueId)` → `IndexingInstruction`
+- `VariantSetNamedInsn(namedVariantId, name, valueId)` → `IndexingInstruction`
+- `VariantSetIndexedInsn(variantId, index, valueId)` → `IndexingInstruction`
+
+公共标记接口：`IndexingInstruction extends LirInstruction`。
+
+### 1.3 GDExtension C API 函数（gdextension-lite 已提供）
+
+所有 8 个 GDExtension C API 函数已通过 `gdextension-lite` 在 `extension_interface.h` 中声明可用：
+
+**GET 函数签名：**
+
+```c
+// variant_get / variant_get_keyed — 签名相同，内部行为不同
+void godot_variant_get(
+    GDExtensionConstVariantPtr p_self,
+    GDExtensionConstVariantPtr p_key,
+    GDExtensionUninitializedVariantPtr r_ret,
+    GDExtensionBool *r_valid);
+
+void godot_variant_get_keyed(
+    GDExtensionConstVariantPtr p_self,
+    GDExtensionConstVariantPtr p_key,
+    GDExtensionUninitializedVariantPtr r_ret,
+    GDExtensionBool *r_valid);
+
+void godot_variant_get_named(
+    GDExtensionConstVariantPtr p_self,
+    GDExtensionConstStringNamePtr p_key,
+    GDExtensionUninitializedVariantPtr r_ret,
+    GDExtensionBool *r_valid);
+
+void godot_variant_get_indexed(
+    GDExtensionConstVariantPtr p_self,
+    GDExtensionInt p_index,
+    GDExtensionUninitializedVariantPtr r_ret,
+    GDExtensionBool *r_valid,
+    GDExtensionBool *r_oob);          // ← 独有 out-of-bounds 标志
+```
+
+**SET 函数签名：**
+
+```c
+void godot_variant_set(
+    GDExtensionVariantPtr p_self,      // ← 可变
+    GDExtensionConstVariantPtr p_key,
+    GDExtensionConstVariantPtr p_value,
+    GDExtensionBool *r_valid);
+
+void godot_variant_set_keyed(
+    GDExtensionVariantPtr p_self,
+    GDExtensionConstVariantPtr p_key,
+    GDExtensionConstVariantPtr p_value,
+    GDExtensionBool *r_valid);
+
+void godot_variant_set_named(
+    GDExtensionVariantPtr p_self,
+    GDExtensionConstStringNamePtr p_key,
+    GDExtensionConstVariantPtr p_value,
+    GDExtensionBool *r_valid);
+
+void godot_variant_set_indexed(
+    GDExtensionVariantPtr p_self,
+    GDExtensionInt p_index,
+    GDExtensionConstVariantPtr p_value,
+    GDExtensionBool *r_valid,
+    GDExtensionBool *r_oob);          // ← 独有 out-of-bounds 标志
+```
+
+**关键差异汇总：**
+- GET 的 `p_self` 为 `Const`；SET 的 `p_self` 为可变。
+- GET 的返回值写入 `GDExtensionUninitializedVariantPtr r_ret`（未初始化输出参数）。
+- SET 的值通过 `GDExtensionConstVariantPtr p_value` 传入。
+- `_indexed` 变体多一个 `GDExtensionBool *r_oob` 输出参数。
+- `_named` 变体的 key 类型为 `GDExtensionConstStringNamePtr`，其余为 `GDExtensionConstVariantPtr` 或 `GDExtensionInt`。
+- 所有操作都通过 `Variant` 指针进行——调用方需确保操作数被 pack 为 Variant。
+
+### 1.4 设计目标
+
+1. 创建 `IndexLoadInsnGen`（处理 4 条 GET 指令）和 `IndexStoreInsnGen`（处理 4 条 SET 指令）。
+2. 遵循现有 `ConstructInsnGen` / `OperatorInsnGen` 的架构模式：直接实现 `CInsnGen<IndexingInstruction>`，使用 `CBodyBuilder` API。
+3. 在 `CCodegen` 中注册两个新生成器。
+4. 编写完整的单元测试。
+5. 核心约束：所有 Variant 操作数需要正确的生命周期管理（pack/unpack/destroy）。
+
+---
+
+## 2. 架构设计
+
+### 2.1 生成器拆分策略
+
+拆分为两个生成器而非一个统一生成器，原因：
+
+1. **返回值语义完全不同**：GET 有 `resultId`（REQUIRED），SET 没有（NONE）。
+2. **C API 参数模式不同**：GET 使用未初始化输出参数 `r_ret`；SET 使用输入参数 `p_value`。
+3. **操作数解析逻辑不同**：GET 读取键/索引 + 接收返回值；SET 读取键/索引 + 提供值。
+4. **生命周期管理不对称**：GET 需要管理返回的 Variant 的所有权；SET 需要管理传入的 value 的打包。
+
+```
+IndexLoadInsnGen  implements CInsnGen<IndexingInstruction>
+  ├── getInsnOpcodes(): {VARIANT_GET, VARIANT_GET_KEYED, VARIANT_GET_NAMED, VARIANT_GET_INDEXED}
+  └── generateCCode(CBodyBuilder): switch(insn) 分派 4 条 GET 指令
+
+IndexStoreInsnGen implements CInsnGen<IndexingInstruction>
+  ├── getInsnOpcodes(): {VARIANT_SET, VARIANT_SET_KEYED, VARIANT_SET_NAMED, VARIANT_SET_INDEXED}
+  └── generateCCode(CBodyBuilder): switch(insn) 分派 4 条 SET 指令
+```
+
+### 2.2 类型策略表（SET 的 self）
+
+`variant_set*` 的关键不是“self 是否是 `GdVariantType`”，而是 **self 运行时 Variant 的可变语义**。  
+在实现层面，按下表对 self 进行分类并选择生成策略：
+
+| self 类别 | 典型类型（gdcc） | 允许策略 | 是否需要 self 回写 |
+|---|---|---|---|
+| 已是 Variant 变量 | `GdVariantType` | 直接传 `&$self` 给 `godot_variant_set*` | 否 |
+| 引用语义容器/对象 | `GdArrayType` / `GdDictionaryType` / `GdPacked*ArrayType` / `GdObjectType` | 可临时 pack 为 Variant 后调用 set；底层对象共享，修改可见 | 否 |
+| 值语义但支持 set 的类型 | `GdStringType`、向量/颜色/矩阵等值类型 | 临时 pack 后调用 set；随后必须 unpack 写回原 self 变量 | 是 |
+| 不支持 set 的类型 | `GdIntType`/`GdFloatType`/`GdBoolType`/`GdNilType`/`GdStringNameType`/`GdNodePathType`/`GdRidType`/`GdCallableType`/`GdSignalType`/`GdVoidType` | 编译期 fail-fast | - |
+
+> 注：`GDExtensionVariantPtr p_self` 仅表示“传入的是可变 Variant 指针”，不等价于“源 IR 变量必须是 `GdVariantType`”。
+
+### 2.3 指令能力矩阵（Godot runtime）
+
+`variant_set*` 在 Godot 引擎内部并非对所有 Variant 类型都有效，能力如下：
+
+| 指令 | 运行时有效 self（核心） | 说明 |
+|---|---|---|
+| `variant_set` | `Dictionary` / `Object`（keyed）；其余类型依 key 类型分派到 named/indexed | key 为 `StringName`/`String`/`int`/`float` 时可能转入 named/indexed 路径 |
+| `variant_set_keyed` | `Dictionary` / `Object` | 其他类型 `r_valid=false` |
+| `variant_set_named` | 支持命名成员的内建值类型、`Object`、`Dictionary` | 例如向量、颜色、变换、矩形、AABB、Plane 等 |
+| `variant_set_indexed` | 支持索引写入的类型 | 例如 `String`、向量、`Color`、`Transform2D`、`Basis`、`Projection`、`Array`、`Dictionary`、`Packed*Array` |
+
+编译器策略：  
+1. 对“明确不支持 set”的 self 类型做编译期 fail-fast。  
+2. 对“可能支持但需运行时判定”的情况生成 `r_valid`/`r_oob` 检查，运行时兜底报错。
+
+### 2.4 代码生成模式总览
+
+#### 2.4.1 GET 指令通用生成模式
+
+```
+1. 校验 resultId 存在且对应非 ref 变量
+2. 校验源 variant 变量存在
+3. 将源 variant 打包为 Variant（如非 Variant 类型）→ 创建临时变量
+4. 准备 key/index 参数
+5. 声明未初始化 Variant 临时变量作为 r_ret
+6. 声明 r_valid (GDExtensionBool)
+7. [仅 _indexed] 声明 r_oob (GDExtensionBool)
+8. 发射 godot_variant_get* 调用
+9. 发射 r_valid 检查 → 失败时打印运行时错误并安全返回
+10. [仅 _indexed] 发射 r_oob 检查 → 失败时打印运行时错误并安全返回
+11. 将 r_ret Variant 拆包到 result 变量（如果 result 不是 Variant 类型）
+12. 销毁 r_ret 临时 Variant
+13. 销毁步骤 3 中的临时打包 Variant（如有）
+```
+
+#### 2.4.2 SET 指令通用生成模式
+
+```
+1. 校验无 resultId（SET 指令 returnKind=NONE）
+2. 校验 self 变量存在，并判定 self 类型策略（直接 Variant / 引用语义 pack / 值语义 pack+回写 / 不支持）
+3. 准备 key/index 参数
+4. 将 value 打包为 Variant（如非 Variant 类型）→ 创建临时变量
+5. 声明 r_valid (GDExtensionBool)
+6. [仅 _indexed] 声明 r_oob (GDExtensionBool)
+7. 发射 godot_variant_set* 调用
+8. 发射 r_valid 检查 → 失败时打印运行时错误并安全返回
+9. [仅 _indexed] 发射 r_oob 检查 → 失败时打印运行时错误并安全返回
+10. 若 self 属于“值语义 pack+回写”策略：将修改后的临时 self Variant unpack 回原 self 变量
+11. 销毁临时 value Variant（如有）
+12. 销毁临时 self Variant（如有）
+```
+
+### 2.5 操作数类型约束
+
+#### GET 指令操作数约束
+
+| 指令 | self 操作数 | key/index 操作数 | result 变量 |
+|---|---|---|---|
+| `variant_get` | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 任意类型（unpack 自 Variant） |
+| `variant_get_keyed` | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 任意类型（unpack 自 Variant） |
+| `variant_get_named` | 任意类型（pack 为 Variant） | STRING 字面量 → StringName | 任意类型（unpack 自 Variant） |
+| `variant_get_indexed` | 任意类型（pack 为 Variant） | INT 字面量 | 任意类型（unpack 自 Variant） |
+
+#### SET 指令操作数约束
+
+| 指令 | self 操作数 | key/index 操作数 | value 操作数 | 额外规则 |
+|---|---|---|---|---|
+| `variant_set` | `Variant` / 可 pack 且支持 set 的类型 | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 值语义 self 需回写；不支持类型 fail-fast |
+| `variant_set_keyed` | `Variant` / `Object` / `Dictionary`（或可 pack 到这些运行时类型） | 任意类型（pack 为 Variant） | 任意类型（pack 为 Variant） | 非 keyed 支持类型 fail-fast |
+| `variant_set_named` | `Variant` / 支持 named-set 的类型 | STRING 字面量 → StringName | 任意类型（pack 为 Variant） | 值语义 self 需回写 |
+| `variant_set_indexed` | `Variant` / 支持 indexed-set 的类型 | INT 字面量 | 任意类型（pack 为 Variant） | 值语义 self 需回写 |
+
+### 2.6 GET 指令的 Variant 打包/拆包策略
+
+GDExtension 的 variant_get* API 全部通过 Variant 指针操作。当 LIR 操作数不是 Variant 类型时，需要进行 pack/unpack 转换。
+
+**self 操作数 pack 策略（GET 的 p_self 为 const）：**
+- 如果 self 已经是 `GdVariantType`：直接取地址 `&$self`
+- 如果 self 不是 `GdVariantType`：创建临时 Variant，调用 `godot_new_Variant_with_<Type>` pack
+
+**key 操作数 pack 策略（仅 variant_get / variant_get_keyed）：**
+- 如果 key 已经是 `GdVariantType`：直接取地址 `&$key`
+- 如果 key 不是 `GdVariantType`：创建临时 Variant，pack
+
+**result unpack 策略：**
+- 如果 result 变量为 `GdVariantType`：直接通过 `callAssign` 以 `godot_new_Variant_with_Variant` 构造拷贝写回（遵循 OperatorInsnGen 的 Variant 回写规则）
+- 如果 result 变量为非 `GdVariantType`：调用 `godot_new_<Type>_with_Variant` unpack 到目标类型
+
+### 2.7 SET 指令的 self 回写策略
+
+对于 `variant_set*`：
+
+- `self` 为 `GdVariantType`：直接传 `&$self`，无需回写。
+- `self` 为引用语义类型（`Array`/`Dictionary`/`Packed*Array`/`Object`）：可 pack 为临时 Variant，执行 set 后无需回写。
+- `self` 为值语义但支持 set 的类型（例如 `String`、向量、`Color`、`Transform2D`、`Basis`、`Projection` 等）：执行 set 后必须将临时 self Variant unpack 回原 self 变量。
+- `self` 为不支持 set 的类型：编译期 fail-fast，不生成调用。
+
+### 2.8 错误处理策略
+
+所有 GDExtension variant_get*/set* 调用都返回 `r_valid` 标志。`_indexed` 变体额外返回 `r_oob` 标志。
+
+**错误处理模式**（参照 `OperatorInsnGen` 的 `godot_variant_evaluate` 错误处理）：
+
+```c
+// 示例：variant_get 的错误处理
+godot_Variant __gdcc_tmp_idx_ret_0;
+GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
+godot_variant_get(&$self, &$key, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1);
+if (!__gdcc_tmp_idx_valid_1) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_get failed", __func__, __FILE__, __LINE__);
+    __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();  // 初始化以便安全析构
+    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
+    // 销毁临时 pack 变量...
+    return;  // 或 return 默认值
+}
+// ... 继续 unpack / 赋值
+```
+
+**`_indexed` 变体的额外 OOB 检查：**
+
+```c
+GDExtensionBool __gdcc_tmp_idx_oob_2 = false;
+godot_variant_get_indexed(&$self, index, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
+if (!__gdcc_tmp_idx_valid_1) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed failed", __func__, __FILE__, __LINE__);
+    // ... 安全返回
+}
+if (__gdcc_tmp_idx_oob_2) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed: index out of bounds", __func__, __FILE__, __LINE__);
+    // ... 安全返回（此时 r_ret 已被写入，需销毁）
+}
+```
+
+**安全返回规则**（与 OperatorInsnGen 一致）：
+- 销毁所有已初始化的临时变量
+- 如果函数返回 void：`goto __finally__`
+- 如果函数返回非 void：`goto __finally__`（通过 `_return_val` 带默认值返回）
+
+---
+
+## 3. 分步实施计划
+
+### 步骤 1：创建 IndexLoadInsnGen
+
+**文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java`
+
+**类结构**：
+
+```java
+public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
+
+    @Override
+    public @NotNull EnumSet<GdInstruction> getInsnOpcodes() {
+        return EnumSet.of(
+            GdInstruction.VARIANT_GET,
+            GdInstruction.VARIANT_GET_KEYED,
+            GdInstruction.VARIANT_GET_NAMED,
+            GdInstruction.VARIANT_GET_INDEXED
+        );
+    }
+
+    @Override
+    public void generateCCode(@NotNull CBodyBuilder bodyBuilder) {
+        var instruction = bodyBuilder.getCurrentInsn(this);
+        switch (instruction) {
+            case VariantGetInsn insn -> emitVariantGet(bodyBuilder, insn);
+            case VariantGetKeyedInsn insn -> emitVariantGetKeyed(bodyBuilder, insn);
+            case VariantGetNamedInsn insn -> emitVariantGetNamed(bodyBuilder, insn);
+            case VariantGetIndexedInsn insn -> emitVariantGetIndexed(bodyBuilder, insn);
+            default -> throw bodyBuilder.invalidInsn("Unsupported index load instruction: "
+                + instruction.getClass().getSimpleName());
+        }
+    }
+}
+```
+
+**实现要点**：
+
+1. **`resolveRequiredResultVariable`**：与 OperatorInsnGen 一致——校验 resultId 非空，变量存在且非 ref。
+2. **`resolveOperandVariable`**：按 variableId 查找操作数变量，不存在则 fail-fast。
+3. **`materializeVariantOperand`**：参照 OperatorInsnGen 的同名方法——如果操作数已是 Variant 则直接引用，否则创建临时 Variant 并 pack。
+4. **`emitVariantGet` / `emitVariantGetKeyed`**：
+   - 两者代码结构几乎相同（API 签名一致），仅 C 函数名不同（`godot_variant_get` vs `godot_variant_get_keyed`）。
+   - 可抽取公共方法 `emitVariantGetCommon(bodyBuilder, cFuncName, selfVar, keyVar, resultVar)`。
+5. **`emitVariantGetNamed`**：
+   - key 为 STRING 字面量，使用 `bodyBuilder.valueOfStringNamePtrLiteral(name)` 生成静态 StringName 指针。
+   - C 调用为 `godot_variant_get_named(&self_variant, GD_STATIC_SN(u8"name"), &r_ret, &r_valid)`。
+6. **`emitVariantGetIndexed`**：
+   - index 为 INT 字面量，直接作为 `(GDExtensionInt)index` 传入。
+   - 额外声明 `r_oob` 标志并检查。
+7. **result 回写**：
+   - Variant→Variant：构造拷贝（`godot_new_Variant_with_Variant` + `callAssign`）。
+   - Variant→非 Variant：调用 unpack 函数（`bodyBuilder.helper().renderUnpackFunctionName(resultType)`）+ `callAssign`。
+8. **错误返回路径**：使用与 OperatorInsnGen 一致的模式——销毁临时变量后 return void 或 return 默认值。
+
+#### 验收标准
+
+- [ ] 编译通过，无 warning
+- [ ] 4 条 GET 指令均可生成正确的 C 代码
+- [ ] self 为 Variant 类型时无多余 pack/unpack
+- [ ] self 为非 Variant 类型时正确 pack 并在结束后销毁
+- [ ] key 为 Variant 类型时无多余 pack
+- [ ] result 为 Variant 类型时使用构造拷贝回写
+- [ ] result 为非 Variant 类型时正确 unpack
+- [ ] r_valid 检查失败时正确打印错误并安全返回
+- [ ] variant_get_indexed 的 r_oob 检查失败时正确打印错误并安全返回
+- [ ] 所有临时变量在所有路径（正常/错误）上均被正确销毁
+
+---
+
+### 步骤 2：创建 IndexStoreInsnGen
+
+**文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexStoreInsnGen.java`
+
+**类结构**：
+
+```java
+public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
+
+    @Override
+    public @NotNull EnumSet<GdInstruction> getInsnOpcodes() {
+        return EnumSet.of(
+            GdInstruction.VARIANT_SET,
+            GdInstruction.VARIANT_SET_KEYED,
+            GdInstruction.VARIANT_SET_NAMED,
+            GdInstruction.VARIANT_SET_INDEXED
+        );
+    }
+
+    @Override
+    public void generateCCode(@NotNull CBodyBuilder bodyBuilder) {
+        var instruction = bodyBuilder.getCurrentInsn(this);
+        switch (instruction) {
+            case VariantSetInsn insn -> emitVariantSet(bodyBuilder, insn);
+            case VariantSetKeyedInsn insn -> emitVariantSetKeyed(bodyBuilder, insn);
+            case VariantSetNamedInsn insn -> emitVariantSetNamed(bodyBuilder, insn);
+            case VariantSetIndexedInsn insn -> emitVariantSetIndexed(bodyBuilder, insn);
+            default -> throw bodyBuilder.invalidInsn("Unsupported index store instruction: "
+                + instruction.getClass().getSimpleName());
+        }
+    }
+}
+```
+
+**实现要点**：
+
+1. **self 分类与策略**：按 2.2 的策略将 self 分为：直接 Variant、引用语义 pack、值语义 pack+回写、不支持类型 fail-fast。
+2. **`materializeVariantValue`**：将 value 操作数打包为 Variant（如非 Variant 类型），使用 `renderPackFunctionName` + `callAssign` 到临时变量。
+3. **`emitVariantSet` / `emitVariantSetKeyed`**：
+   - 两者代码结构几乎相同，仅 C 函数名不同。
+   - key 打包策略与 GET 一致。
+   - 可抽取公共方法 `emitVariantSetCommon(bodyBuilder, cFuncName, selfVar, keyVar, valueVar)`。
+4. **`emitVariantSetNamed`**：
+   - key 为 STRING 字面量，生成静态 StringName 指针。
+5. **`emitVariantSetIndexed`**：
+   - index 为 INT 字面量。
+   - 额外声明并检查 `r_oob` 标志。
+6. **self 回写**：仅当 self 属于“值语义 pack+回写”策略时，将临时 self Variant unpack 回原 self 变量。
+7. **无 result 回写**：SET 指令 `ReturnKind=NONE`，无 resultId。
+8. **错误返回路径**：与 GET 一致。
+
+#### 验收标准
+
+- [ ] 编译通过，无 warning
+- [ ] 4 条 SET 指令均可生成正确的 C 代码
+- [ ] self 分类策略正确：直接 Variant / 引用语义 pack / 值语义 pack+回写 / 不支持类型 fail-fast
+- [ ] key 为 Variant 类型时无多余 pack
+- [ ] value 为 Variant 类型时无多余 pack
+- [ ] value 为非 Variant 类型时正确 pack 并在结束后销毁
+- [ ] 值语义 self 在 set 后正确 unpack 回写
+- [ ] r_valid 检查失败时正确打印错误并安全返回
+- [ ] variant_set_indexed 的 r_oob 检查失败时正确打印错误并安全返回
+- [ ] 所有临时变量在所有路径（正常/错误）上均被正确销毁
+- [ ] 不意外设置 resultId（SET 不返回值）
+
+---
+
+### 步骤 3：注册生成器到 CCodegen
+
+**文件**：`src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`
+
+**修改内容**：在 static 块中添加两行注册：
+
+```java
+static {
+    // ... 现有注册 ...
+    registerInsnGen(new LoadStaticInsnGen());
+    registerInsnGen(new StoreStaticInsnGen());
+    // ↓ 新增
+    registerInsnGen(new IndexLoadInsnGen());
+    registerInsnGen(new IndexStoreInsnGen());
+}
+```
+
+**导入**：添加 `import dev.superice.gdcc.backend.c.gen.insn.IndexLoadInsnGen;` 和 `import dev.superice.gdcc.backend.c.gen.insn.IndexStoreInsnGen;`（如未使用通配符导入）。
+
+#### 验收标准
+
+- [ ] 编译通过
+- [ ] `INSN_GENS` 包含 8 条新的 opcode → generator 映射
+- [ ] 不影响现有 15 个生成器的注册
+
+---
+
+### 步骤 4：创建 IndexLoadInsnGen 单元测试
+
+**文件**：`src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java`
+
+**测试类结构**（参照 `COperatorInsnGenTest` / `CConstructInsnGenTest` 模式）：
+
+```java
+class IndexLoadInsnGenTest {
+    // Helper methods: generateBody, newTestClass, newFunction, entry, newCodegen, emptyApi
+    // Record: VariableSpec(String id, GdType type, boolean ref)
+}
+```
+
+**测试用例清单**：
+
+**variant_get 正向用例：**
+1. `variant_get_variant_key_variant_result` — self=Variant, key=Variant, result=Variant → 不需要 pack/unpack，生成 `godot_variant_get` 调用 + 构造拷贝回写
+2. `variant_get_non_variant_self_pack` — self=Array, key=Variant, result=Variant → self 需 pack
+3. `variant_get_non_variant_key_pack` — self=Variant, key=int, result=Variant → key 需 pack
+4. `variant_get_non_variant_result_unpack` — self=Variant, key=Variant, result=int → 需 unpack
+
+**variant_get 错误用例：**
+5. `variant_get_missing_result_fails` — resultId 为 null → `InvalidInsnException`
+6. `variant_get_ref_result_fails` — result 变量为 ref → `InvalidInsnException`
+7. `variant_get_missing_variant_operand_fails` — variantId 不存在 → `InvalidInsnException`
+8. `variant_get_missing_key_operand_fails` — keyId 不存在 → `InvalidInsnException`
+
+**variant_get_keyed 正向用例：**
+9. `variant_get_keyed_basic` — 类似 variant_get，验证生成 `godot_variant_get_keyed`
+
+**variant_get_named 正向用例：**
+10. `variant_get_named_basic` — self=Variant, name="property", result=Variant → 生成 `godot_variant_get_named` + `GD_STATIC_SN`
+11. `variant_get_named_non_variant_self` — self=Dictionary, result=int → pack self, unpack result
+
+**variant_get_indexed 正向用例：**
+12. `variant_get_indexed_basic` — self=Variant, index=0, result=Variant → 生成 `godot_variant_get_indexed` + r_oob 检查
+13. `variant_get_indexed_non_variant_self` — self=Array, index=2, result=int → pack self, unpack result
+
+**r_valid / r_oob 错误处理验证：**
+14. `variant_get_emits_valid_check` — 验证生成的代码包含 r_valid 检查和 GDCC_PRINT_RUNTIME_ERROR
+15. `variant_get_indexed_emits_oob_check` — 验证生成的代码包含 r_oob 检查
+
+**生命周期验证：**
+16. `variant_get_destroys_temp_pack_vars` — 验证临时 pack Variant 被正确析构
+17. `variant_get_destroys_ret_variant` — 验证 r_ret Variant 被正确析构
+
+#### 验收标准
+
+- [ ] 全部测试用例通过
+- [ ] 覆盖 4 种 GET 指令
+- [ ] 覆盖 Variant/非 Variant self、key、result 组合
+- [ ] 覆盖错误路径（缺失变量、ref 变量）
+- [ ] 覆盖 r_valid 和 r_oob 检查
+- [ ] 覆盖临时变量生命周期
+
+---
+
+### 步骤 5：创建 IndexStoreInsnGen 单元测试
+
+**文件**：`src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenTest.java`
+
+**测试用例清单**：
+
+**variant_set 正向用例：**
+1. `variant_set_variant_key_variant_value` — self=Variant, key=Variant, value=Variant → 无 pack 开销
+2. `variant_set_non_variant_key_pack` — self=Variant, key=int, value=Variant → key 需 pack
+3. `variant_set_non_variant_value_pack` — self=Variant, key=Variant, value=int → value 需 pack
+4. `variant_set_array_self_pack_succeeds` — self=Array, key=int, value=Variant → self 允许 pack 且无需回写
+5. `variant_set_value_semantic_self_emits_writeback` — self=Vector3（或 Color），set 后应生成 unpack 回写
+
+**variant_set 错误用例：**
+1. `variant_set_unsupported_self_fails` — self=int（或 bool）→ `InvalidInsnException`
+2. `variant_set_missing_variant_operand_fails` — variantId 不存在 → `InvalidInsnException`
+3. `variant_set_missing_key_operand_fails` — keyId 不存在 → `InvalidInsnException`
+4. `variant_set_missing_value_operand_fails` — valueId 不存在 → `InvalidInsnException`
+
+**variant_set_keyed 正向用例：**
+1. `variant_set_keyed_basic` — 验证生成 `godot_variant_set_keyed`
+
+**variant_set_named 正向用例：**
+1. `variant_set_named_basic` — self=Variant, name="property", value=Variant → 生成 `godot_variant_set_named` + `GD_STATIC_SN`
+2. `variant_set_named_non_variant_value` — value=int → pack value
+
+**variant_set_named 错误用例：**
+1. `variant_set_named_unsupported_self_fails` — self=int（不支持 named-set）→ fail-fast
+
+**variant_set_indexed 正向用例：**
+1. `variant_set_indexed_basic` — self=Variant, index=0, value=Variant → 生成 `godot_variant_set_indexed` + r_oob 检查
+2. `variant_set_indexed_non_variant_value` — value=int → pack value
+3. `variant_set_indexed_array_self_pack_succeeds` — self=Array, index=0, value=Variant → 引用语义路径
+
+**r_valid / r_oob 错误处理验证：**
+1. `variant_set_emits_valid_check` — 验证 r_valid 检查
+2. `variant_set_indexed_emits_oob_check` — 验证 r_oob 检查
+
+**生命周期验证：**
+1. `variant_set_destroys_temp_pack_vars` — 验证临时 pack 的 key/value Variant 被正确析构
+2. `variant_set_value_semantic_writeback_path_destroys_self_temp` — 验证值语义回写路径中的 self 临时 Variant 被正确析构
+
+#### 验收标准
+
+- [ ] 全部测试用例通过
+- [ ] 覆盖 4 种 SET 指令
+- [ ] 覆盖 self 分类策略（直接 Variant / 引用语义 / 值语义回写 / 不支持类型）
+- [ ] 覆盖 Variant/非 Variant key、value 组合
+- [ ] 覆盖错误路径
+- [ ] 覆盖 r_valid 和 r_oob 检查
+- [ ] 覆盖临时变量生命周期
+
+---
+
+### 步骤 6：编译验证与现有测试回归
+
+**执行命令**：
+
+```bash
+./gradlew classes --no-daemon --info --console=plain
+./gradlew test --tests IndexLoadInsnGenTest --no-daemon --info --console=plain
+./gradlew test --tests IndexStoreInsnGenTest --no-daemon --info --console=plain
+./gradlew test --tests CCodegenTest --no-daemon --info --console=plain
+./gradlew test --no-daemon --info --console=plain
+```
+
+#### 验收标准
+
+- [ ] 编译无错误
+- [ ] 新增测试全部通过
+- [ ] 现有测试无回归
+
+---
+
+## 4. 生成的 C 代码示例
+
+### 4.1 variant_get（self=Variant, key=Variant, result=Variant）
+
+LIR:
+```
+$result = variant_get $dict $key
+```
+
+生成 C 代码：
+```c
+godot_Variant __gdcc_tmp_idx_ret_0;
+GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
+godot_variant_get(&$dict, &$key, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1);
+if (!__gdcc_tmp_idx_valid_1) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_get failed", __func__, __FILE__, __LINE__);
+    __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();
+    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
+    goto __finally__;
+}
+$result = godot_new_Variant_with_Variant(&__gdcc_tmp_idx_ret_0);
+godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
+```
+
+### 4.2 variant_get（self=Array, key=int, result=String）
+
+LIR:
+```
+$result = variant_get $arr $idx
+```
+
+生成 C 代码：
+```c
+godot_Variant __gdcc_tmp_idx_self_0 = godot_new_Variant_with_Array(&$arr);
+godot_Variant __gdcc_tmp_idx_key_1 = godot_new_Variant_with_int($idx);
+godot_Variant __gdcc_tmp_idx_ret_2;
+GDExtensionBool __gdcc_tmp_idx_valid_3 = false;
+godot_variant_get(&__gdcc_tmp_idx_self_0, &__gdcc_tmp_idx_key_1, &__gdcc_tmp_idx_ret_2, &__gdcc_tmp_idx_valid_3);
+if (!__gdcc_tmp_idx_valid_3) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_get failed", __func__, __FILE__, __LINE__);
+    __gdcc_tmp_idx_ret_2 = godot_new_Variant_nil();
+    godot_variant_destroy(&__gdcc_tmp_idx_ret_2);
+    godot_variant_destroy(&__gdcc_tmp_idx_key_1);
+    godot_variant_destroy(&__gdcc_tmp_idx_self_0);
+    goto __finally__;
+}
+$result = godot_new_String_with_Variant(&__gdcc_tmp_idx_ret_2);
+godot_variant_destroy(&__gdcc_tmp_idx_ret_2);
+godot_variant_destroy(&__gdcc_tmp_idx_key_1);
+godot_variant_destroy(&__gdcc_tmp_idx_self_0);
+```
+
+### 4.3 variant_get_named（self=Variant, name="position", result=Vector3）
+
+LIR:
+```
+$result = variant_get_named $obj "position"
+```
+
+生成 C 代码：
+```c
+godot_Variant __gdcc_tmp_idx_ret_0;
+GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
+godot_variant_get_named(&$obj, GD_STATIC_SN(u8"position"), &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1);
+if (!__gdcc_tmp_idx_valid_1) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_named 'position' failed", __func__, __FILE__, __LINE__);
+    __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();
+    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
+    goto __finally__;
+}
+$result = godot_new_Vector3_with_Variant(&__gdcc_tmp_idx_ret_0);
+godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
+```
+
+### 4.4 variant_get_indexed（self=Variant, index=2, result=Variant）
+
+LIR:
+```
+$result = variant_get_indexed $arr 2
+```
+
+生成 C 代码：
+```c
+godot_Variant __gdcc_tmp_idx_ret_0;
+GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
+GDExtensionBool __gdcc_tmp_idx_oob_2 = false;
+godot_variant_get_indexed(&$arr, (GDExtensionInt)2, &__gdcc_tmp_idx_ret_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
+if (!__gdcc_tmp_idx_valid_1) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed failed", __func__, __FILE__, __LINE__);
+    __gdcc_tmp_idx_ret_0 = godot_new_Variant_nil();
+    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
+    goto __finally__;
+}
+if (__gdcc_tmp_idx_oob_2) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_get_indexed: index out of bounds", __func__, __FILE__, __LINE__);
+    godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
+    goto __finally__;
+}
+$result = godot_new_Variant_with_Variant(&__gdcc_tmp_idx_ret_0);
+godot_variant_destroy(&__gdcc_tmp_idx_ret_0);
+```
+
+### 4.5 variant_set（self=Variant, key=Variant, value=Variant）
+
+LIR:
+```
+variant_set $dict $key $value
+```
+
+生成 C 代码：
+```c
+GDExtensionBool __gdcc_tmp_idx_valid_0 = false;
+godot_variant_set(&$dict, &$key, &$value, &__gdcc_tmp_idx_valid_0);
+if (!__gdcc_tmp_idx_valid_0) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_set failed", __func__, __FILE__, __LINE__);
+    goto __finally__;
+}
+```
+
+### 4.6 variant_set_named（self=Variant, name="health", value=int）
+
+LIR:
+```
+variant_set_named $obj "health" $hp
+```
+
+生成 C 代码：
+```c
+godot_Variant __gdcc_tmp_idx_val_0 = godot_new_Variant_with_int($hp);
+GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
+godot_variant_set_named(&$obj, GD_STATIC_SN(u8"health"), &__gdcc_tmp_idx_val_0, &__gdcc_tmp_idx_valid_1);
+if (!__gdcc_tmp_idx_valid_1) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_set_named 'health' failed", __func__, __FILE__, __LINE__);
+    godot_variant_destroy(&__gdcc_tmp_idx_val_0);
+    goto __finally__;
+}
+godot_variant_destroy(&__gdcc_tmp_idx_val_0);
+```
+
+### 4.7 variant_set_indexed（self=Variant, index=0, value=int）
+
+LIR:
+```
+variant_set_indexed $arr 0 $val
+```
+
+生成 C 代码：
+```c
+godot_Variant __gdcc_tmp_idx_val_0 = godot_new_Variant_with_int($val);
+GDExtensionBool __gdcc_tmp_idx_valid_1 = false;
+GDExtensionBool __gdcc_tmp_idx_oob_2 = false;
+godot_variant_set_indexed(&$arr, (GDExtensionInt)0, &__gdcc_tmp_idx_val_0, &__gdcc_tmp_idx_valid_1, &__gdcc_tmp_idx_oob_2);
+if (!__gdcc_tmp_idx_valid_1) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_set_indexed failed", __func__, __FILE__, __LINE__);
+    godot_variant_destroy(&__gdcc_tmp_idx_val_0);
+    goto __finally__;
+}
+if (__gdcc_tmp_idx_oob_2) {
+    GDCC_PRINT_RUNTIME_ERROR("variant_set_indexed: index out of bounds", __func__, __FILE__, __LINE__);
+    godot_variant_destroy(&__gdcc_tmp_idx_val_0);
+    goto __finally__;
+}
+godot_variant_destroy(&__gdcc_tmp_idx_val_0);
+```
+
+---
+
+## 5. 关键实现锚点
+
+| 用途 | 文件路径 |
+|---|---|
+| CInsnGen 接口 | `src/main/java/dev/superice/gdcc/backend/c/gen/CInsnGen.java` |
+| CBodyBuilder（代码构建器） | `src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java` |
+| CGenHelper（类型渲染/pack-unpack 函数名） | `src/main/java/dev/superice/gdcc/backend/c/gen/CGenHelper.java` |
+| CCodegen（注册入口） | `src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java` |
+| IndexingInstruction 接口 | `src/main/java/dev/superice/gdcc/lir/insn/IndexingInstruction.java` |
+| GdInstruction 枚举 | `src/main/java/dev/superice/gdcc/enums/GdInstruction.java` |
+| OperatorInsnGen（参考：Variant evaluate 模式） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/OperatorInsnGen.java` |
+| ConstructInsnGen（参考：pattern match 分派） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/ConstructInsnGen.java` |
+| C helper 头文件 | `src/main/c/codegen/include_451/gdcc/gdcc_helper.h` |
+| GDExtension C API 声明（gdextension-lite） | `tmp/inspect_gdlite/generated/extension_interface.h` |
+
+---
+
+## 6. 关键 CBodyBuilder API 使用指南
+
+### 6.1 用于 GET 指令的核心 API
+
+```java
+// 获取当前指令（类型安全）
+var insn = bodyBuilder.getCurrentInsn(this);
+
+// 解析变量
+var resultVar = bodyBuilder.func().getVariableById(resultId);
+var selfVar = bodyBuilder.func().getVariableById(variantId);
+
+// 创建变量引用
+bodyBuilder.valueOfVar(variable)           // 读取变量值
+bodyBuilder.targetOfVar(variable)          // 写入目标
+
+// 临时变量（未初始化，用于 r_ret 输出参数）
+var retTemp = bodyBuilder.newTempVariable("idx_ret", GdVariantType.VARIANT);
+bodyBuilder.declareUninitializedTempVar(retTemp);
+
+// 临时变量（初始化，用于 r_valid 标志）
+var validTemp = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
+bodyBuilder.declareTempVar(validTemp);
+
+// Pack 操作（通过 callAssign 到临时变量）
+var packFunc = bodyBuilder.helper().renderPackFunctionName(selfVar.type());
+bodyBuilder.callAssign(selfTemp, packFunc, GdVariantType.VARIANT, List.of(bodyBuilder.valueOfVar(selfVar)));
+
+// Unpack 操作（通过 callAssign 到 result 目标）
+var unpackFunc = bodyBuilder.helper().renderUnpackFunctionName(resultVar.type());
+bodyBuilder.callAssign(bodyBuilder.targetOfVar(resultVar), unpackFunc, resultVar.type(), List.of(retTemp));
+
+// Variant 回写（构造拷贝）
+bodyBuilder.callAssign(bodyBuilder.targetOfVar(resultVar), "godot_new_Variant_with_Variant",
+    GdVariantType.VARIANT, List.of(retTemp));
+
+// 销毁临时变量
+bodyBuilder.destroyTempVar(retTemp);
+
+// StringName 字面量
+bodyBuilder.valueOfStringNamePtrLiteral("property_name")
+// 渲染为 GD_STATIC_SN(u8"property_name")
+
+// 手动行发射（用于低级 C 调用和条件检查）
+bodyBuilder.appendLine("godot_variant_get(&..., &..., &..., &...);");
+bodyBuilder.appendLine("if (!__gdcc_tmp_idx_valid_0) {");
+
+// 错误报告
+bodyBuilder.appendLine("GDCC_PRINT_RUNTIME_ERROR(\"...\", __func__, __FILE__, __LINE__);");
+
+// 安全返回
+bodyBuilder.returnVoid();  // void 函数
+bodyBuilder.returnValue(bodyBuilder.valueOfExpr(CBodyBuilder.renderDefaultValueExpr(returnType), returnType));
+```
+
+### 6.2 `renderStaticStringNameLiteral` 用法
+
+```java
+// 在 CBodyBuilder 上有静态方法
+CBodyBuilder.renderStaticStringNameLiteral("property_name")
+// → GD_STATIC_SN(u8"property_name")
+```
+
+---
+
+## 7. 风险与防线
+
+### 7.1 风险：Variant 生命周期泄漏
+
+- **描述**：GET 指令的 `r_ret` 是未初始化 Variant 输出参数，GDExtension API 会写入一个新的 Variant。如果不在所有路径上销毁，会导致内存泄漏。
+- **防线**：
+  1. 正常路径：unpack 后立即销毁 `r_ret`。
+  2. 错误路径（r_valid=false）：先将 `r_ret` 赋为 `godot_new_Variant_nil()` 使其安全可析构，再销毁。
+  3. 错误路径（r_oob=true）：此时 `r_ret` 已被 API 写入有效值，直接销毁。
+  4. 单元测试显式验证生成代码中包含 `godot_variant_destroy` 调用。
+
+### 7.2 风险：SET 指令的 self 类型误用
+
+- **描述**：若不区分 self 的语义类别，容易出现两类问题：
+  1. 把不支持 set 的类型放进 `variant_set*`，导致运行时 `r_valid=false`；
+  2. 对值语义类型执行 set 后未回写，导致修改丢失。
+- **防线**：
+  1. IndexStoreInsnGen 在生成代码前执行 self 分类（Variant / 引用语义 / 值语义 / 不支持）。
+  2. 不支持类型编译期 fail-fast 并给出清晰错误信息。
+  3. 值语义路径强制执行 unpack 回写，并通过单元测试覆盖。
+
+### 7.3 风险：`variant_get_indexed` / `variant_set_indexed` 的 r_oob 语义
+
+- **描述**：`_indexed` 变体在 r_valid=true 但 r_oob=true 时的行为需要明确。Godot 引擎在 OOB 时仍会写入 `r_ret`（对 GET 来说是默认值）。
+- **防线**：
+  1. 先检查 `r_valid`，再检查 `r_oob`，保持与 Godot 内部检查顺序一致。
+  2. OOB 时打印运行时错误并安全返回。
+  3. OOB 路径销毁 `r_ret`（因为 API 已写入值）。
+
+### 7.4 风险：与 OperatorInsnGen 的 Variant 回写策略不一致
+
+- **描述**：GET 指令的 result 回写必须与 OperatorInsnGen 的 `variant_evaluate` result 回写保持一致：Variant→Variant 使用构造拷贝，Variant→非 Variant 使用 unpack。
+- **防线**：
+  1. 实现代码直接参照 OperatorInsnGen 的 `emitBinaryVariantEvaluate` 中的回写模式。
+  2. 单元测试验证 Variant→Variant 路径生成 `godot_new_Variant_with_Variant`。
+
+---
+
+## 8. 长期约定（实现后必须保持）
+
+### 8.1 SET 指令的 self 类型约束
+
+- `variant_set*` 指令的 self 按策略分类处理：`GdVariantType` 直传、引用语义类型可 pack、值语义类型 pack+回写。
+- 对不支持 set 的类型保持编译期 fail-fast。
+- 该约定优先于“self 必须是 Variant”这一旧规则。
+
+### 8.2 GET 指令的 r_ret 生命周期
+
+- `r_ret` 使用 `declareUninitializedTempVar` 声明。
+- 所有代码路径（正常/错误）必须在退出前销毁 `r_ret`。
+- 错误路径中如果 `r_ret` 未被 API 写入（r_valid=false 时，Godot 可能未初始化 r_ret），需要先赋 `godot_new_Variant_nil()` 再销毁。
+
+### 8.3 生成器拆分维护
+
+- GET 和 SET 分属两个独立生成器（`IndexLoadInsnGen` / `IndexStoreInsnGen`）。
+- 如果未来增加新的 indexing 指令，按 ReturnKind（REQUIRED/NONE）分配到对应生成器。
+
+---
+
+## 9. 回归测试基线
+
+### 9.1 新增测试文件
+
+- `src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java`
+- `src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenTest.java`
+
+### 9.2 建议执行命令
+
+```bash
+# 编译
+./gradlew classes --no-daemon --info --console=plain
+
+# 新增测试
+./gradlew test --tests IndexLoadInsnGenTest --no-daemon --info --console=plain
+./gradlew test --tests IndexStoreInsnGenTest --no-daemon --info --console=plain
+
+# 回归测试
+./gradlew test --tests CCodegenTest --no-daemon --info --console=plain
+./gradlew test --tests COperatorInsnGenTest --no-daemon --info --console=plain
+./gradlew test --tests CConstructInsnGenTest --no-daemon --info --console=plain
+
+# 全量测试
+./gradlew test --no-daemon --info --console=plain
+```
+
+---
+
+## 10. 非目标（当前不做）
+
+- 不修改现有 8 个 LIR `IndexingInstruction` record 类。
+- 不修改 `GdInstruction` 枚举定义。
+- 不修改 `IndexingInstruction` 接口。
+- 不在 `gdcc_helper.h` 中添加 C helper 包装函数（直接使用 gdextension-lite 提供的 API）。
+- 不添加引擎集成测试（本计划仅覆盖单元测试；引擎集成测试作为后续单独任务）。
+- 不处理 variant_get*/set* 结果类型的编译期类型检查（运行时 r_valid 检查已足够）。

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java
@@ -566,6 +566,18 @@ public final class CBodyBuilder {
         return this;
     }
 
+    /// Returns default value for current function return type.
+    /// - void: emits `goto __finally__` (or `return` when already in `__finally__`)
+    /// - non-void: emits return with `renderDefaultValueExpr(returnType)` semantics
+    public @NotNull CBodyBuilder returnDefault() {
+        var returnType = func.getReturnType();
+        if (returnType instanceof GdVoidType) {
+            return returnVoid();
+        }
+        var defaultExpr = renderDefaultValueExpr(returnType);
+        return returnValue(valueOfExpr(defaultExpr, returnType));
+    }
+
     public @NotNull CBodyBuilder returnTerminal() {
         var returnType = func.getReturnType();
         if (!checkInFinallyBlock()) {
@@ -778,7 +790,7 @@ public final class CBodyBuilder {
     /// - Value-semantic types (String, StringName, Variant, etc.): pass by pointer (&)
     /// When requireGodotRawPtr is true, GDCC object pointers are auto-converted to Godot
     /// object pointers via `gdcc_object_to_godot_object_ptr(value, Type_object_ptr)`.
-    private @NotNull RenderResult renderArgument(@NotNull ValueRef value, boolean requireGodotRawPtr) {
+    public @NotNull RenderResult renderArgument(@NotNull ValueRef value, boolean requireGodotRawPtr) {
         var type = value.type();
 
         // Convert GDCC object ptr to Godot raw ptr when calling GDExtension functions
@@ -1397,14 +1409,14 @@ public final class CBodyBuilder {
         }
     }
 
-    private record RenderResult(@NotNull String code,
-                                @NotNull List<TempVar> temps,
-                                @Nullable String preCode) {
+    public record RenderResult(@NotNull String code,
+                               @NotNull List<TempVar> temps,
+                               @Nullable String preCode) {
         private RenderResult(@NotNull String code, @NotNull List<TempVar> temps) {
             this(code, temps, null);
         }
 
-        private RenderResult {
+        public RenderResult {
             Objects.requireNonNull(code);
             Objects.requireNonNull(temps);
         }

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
@@ -46,6 +46,7 @@ public class CCodegen implements Codegen {
         registerInsnGen(new LoadStaticInsnGen());
         registerInsnGen(new StoreStaticInsnGen());
         registerInsnGen(new IndexLoadInsnGen());
+        registerInsnGen(new IndexStoreInsnGen());
     }
 
     public CodegenContext ctx;

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
@@ -45,6 +45,7 @@ public class CCodegen implements Codegen {
         registerInsnGen(new OperatorInsnGen());
         registerInsnGen(new LoadStaticInsnGen());
         registerInsnGen(new StoreStaticInsnGen());
+        registerInsnGen(new IndexLoadInsnGen());
     }
 
     public CodegenContext ctx;

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java
@@ -335,9 +335,6 @@ public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
     private @NotNull LirVariable resolveIndexedOperandVariable(@NotNull CBodyBuilder bodyBuilder,
                                                                @NotNull String indexId) {
         var indexVar = resolveOperandVariable(bodyBuilder, indexId, "index");
-        if (indexVar.ref()) {
-            throw bodyBuilder.invalidInsn("Index load index operand variable ID '" + indexId + "' cannot be a reference");
-        }
         if (!(indexVar.type() instanceof GdIntType)) {
             throw bodyBuilder.invalidInsn("Index load index operand variable ID '" + indexId +
                     "' must be int, got '" + indexVar.type().getTypeName() + "'");

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java
@@ -1,0 +1,364 @@
+package dev.superice.gdcc.backend.c.gen.insn;
+
+import dev.superice.gdcc.backend.c.gen.CBodyBuilder;
+import dev.superice.gdcc.backend.c.gen.CInsnGen;
+import dev.superice.gdcc.enums.GdInstruction;
+import dev.superice.gdcc.lir.LirVariable;
+import dev.superice.gdcc.lir.insn.IndexingInstruction;
+import dev.superice.gdcc.lir.insn.VariantGetIndexedInsn;
+import dev.superice.gdcc.lir.insn.VariantGetInsn;
+import dev.superice.gdcc.lir.insn.VariantGetKeyedInsn;
+import dev.superice.gdcc.lir.insn.VariantGetNamedInsn;
+import dev.superice.gdcc.type.GdBoolType;
+import dev.superice.gdcc.type.GdIntType;
+import dev.superice.gdcc.type.GdStringNameType;
+import dev.superice.gdcc.type.GdVariantType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+
+/// C code generator for indexing load instructions:
+/// - variant_get
+/// - variant_get_keyed
+/// - variant_get_named
+/// - variant_get_indexed
+public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
+    @Override
+    public @NotNull EnumSet<GdInstruction> getInsnOpcodes() {
+        return EnumSet.of(
+                GdInstruction.VARIANT_GET,
+                GdInstruction.VARIANT_GET_KEYED,
+                GdInstruction.VARIANT_GET_NAMED,
+                GdInstruction.VARIANT_GET_INDEXED
+        );
+    }
+
+    @Override
+    public void generateCCode(@NotNull CBodyBuilder bodyBuilder) {
+        var instruction = bodyBuilder.getCurrentInsn(this);
+        switch (instruction) {
+            case VariantGetInsn insn -> emitVariantGet(bodyBuilder, insn);
+            case VariantGetKeyedInsn insn -> emitVariantGetKeyed(bodyBuilder, insn);
+            case VariantGetNamedInsn insn -> emitVariantGetNamed(bodyBuilder, insn);
+            case VariantGetIndexedInsn insn -> emitVariantGetIndexed(bodyBuilder, insn);
+            default -> throw bodyBuilder.invalidInsn("Unsupported index load instruction: " +
+                    instruction.getClass().getSimpleName());
+        }
+    }
+
+    private void emitVariantGet(@NotNull CBodyBuilder bodyBuilder, @NotNull VariantGetInsn insn) {
+        var resultVar = resolveRequiredResultVariable(bodyBuilder, insn.resultId());
+        var selfVar = resolveOperandVariable(bodyBuilder, insn.variantId(), "self");
+        var keyVar = resolveOperandVariable(bodyBuilder, insn.keyId(), "key");
+
+        emitVariantGetByVariantKey(
+                bodyBuilder,
+                insn.opcode().opcode(),
+                "godot_variant_get",
+                resultVar,
+                selfVar,
+                keyVar
+        );
+    }
+
+    private void emitVariantGetKeyed(@NotNull CBodyBuilder bodyBuilder, @NotNull VariantGetKeyedInsn insn) {
+        var resultVar = resolveRequiredResultVariable(bodyBuilder, insn.resultId());
+        var selfVar = resolveOperandVariable(bodyBuilder, insn.keyedVariantId(), "self");
+        var keyVar = resolveOperandVariable(bodyBuilder, insn.keyId(), "key");
+
+        emitVariantGetByVariantKey(
+                bodyBuilder,
+                insn.opcode().opcode(),
+                "godot_variant_get_keyed",
+                resultVar,
+                selfVar,
+                keyVar
+        );
+    }
+
+    private void emitVariantGetByVariantKey(@NotNull CBodyBuilder bodyBuilder,
+                                            @NotNull String insnName,
+                                            @NotNull String cFunctionName,
+                                            @NotNull LirVariable resultVar,
+                                            @NotNull LirVariable selfVar,
+                                            @NotNull LirVariable keyVar) {
+        var selfOperand = materializeVariantOperand(bodyBuilder, selfVar, "idx_self_variant");
+        var keyOperand = materializeVariantOperand(bodyBuilder, keyVar, "idx_key_variant");
+        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
+        var keyArgCode = renderArgumentCode(bodyBuilder, keyOperand.variantValue());
+        var retTemp = bodyBuilder.newTempVariable("idx_ret", GdVariantType.VARIANT);
+        bodyBuilder.declareUninitializedTempVar(retTemp);
+        var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
+        bodyBuilder.declareTempVar(validFlag);
+
+        bodyBuilder.appendLine(
+                cFunctionName + "(" +
+                        selfArgCode + ", " +
+                        keyArgCode + ", " +
+                        "&" + retTemp.name() + ", " +
+                        "&" + validFlag.name() +
+                        ");"
+        );
+        bodyBuilder.appendLine("if (!" + validFlag.name() + ") {");
+        bodyBuilder.appendLine(
+                "GDCC_PRINT_RUNTIME_ERROR(\"" + insnName +
+                        " failed: self=$" + selfVar.id() +
+                        ", key=$" + keyVar.id() +
+                        ", result=$" + resultVar.id() +
+                        "\", __func__, __FILE__, __LINE__);"
+        );
+        emitInvalidReturn(bodyBuilder, retTemp, keyOperand.tempVar(), selfOperand.tempVar());
+        bodyBuilder.appendLine("}");
+        retTemp.setInitialized(true);
+        if (keyOperand.tempVar() != null) {
+            keyOperand.tempVar().setInitialized(true);
+        }
+        if (selfOperand.tempVar() != null) {
+            selfOperand.tempVar().setInitialized(true);
+        }
+
+        emitAssignResultFromVariant(bodyBuilder, resultVar, retTemp);
+        bodyBuilder.destroyTempVar(retTemp);
+        if (keyOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(keyOperand.tempVar());
+        }
+        if (selfOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(selfOperand.tempVar());
+        }
+    }
+
+    private void emitVariantGetNamed(@NotNull CBodyBuilder bodyBuilder, @NotNull VariantGetNamedInsn insn) {
+        var resultVar = resolveRequiredResultVariable(bodyBuilder, insn.resultId());
+        var selfVar = resolveOperandVariable(bodyBuilder, insn.namedVariantId(), "self");
+        var nameVar = resolveStringNameOperandVariable(bodyBuilder, insn.nameId());
+        var selfOperand = materializeVariantOperand(bodyBuilder, selfVar, "idx_self_variant");
+        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
+        var retTemp = bodyBuilder.newTempVariable("idx_ret", GdVariantType.VARIANT);
+        bodyBuilder.declareUninitializedTempVar(retTemp);
+        var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
+        bodyBuilder.declareTempVar(validFlag);
+        var keyArgCode = renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(nameVar));
+
+        bodyBuilder.appendLine(
+                "godot_variant_get_named(" +
+                        selfArgCode + ", " +
+                        keyArgCode + ", " +
+                        "&" + retTemp.name() + ", " +
+                        "&" + validFlag.name() +
+                        ");"
+        );
+        bodyBuilder.appendLine("if (!" + validFlag.name() + ") {");
+        bodyBuilder.appendLine(
+                "GDCC_PRINT_RUNTIME_ERROR(\"variant_get_named failed: self=$" + selfVar.id() +
+                        ", name=$" + nameVar.id() +
+                        ", result=$" + resultVar.id() +
+                        "\", __func__, __FILE__, __LINE__);"
+        );
+        emitInvalidReturn(bodyBuilder, retTemp, null, selfOperand.tempVar());
+        bodyBuilder.appendLine("}");
+        retTemp.setInitialized(true);
+        if (selfOperand.tempVar() != null) {
+            selfOperand.tempVar().setInitialized(true);
+        }
+
+        emitAssignResultFromVariant(bodyBuilder, resultVar, retTemp);
+        bodyBuilder.destroyTempVar(retTemp);
+        if (selfOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(selfOperand.tempVar());
+        }
+    }
+
+    private void emitVariantGetIndexed(@NotNull CBodyBuilder bodyBuilder, @NotNull VariantGetIndexedInsn insn) {
+        var resultVar = resolveRequiredResultVariable(bodyBuilder, insn.resultId());
+        var selfVar = resolveOperandVariable(bodyBuilder, insn.variantId(), "self");
+        var indexVar = resolveIndexedOperandVariable(bodyBuilder, insn.indexId());
+        var selfOperand = materializeVariantOperand(bodyBuilder, selfVar, "idx_self_variant");
+        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
+        var indexArgCode = renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(indexVar));
+        var retTemp = bodyBuilder.newTempVariable("idx_ret", GdVariantType.VARIANT);
+        bodyBuilder.declareUninitializedTempVar(retTemp);
+        var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
+        bodyBuilder.declareTempVar(validFlag);
+        var oobFlag = bodyBuilder.newTempVariable("idx_oob", GdBoolType.BOOL, "false");
+        bodyBuilder.declareTempVar(oobFlag);
+
+        bodyBuilder.appendLine(
+                "godot_variant_get_indexed(" +
+                        selfArgCode + ", " +
+                        "(GDExtensionInt)" + indexArgCode + ", " +
+                        "&" + retTemp.name() + ", " +
+                        "&" + validFlag.name() + ", " +
+                        "&" + oobFlag.name() +
+                        ");"
+        );
+        bodyBuilder.appendLine("if (!" + validFlag.name() + ") {");
+        bodyBuilder.appendLine(
+                "GDCC_PRINT_RUNTIME_ERROR(\"variant_get_indexed failed: self=$" + selfVar.id() +
+                        ", index=$" + indexVar.id() +
+                        ", result=$" + resultVar.id() +
+                        "\", __func__, __FILE__, __LINE__);"
+        );
+        emitInvalidReturn(bodyBuilder, retTemp, null, selfOperand.tempVar());
+        bodyBuilder.appendLine("}");
+        retTemp.setInitialized(true);
+        if (selfOperand.tempVar() != null) {
+            selfOperand.tempVar().setInitialized(true);
+        }
+
+        bodyBuilder.appendLine("if (" + oobFlag.name() + ") {");
+        bodyBuilder.appendLine(
+                "GDCC_PRINT_RUNTIME_ERROR(\"variant_get_indexed index out of bounds: index=$" +
+                        indexVar.id() + "\", __func__, __FILE__, __LINE__);"
+        );
+        emitOobReturn(bodyBuilder, retTemp, selfOperand.tempVar());
+        bodyBuilder.appendLine("}");
+        retTemp.setInitialized(true);
+        if (selfOperand.tempVar() != null) {
+            selfOperand.tempVar().setInitialized(true);
+        }
+
+        emitAssignResultFromVariant(bodyBuilder, resultVar, retTemp);
+        bodyBuilder.destroyTempVar(retTemp);
+        if (selfOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(selfOperand.tempVar());
+        }
+    }
+
+    private void emitAssignResultFromVariant(@NotNull CBodyBuilder bodyBuilder,
+                                             @NotNull LirVariable resultVar,
+                                             @NotNull CBodyBuilder.TempVar retTemp) {
+        if (resultVar.type() instanceof GdVariantType) {
+            bodyBuilder.callAssign(
+                    bodyBuilder.targetOfVar(resultVar),
+                    "godot_new_Variant_with_Variant",
+                    GdVariantType.VARIANT,
+                    List.of(retTemp)
+            );
+            return;
+        }
+
+        var unpackFunctionName = bodyBuilder.helper().renderUnpackFunctionName(resultVar.type());
+        bodyBuilder.callAssign(
+                bodyBuilder.targetOfVar(resultVar),
+                unpackFunctionName,
+                resultVar.type(),
+                List.of(retTemp)
+        );
+    }
+
+    private void emitInvalidReturn(@NotNull CBodyBuilder bodyBuilder,
+                                   @NotNull CBodyBuilder.TempVar retTemp,
+                                   @Nullable CBodyBuilder.TempVar keyTemp,
+                                   @Nullable CBodyBuilder.TempVar selfTemp) {
+        bodyBuilder.assignExpr(retTemp, "godot_new_Variant_nil()", GdVariantType.VARIANT);
+        bodyBuilder.destroyTempVar(retTemp);
+        if (keyTemp != null) {
+            bodyBuilder.destroyTempVar(keyTemp);
+        }
+        if (selfTemp != null) {
+            bodyBuilder.destroyTempVar(selfTemp);
+        }
+        bodyBuilder.returnDefault();
+    }
+
+    private void emitOobReturn(@NotNull CBodyBuilder bodyBuilder,
+                               @NotNull CBodyBuilder.TempVar retTemp,
+                               @Nullable CBodyBuilder.TempVar selfTemp) {
+        bodyBuilder.destroyTempVar(retTemp);
+        if (selfTemp != null) {
+            bodyBuilder.destroyTempVar(selfTemp);
+        }
+        bodyBuilder.returnDefault();
+    }
+
+    private @NotNull VariantOperand materializeVariantOperand(@NotNull CBodyBuilder bodyBuilder,
+                                                              @NotNull LirVariable operandVar,
+                                                              @NotNull String tempPrefix) {
+        if (operandVar.type() instanceof GdVariantType) {
+            return new VariantOperand(bodyBuilder.valueOfVar(operandVar), null);
+        }
+
+        var tempVariant = bodyBuilder.newTempVariable(tempPrefix, GdVariantType.VARIANT);
+        bodyBuilder.declareTempVar(tempVariant);
+        var packFunctionName = bodyBuilder.helper().renderPackFunctionName(operandVar.type());
+        bodyBuilder.callAssign(
+                tempVariant,
+                packFunctionName,
+                GdVariantType.VARIANT,
+                List.of(bodyBuilder.valueOfVar(operandVar))
+        );
+        return new VariantOperand(tempVariant, tempVariant);
+    }
+
+    private @NotNull String renderArgumentCode(@NotNull CBodyBuilder bodyBuilder,
+                                               @NotNull CBodyBuilder.ValueRef valueRef) {
+        var rendered = bodyBuilder.renderArgument(valueRef, false);
+        if (rendered.preCode() != null && !rendered.preCode().isBlank()) {
+            bodyBuilder.appendRaw(rendered.preCode());
+        }
+        if (!rendered.temps().isEmpty()) {
+            throw bodyBuilder.invalidInsn("Unexpected temporary variables in argument code for index load instruction: " +
+                    rendered.temps().stream().map(CBodyBuilder.TempVar::name).toList());
+        }
+        return rendered.code();
+    }
+
+    private @NotNull LirVariable resolveRequiredResultVariable(@NotNull CBodyBuilder bodyBuilder,
+                                                               @Nullable String resultId) {
+        if (resultId == null || resultId.isBlank()) {
+            throw bodyBuilder.invalidInsn("Index load instruction missing required result variable ID");
+        }
+        var resultVar = bodyBuilder.func().getVariableById(resultId);
+        if (resultVar == null) {
+            throw bodyBuilder.invalidInsn("Result variable ID '" + resultId + "' not found in function");
+        }
+        if (resultVar.ref()) {
+            throw bodyBuilder.invalidInsn("Result variable ID '" + resultId + "' cannot be a reference");
+        }
+        return resultVar;
+    }
+
+    private @NotNull LirVariable resolveOperandVariable(@NotNull CBodyBuilder bodyBuilder,
+                                                        @NotNull String variableId,
+                                                        @NotNull String role) {
+        var variable = bodyBuilder.func().getVariableById(variableId);
+        if (variable == null) {
+            throw bodyBuilder.invalidInsn("Index load " + role + " operand variable ID '" + variableId +
+                    "' not found in function");
+        }
+        return variable;
+    }
+
+    private @NotNull LirVariable resolveIndexedOperandVariable(@NotNull CBodyBuilder bodyBuilder,
+                                                               @NotNull String indexId) {
+        var indexVar = resolveOperandVariable(bodyBuilder, indexId, "index");
+        if (indexVar.ref()) {
+            throw bodyBuilder.invalidInsn("Index load index operand variable ID '" + indexId + "' cannot be a reference");
+        }
+        if (!(indexVar.type() instanceof GdIntType)) {
+            throw bodyBuilder.invalidInsn("Index load index operand variable ID '" + indexId +
+                    "' must be int, got '" + indexVar.type().getTypeName() + "'");
+        }
+        return indexVar;
+    }
+
+    private @NotNull LirVariable resolveStringNameOperandVariable(@NotNull CBodyBuilder bodyBuilder,
+                                                                  @NotNull String nameId) {
+        var nameVar = resolveOperandVariable(bodyBuilder, nameId, "name");
+        if (!(nameVar.type() instanceof GdStringNameType)) {
+            throw bodyBuilder.invalidInsn("Index load name operand variable ID '" + nameId +
+                    "' must be StringName, got '" + nameVar.type().getTypeName() + "'");
+        }
+        return nameVar;
+    }
+
+    private record VariantOperand(@NotNull CBodyBuilder.ValueRef variantValue,
+                                  @Nullable CBodyBuilder.TempVar tempVar) {
+        private VariantOperand {
+            Objects.requireNonNull(variantValue);
+        }
+    }
+}

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexLoadInsnGen.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
 
 /// C code generator for indexing load instructions:
 /// - variant_get
@@ -85,10 +84,10 @@ public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
                                             @NotNull LirVariable resultVar,
                                             @NotNull LirVariable selfVar,
                                             @NotNull LirVariable keyVar) {
-        var selfOperand = materializeVariantOperand(bodyBuilder, selfVar, "idx_self_variant");
-        var keyOperand = materializeVariantOperand(bodyBuilder, keyVar, "idx_key_variant");
-        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
-        var keyArgCode = renderArgumentCode(bodyBuilder, keyOperand.variantValue());
+        var selfOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, selfVar, "idx_self_variant");
+        var keyOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, keyVar, "idx_key_variant");
+        var selfArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, selfOperand.variantValue(), "index load instruction");
+        var keyArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, keyOperand.variantValue(), "index load instruction");
         var retTemp = bodyBuilder.newTempVariable("idx_ret", GdVariantType.VARIANT);
         bodyBuilder.declareUninitializedTempVar(retTemp);
         var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
@@ -134,13 +133,13 @@ public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
         var resultVar = resolveRequiredResultVariable(bodyBuilder, insn.resultId());
         var selfVar = resolveOperandVariable(bodyBuilder, insn.namedVariantId(), "self");
         var nameVar = resolveStringNameOperandVariable(bodyBuilder, insn.nameId());
-        var selfOperand = materializeVariantOperand(bodyBuilder, selfVar, "idx_self_variant");
-        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
+        var selfOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, selfVar, "idx_self_variant");
+        var selfArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, selfOperand.variantValue(), "index load instruction");
         var retTemp = bodyBuilder.newTempVariable("idx_ret", GdVariantType.VARIANT);
         bodyBuilder.declareUninitializedTempVar(retTemp);
         var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
         bodyBuilder.declareTempVar(validFlag);
-        var keyArgCode = renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(nameVar));
+        var keyArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(nameVar), "index load instruction");
 
         bodyBuilder.appendLine(
                 "godot_variant_get_named(" +
@@ -175,9 +174,9 @@ public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
         var resultVar = resolveRequiredResultVariable(bodyBuilder, insn.resultId());
         var selfVar = resolveOperandVariable(bodyBuilder, insn.variantId(), "self");
         var indexVar = resolveIndexedOperandVariable(bodyBuilder, insn.indexId());
-        var selfOperand = materializeVariantOperand(bodyBuilder, selfVar, "idx_self_variant");
-        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
-        var indexArgCode = renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(indexVar));
+        var selfOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, selfVar, "idx_self_variant");
+        var selfArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, selfOperand.variantValue(), "index load instruction");
+        var indexArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(indexVar), "index load instruction");
         var retTemp = bodyBuilder.newTempVariable("idx_ret", GdVariantType.VARIANT);
         bodyBuilder.declareUninitializedTempVar(retTemp);
         var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
@@ -274,38 +273,6 @@ public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
         bodyBuilder.returnDefault();
     }
 
-    private @NotNull VariantOperand materializeVariantOperand(@NotNull CBodyBuilder bodyBuilder,
-                                                              @NotNull LirVariable operandVar,
-                                                              @NotNull String tempPrefix) {
-        if (operandVar.type() instanceof GdVariantType) {
-            return new VariantOperand(bodyBuilder.valueOfVar(operandVar), null);
-        }
-
-        var tempVariant = bodyBuilder.newTempVariable(tempPrefix, GdVariantType.VARIANT);
-        bodyBuilder.declareTempVar(tempVariant);
-        var packFunctionName = bodyBuilder.helper().renderPackFunctionName(operandVar.type());
-        bodyBuilder.callAssign(
-                tempVariant,
-                packFunctionName,
-                GdVariantType.VARIANT,
-                List.of(bodyBuilder.valueOfVar(operandVar))
-        );
-        return new VariantOperand(tempVariant, tempVariant);
-    }
-
-    private @NotNull String renderArgumentCode(@NotNull CBodyBuilder bodyBuilder,
-                                               @NotNull CBodyBuilder.ValueRef valueRef) {
-        var rendered = bodyBuilder.renderArgument(valueRef, false);
-        if (rendered.preCode() != null && !rendered.preCode().isBlank()) {
-            bodyBuilder.appendRaw(rendered.preCode());
-        }
-        if (!rendered.temps().isEmpty()) {
-            throw bodyBuilder.invalidInsn("Unexpected temporary variables in argument code for index load instruction: " +
-                    rendered.temps().stream().map(CBodyBuilder.TempVar::name).toList());
-        }
-        return rendered.code();
-    }
-
     private @NotNull LirVariable resolveRequiredResultVariable(@NotNull CBodyBuilder bodyBuilder,
                                                                @Nullable String resultId) {
         if (resultId == null || resultId.isBlank()) {
@@ -352,10 +319,4 @@ public final class IndexLoadInsnGen implements CInsnGen<IndexingInstruction> {
         return nameVar;
     }
 
-    private record VariantOperand(@NotNull CBodyBuilder.ValueRef variantValue,
-                                  @Nullable CBodyBuilder.TempVar tempVar) {
-        private VariantOperand {
-            Objects.requireNonNull(variantValue);
-        }
-    }
 }

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexStoreInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexStoreInsnGen.java
@@ -69,8 +69,8 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
         var valueVar = resolveOperandVariable(bodyBuilder, insn.valueId(), "value");
 
         var selfOperand = materializeSelfOperand(bodyBuilder, selfVar, SelfMode.VARIANT_SET);
-        var keyOperand = materializeVariantOperand(bodyBuilder, keyVar, "idx_key_variant");
-        var valueOperand = materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
+        var keyOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, keyVar, "idx_key_variant");
+        var valueOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
 
         emitVariantSetByVariantKey(
                 bodyBuilder,
@@ -92,8 +92,8 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
         var valueVar = resolveOperandVariable(bodyBuilder, insn.valueId(), "value");
 
         var selfOperand = materializeSelfOperand(bodyBuilder, selfVar, SelfMode.VARIANT_SET_KEYED);
-        var keyOperand = materializeVariantOperand(bodyBuilder, keyVar, "idx_key_variant");
-        var valueOperand = materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
+        var keyOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, keyVar, "idx_key_variant");
+        var valueOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
 
         emitVariantSetByVariantKey(
                 bodyBuilder,
@@ -115,11 +115,11 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
                                             @NotNull LirVariable keyVar,
                                             @NotNull LirVariable valueVar,
                                             @NotNull SelfOperand selfOperand,
-                                            @NotNull VariantOperand keyOperand,
-                                            @NotNull VariantOperand valueOperand) {
-        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
-        var keyArgCode = renderArgumentCode(bodyBuilder, keyOperand.variantValue());
-        var valueArgCode = renderArgumentCode(bodyBuilder, valueOperand.variantValue());
+                                            @NotNull InsnGenSupport.VariantOperand keyOperand,
+                                            @NotNull InsnGenSupport.VariantOperand valueOperand) {
+        var selfArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, selfOperand.variantValue(), "index store instruction");
+        var keyArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, keyOperand.variantValue(), "index store instruction");
+        var valueArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, valueOperand.variantValue(), "index store instruction");
         var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
         bodyBuilder.declareTempVar(validFlag);
 
@@ -163,10 +163,10 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
         var valueVar = resolveOperandVariable(bodyBuilder, insn.valueId(), "value");
 
         var selfOperand = materializeSelfOperand(bodyBuilder, selfVar, SelfMode.VARIANT_SET_NAMED);
-        var valueOperand = materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
-        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
-        var keyArgCode = renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(nameVar));
-        var valueArgCode = renderArgumentCode(bodyBuilder, valueOperand.variantValue());
+        var valueOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
+        var selfArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, selfOperand.variantValue(), "index store instruction");
+        var keyArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(nameVar), "index store instruction");
+        var valueArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, valueOperand.variantValue(), "index store instruction");
         var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
         bodyBuilder.declareTempVar(validFlag);
 
@@ -206,10 +206,10 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
         var valueVar = resolveOperandVariable(bodyBuilder, insn.valueId(), "value");
 
         var selfOperand = materializeSelfOperand(bodyBuilder, selfVar, SelfMode.VARIANT_SET_INDEXED);
-        var valueOperand = materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
-        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
-        var indexArgCode = renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(indexVar));
-        var valueArgCode = renderArgumentCode(bodyBuilder, valueOperand.variantValue());
+        var valueOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
+        var selfArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, selfOperand.variantValue(), "index store instruction");
+        var indexArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(indexVar), "index store instruction");
+        var valueArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, valueOperand.variantValue(), "index store instruction");
         var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
         bodyBuilder.declareTempVar(validFlag);
         var oobFlag = bodyBuilder.newTempVariable("idx_oob", GdBoolType.BOOL, "false");
@@ -375,38 +375,6 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
                 type instanceof GdPackedArrayType;
     }
 
-    private @NotNull VariantOperand materializeVariantOperand(@NotNull CBodyBuilder bodyBuilder,
-                                                              @NotNull LirVariable operandVar,
-                                                              @NotNull String tempPrefix) {
-        if (operandVar.type() instanceof GdVariantType) {
-            return new VariantOperand(bodyBuilder.valueOfVar(operandVar), null);
-        }
-
-        var tempVariant = bodyBuilder.newTempVariable(tempPrefix, GdVariantType.VARIANT);
-        bodyBuilder.declareTempVar(tempVariant);
-        var packFunctionName = bodyBuilder.helper().renderPackFunctionName(operandVar.type());
-        bodyBuilder.callAssign(
-                tempVariant,
-                packFunctionName,
-                GdVariantType.VARIANT,
-                List.of(bodyBuilder.valueOfVar(operandVar))
-        );
-        return new VariantOperand(tempVariant, tempVariant);
-    }
-
-    private @NotNull String renderArgumentCode(@NotNull CBodyBuilder bodyBuilder,
-                                               @NotNull CBodyBuilder.ValueRef valueRef) {
-        var rendered = bodyBuilder.renderArgument(valueRef, false);
-        if (rendered.preCode() != null && !rendered.preCode().isBlank()) {
-            bodyBuilder.appendRaw(rendered.preCode());
-        }
-        if (!rendered.temps().isEmpty()) {
-            throw bodyBuilder.invalidInsn("Unexpected temporary variables in argument code for index store instruction: " +
-                    rendered.temps().stream().map(CBodyBuilder.TempVar::name).toList());
-        }
-        return rendered.code();
-    }
-
     private void emitFailureReturn(@NotNull CBodyBuilder bodyBuilder,
                                    @Nullable CBodyBuilder.TempVar... tempsToDestroy) {
         if (tempsToDestroy != null) {
@@ -494,10 +462,4 @@ public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
         }
     }
 
-    private record VariantOperand(@NotNull CBodyBuilder.ValueRef variantValue,
-                                  @Nullable CBodyBuilder.TempVar tempVar) {
-        private VariantOperand {
-            Objects.requireNonNull(variantValue);
-        }
-    }
 }

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexStoreInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/IndexStoreInsnGen.java
@@ -1,0 +1,503 @@
+package dev.superice.gdcc.backend.c.gen.insn;
+
+import dev.superice.gdcc.backend.c.gen.CBodyBuilder;
+import dev.superice.gdcc.backend.c.gen.CInsnGen;
+import dev.superice.gdcc.enums.GdInstruction;
+import dev.superice.gdcc.lir.LirVariable;
+import dev.superice.gdcc.lir.insn.IndexingInstruction;
+import dev.superice.gdcc.lir.insn.VariantSetIndexedInsn;
+import dev.superice.gdcc.lir.insn.VariantSetInsn;
+import dev.superice.gdcc.lir.insn.VariantSetKeyedInsn;
+import dev.superice.gdcc.lir.insn.VariantSetNamedInsn;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdBoolType;
+import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdIntType;
+import dev.superice.gdcc.type.GdMetaType;
+import dev.superice.gdcc.type.GdNilType;
+import dev.superice.gdcc.type.GdNodePathType;
+import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdPackedArrayType;
+import dev.superice.gdcc.type.GdPrimitiveType;
+import dev.superice.gdcc.type.GdRidType;
+import dev.superice.gdcc.type.GdStringNameType;
+import dev.superice.gdcc.type.GdStringType;
+import dev.superice.gdcc.type.GdType;
+import dev.superice.gdcc.type.GdVariantType;
+import dev.superice.gdcc.type.GdVectorType;
+import dev.superice.gdcc.type.GdVoidType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+
+/// C code generator for indexing store instructions:
+/// - variant_set
+/// - variant_set_keyed
+/// - variant_set_named
+/// - variant_set_indexed
+public final class IndexStoreInsnGen implements CInsnGen<IndexingInstruction> {
+    @Override
+    public @NotNull EnumSet<GdInstruction> getInsnOpcodes() {
+        return EnumSet.of(
+                GdInstruction.VARIANT_SET,
+                GdInstruction.VARIANT_SET_KEYED,
+                GdInstruction.VARIANT_SET_NAMED,
+                GdInstruction.VARIANT_SET_INDEXED
+        );
+    }
+
+    @Override
+    public void generateCCode(@NotNull CBodyBuilder bodyBuilder) {
+        var instruction = bodyBuilder.getCurrentInsn(this);
+        switch (instruction) {
+            case VariantSetInsn insn -> emitVariantSet(bodyBuilder, insn);
+            case VariantSetKeyedInsn insn -> emitVariantSetKeyed(bodyBuilder, insn);
+            case VariantSetNamedInsn insn -> emitVariantSetNamed(bodyBuilder, insn);
+            case VariantSetIndexedInsn insn -> emitVariantSetIndexed(bodyBuilder, insn);
+            default -> throw bodyBuilder.invalidInsn("Unsupported index store instruction: " +
+                    instruction.getClass().getSimpleName());
+        }
+    }
+
+    private void emitVariantSet(@NotNull CBodyBuilder bodyBuilder, @NotNull VariantSetInsn insn) {
+        ensureNoResultVariable(bodyBuilder, insn.resultId(), insn.opcode().opcode());
+        var selfVar = resolveOperandVariable(bodyBuilder, insn.variantId(), "self");
+        var keyVar = resolveOperandVariable(bodyBuilder, insn.keyId(), "key");
+        var valueVar = resolveOperandVariable(bodyBuilder, insn.valueId(), "value");
+
+        var selfOperand = materializeSelfOperand(bodyBuilder, selfVar, SelfMode.VARIANT_SET);
+        var keyOperand = materializeVariantOperand(bodyBuilder, keyVar, "idx_key_variant");
+        var valueOperand = materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
+
+        emitVariantSetByVariantKey(
+                bodyBuilder,
+                insn.opcode().opcode(),
+                "godot_variant_set",
+                selfVar,
+                keyVar,
+                valueVar,
+                selfOperand,
+                keyOperand,
+                valueOperand
+        );
+    }
+
+    private void emitVariantSetKeyed(@NotNull CBodyBuilder bodyBuilder, @NotNull VariantSetKeyedInsn insn) {
+        ensureNoResultVariable(bodyBuilder, insn.resultId(), insn.opcode().opcode());
+        var selfVar = resolveOperandVariable(bodyBuilder, insn.keyedVariantId(), "self");
+        var keyVar = resolveOperandVariable(bodyBuilder, insn.keyId(), "key");
+        var valueVar = resolveOperandVariable(bodyBuilder, insn.valueId(), "value");
+
+        var selfOperand = materializeSelfOperand(bodyBuilder, selfVar, SelfMode.VARIANT_SET_KEYED);
+        var keyOperand = materializeVariantOperand(bodyBuilder, keyVar, "idx_key_variant");
+        var valueOperand = materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
+
+        emitVariantSetByVariantKey(
+                bodyBuilder,
+                insn.opcode().opcode(),
+                "godot_variant_set_keyed",
+                selfVar,
+                keyVar,
+                valueVar,
+                selfOperand,
+                keyOperand,
+                valueOperand
+        );
+    }
+
+    private void emitVariantSetByVariantKey(@NotNull CBodyBuilder bodyBuilder,
+                                            @NotNull String insnName,
+                                            @NotNull String cFunctionName,
+                                            @NotNull LirVariable selfVar,
+                                            @NotNull LirVariable keyVar,
+                                            @NotNull LirVariable valueVar,
+                                            @NotNull SelfOperand selfOperand,
+                                            @NotNull VariantOperand keyOperand,
+                                            @NotNull VariantOperand valueOperand) {
+        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
+        var keyArgCode = renderArgumentCode(bodyBuilder, keyOperand.variantValue());
+        var valueArgCode = renderArgumentCode(bodyBuilder, valueOperand.variantValue());
+        var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
+        bodyBuilder.declareTempVar(validFlag);
+
+        bodyBuilder.appendLine(
+                cFunctionName + "(" +
+                        selfArgCode + ", " +
+                        keyArgCode + ", " +
+                        valueArgCode + ", " +
+                        "&" + validFlag.name() +
+                        ");"
+        );
+        bodyBuilder.appendLine("if (!" + validFlag.name() + ") {");
+        bodyBuilder.appendLine(
+                "GDCC_PRINT_RUNTIME_ERROR(\"" + insnName +
+                        " failed: self=$" + selfVar.id() +
+                        ", key=$" + keyVar.id() +
+                        ", value=$" + valueVar.id() +
+                        "\", __func__, __FILE__, __LINE__);"
+        );
+        emitFailureReturn(bodyBuilder, valueOperand.tempVar(), keyOperand.tempVar(), selfOperand.tempVar());
+        bodyBuilder.appendLine("}");
+        restoreInitialized(valueOperand.tempVar(), keyOperand.tempVar(), selfOperand.tempVar());
+
+        emitSelfWritebackIfNeeded(bodyBuilder, selfVar, selfOperand);
+
+        if (valueOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(valueOperand.tempVar());
+        }
+        if (keyOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(keyOperand.tempVar());
+        }
+        if (selfOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(selfOperand.tempVar());
+        }
+    }
+
+    private void emitVariantSetNamed(@NotNull CBodyBuilder bodyBuilder, @NotNull VariantSetNamedInsn insn) {
+        ensureNoResultVariable(bodyBuilder, insn.resultId(), insn.opcode().opcode());
+        var selfVar = resolveOperandVariable(bodyBuilder, insn.namedVariantId(), "self");
+        var nameVar = resolveStringNameOperandVariable(bodyBuilder, insn.nameId());
+        var valueVar = resolveOperandVariable(bodyBuilder, insn.valueId(), "value");
+
+        var selfOperand = materializeSelfOperand(bodyBuilder, selfVar, SelfMode.VARIANT_SET_NAMED);
+        var valueOperand = materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
+        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
+        var keyArgCode = renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(nameVar));
+        var valueArgCode = renderArgumentCode(bodyBuilder, valueOperand.variantValue());
+        var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
+        bodyBuilder.declareTempVar(validFlag);
+
+        bodyBuilder.appendLine(
+                "godot_variant_set_named(" +
+                        selfArgCode + ", " +
+                        keyArgCode + ", " +
+                        valueArgCode + ", " +
+                        "&" + validFlag.name() +
+                        ");"
+        );
+        bodyBuilder.appendLine("if (!" + validFlag.name() + ") {");
+        bodyBuilder.appendLine(
+                "GDCC_PRINT_RUNTIME_ERROR(\"variant_set_named failed: self=$" + selfVar.id() +
+                        ", name=$" + nameVar.id() +
+                        ", value=$" + valueVar.id() +
+                        "\", __func__, __FILE__, __LINE__);"
+        );
+        emitFailureReturn(bodyBuilder, valueOperand.tempVar(), selfOperand.tempVar());
+        bodyBuilder.appendLine("}");
+        restoreInitialized(valueOperand.tempVar(), selfOperand.tempVar());
+
+        emitSelfWritebackIfNeeded(bodyBuilder, selfVar, selfOperand);
+
+        if (valueOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(valueOperand.tempVar());
+        }
+        if (selfOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(selfOperand.tempVar());
+        }
+    }
+
+    private void emitVariantSetIndexed(@NotNull CBodyBuilder bodyBuilder, @NotNull VariantSetIndexedInsn insn) {
+        ensureNoResultVariable(bodyBuilder, insn.resultId(), insn.opcode().opcode());
+        var selfVar = resolveOperandVariable(bodyBuilder, insn.variantId(), "self");
+        var indexVar = resolveIndexedOperandVariable(bodyBuilder, insn.indexId());
+        var valueVar = resolveOperandVariable(bodyBuilder, insn.valueId(), "value");
+
+        var selfOperand = materializeSelfOperand(bodyBuilder, selfVar, SelfMode.VARIANT_SET_INDEXED);
+        var valueOperand = materializeVariantOperand(bodyBuilder, valueVar, "idx_val_variant");
+        var selfArgCode = renderArgumentCode(bodyBuilder, selfOperand.variantValue());
+        var indexArgCode = renderArgumentCode(bodyBuilder, bodyBuilder.valueOfVar(indexVar));
+        var valueArgCode = renderArgumentCode(bodyBuilder, valueOperand.variantValue());
+        var validFlag = bodyBuilder.newTempVariable("idx_valid", GdBoolType.BOOL, "false");
+        bodyBuilder.declareTempVar(validFlag);
+        var oobFlag = bodyBuilder.newTempVariable("idx_oob", GdBoolType.BOOL, "false");
+        bodyBuilder.declareTempVar(oobFlag);
+
+        bodyBuilder.appendLine(
+                "godot_variant_set_indexed(" +
+                        selfArgCode + ", " +
+                        "(GDExtensionInt)" + indexArgCode + ", " +
+                        valueArgCode + ", " +
+                        "&" + validFlag.name() + ", " +
+                        "&" + oobFlag.name() +
+                        ");"
+        );
+        bodyBuilder.appendLine("if (!" + validFlag.name() + ") {");
+        bodyBuilder.appendLine(
+                "GDCC_PRINT_RUNTIME_ERROR(\"variant_set_indexed failed: self=$" + selfVar.id() +
+                        ", index=$" + indexVar.id() +
+                        ", value=$" + valueVar.id() +
+                        "\", __func__, __FILE__, __LINE__);"
+        );
+        emitFailureReturn(bodyBuilder, valueOperand.tempVar(), selfOperand.tempVar());
+        bodyBuilder.appendLine("}");
+        restoreInitialized(valueOperand.tempVar(), selfOperand.tempVar());
+
+        bodyBuilder.appendLine("if (" + oobFlag.name() + ") {");
+        bodyBuilder.appendLine(
+                "GDCC_PRINT_RUNTIME_ERROR(\"variant_set_indexed index out of bounds: index=$" +
+                        indexVar.id() + "\", __func__, __FILE__, __LINE__);"
+        );
+        emitFailureReturn(bodyBuilder, valueOperand.tempVar(), selfOperand.tempVar());
+        bodyBuilder.appendLine("}");
+        restoreInitialized(valueOperand.tempVar(), selfOperand.tempVar());
+
+        emitSelfWritebackIfNeeded(bodyBuilder, selfVar, selfOperand);
+
+        if (valueOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(valueOperand.tempVar());
+        }
+        if (selfOperand.tempVar() != null) {
+            bodyBuilder.destroyTempVar(selfOperand.tempVar());
+        }
+    }
+
+    private void emitSelfWritebackIfNeeded(@NotNull CBodyBuilder bodyBuilder,
+                                           @NotNull LirVariable selfVar,
+                                           @NotNull SelfOperand selfOperand) {
+        if (!selfOperand.requiresWriteback()) {
+            return;
+        }
+        if (selfOperand.tempVar() == null) {
+            throw bodyBuilder.invalidInsn("Internal error: missing self temp variant for writeback");
+        }
+        var unpackFunctionName = bodyBuilder.helper().renderUnpackFunctionName(selfVar.type());
+        bodyBuilder.callAssign(
+                bodyBuilder.targetOfVar(selfVar),
+                unpackFunctionName,
+                selfVar.type(),
+                List.of(selfOperand.tempVar())
+        );
+    }
+
+    private @NotNull SelfOperand materializeSelfOperand(@NotNull CBodyBuilder bodyBuilder,
+                                                        @NotNull LirVariable selfVar,
+                                                        @NotNull SelfMode selfMode) {
+        if (selfVar.type() instanceof GdVariantType) {
+            return new SelfOperand(bodyBuilder.valueOfVar(selfVar), null, false);
+        }
+        var selfStrategy = resolveSelfStrategy(bodyBuilder, selfVar, selfMode);
+        if (selfVar.ref() && selfStrategy == SelfStrategy.VALUE_SEMANTIC) {
+            throw bodyBuilder.invalidInsn("Index store self operand variable ID '" + selfVar.id() +
+                    "' is a reference and requires writeback, which is not supported for type '" +
+                    selfVar.type().getTypeName() + "'");
+        }
+        var selfVariantTemp = bodyBuilder.newTempVariable("idx_self_variant", GdVariantType.VARIANT);
+        bodyBuilder.declareTempVar(selfVariantTemp);
+        var packFunctionName = bodyBuilder.helper().renderPackFunctionName(selfVar.type());
+        bodyBuilder.callAssign(
+                selfVariantTemp,
+                packFunctionName,
+                GdVariantType.VARIANT,
+                List.of(bodyBuilder.valueOfVar(selfVar))
+        );
+        return new SelfOperand(
+                selfVariantTemp,
+                selfVariantTemp,
+                selfStrategy == SelfStrategy.VALUE_SEMANTIC
+        );
+    }
+
+    private @NotNull SelfStrategy resolveSelfStrategy(@NotNull CBodyBuilder bodyBuilder,
+                                                      @NotNull LirVariable selfVar,
+                                                      @NotNull SelfMode selfMode) {
+        var selfType = selfVar.type();
+        if (isUnsupportedSetSelfType(selfType)) {
+            throw bodyBuilder.invalidInsn("Index store instruction '" + selfMode.insnName +
+                    "' self operand variable ID '" + selfVar.id() + "' has unsupported type '" +
+                    selfType.getTypeName() + "'");
+        }
+
+        return switch (selfMode) {
+            case VARIANT_SET -> isReferenceSemanticSelfType(selfType)
+                    ? SelfStrategy.REFERENCE_SEMANTIC
+                    : SelfStrategy.VALUE_SEMANTIC;
+            case VARIANT_SET_KEYED -> {
+                if (selfType instanceof GdObjectType || selfType instanceof GdDictionaryType) {
+                    yield SelfStrategy.REFERENCE_SEMANTIC;
+                }
+                throw bodyBuilder.invalidInsn("variant_set_keyed self operand variable ID '" + selfVar.id() +
+                        "' must be Variant/Object/Dictionary, got '" + selfType.getTypeName() + "'");
+            }
+            case VARIANT_SET_NAMED -> {
+                if (selfType instanceof GdObjectType || selfType instanceof GdDictionaryType) {
+                    yield SelfStrategy.REFERENCE_SEMANTIC;
+                }
+                if (isNamedValueSemanticSelfType(selfType)) {
+                    yield SelfStrategy.VALUE_SEMANTIC;
+                }
+                throw bodyBuilder.invalidInsn("variant_set_named self operand variable ID '" + selfVar.id() +
+                        "' is not supported for named set, got '" + selfType.getTypeName() + "'");
+            }
+            case VARIANT_SET_INDEXED -> {
+                if (isIndexedReferenceSemanticSelfType(selfType)) {
+                    yield SelfStrategy.REFERENCE_SEMANTIC;
+                }
+                if (isIndexedValueSemanticSelfType(selfType)) {
+                    yield SelfStrategy.VALUE_SEMANTIC;
+                }
+                throw bodyBuilder.invalidInsn("variant_set_indexed self operand variable ID '" + selfVar.id() +
+                        "' is not supported for indexed set, got '" + selfType.getTypeName() + "'");
+            }
+        };
+    }
+
+    private boolean isUnsupportedSetSelfType(@NotNull GdType type) {
+        return type instanceof GdPrimitiveType ||
+                type instanceof GdNilType ||
+                type instanceof GdStringNameType ||
+                type instanceof GdNodePathType ||
+                type instanceof GdRidType ||
+                type instanceof GdMetaType ||
+                type instanceof GdVoidType;
+    }
+
+    private boolean isReferenceSemanticSelfType(@NotNull GdType type) {
+        return type instanceof GdObjectType ||
+                type instanceof GdArrayType ||
+                type instanceof GdDictionaryType;
+    }
+
+    private boolean isNamedValueSemanticSelfType(@NotNull GdType type) {
+        return type instanceof GdStringType || type instanceof GdVectorType;
+    }
+
+    private boolean isIndexedReferenceSemanticSelfType(@NotNull GdType type) {
+        return type instanceof GdArrayType ||
+                type instanceof GdDictionaryType;
+    }
+
+    private boolean isIndexedValueSemanticSelfType(@NotNull GdType type) {
+        return type instanceof GdStringType ||
+                type instanceof GdVectorType ||
+                type instanceof GdPackedArrayType;
+    }
+
+    private @NotNull VariantOperand materializeVariantOperand(@NotNull CBodyBuilder bodyBuilder,
+                                                              @NotNull LirVariable operandVar,
+                                                              @NotNull String tempPrefix) {
+        if (operandVar.type() instanceof GdVariantType) {
+            return new VariantOperand(bodyBuilder.valueOfVar(operandVar), null);
+        }
+
+        var tempVariant = bodyBuilder.newTempVariable(tempPrefix, GdVariantType.VARIANT);
+        bodyBuilder.declareTempVar(tempVariant);
+        var packFunctionName = bodyBuilder.helper().renderPackFunctionName(operandVar.type());
+        bodyBuilder.callAssign(
+                tempVariant,
+                packFunctionName,
+                GdVariantType.VARIANT,
+                List.of(bodyBuilder.valueOfVar(operandVar))
+        );
+        return new VariantOperand(tempVariant, tempVariant);
+    }
+
+    private @NotNull String renderArgumentCode(@NotNull CBodyBuilder bodyBuilder,
+                                               @NotNull CBodyBuilder.ValueRef valueRef) {
+        var rendered = bodyBuilder.renderArgument(valueRef, false);
+        if (rendered.preCode() != null && !rendered.preCode().isBlank()) {
+            bodyBuilder.appendRaw(rendered.preCode());
+        }
+        if (!rendered.temps().isEmpty()) {
+            throw bodyBuilder.invalidInsn("Unexpected temporary variables in argument code for index store instruction: " +
+                    rendered.temps().stream().map(CBodyBuilder.TempVar::name).toList());
+        }
+        return rendered.code();
+    }
+
+    private void emitFailureReturn(@NotNull CBodyBuilder bodyBuilder,
+                                   @Nullable CBodyBuilder.TempVar... tempsToDestroy) {
+        if (tempsToDestroy != null) {
+            for (var temp : tempsToDestroy) {
+                if (temp != null) {
+                    bodyBuilder.destroyTempVar(temp);
+                }
+            }
+        }
+        bodyBuilder.returnDefault();
+    }
+
+    private void restoreInitialized(@Nullable CBodyBuilder.TempVar... tempsToRestore) {
+        for (var temp : tempsToRestore) {
+            if (temp != null) {
+                temp.setInitialized(true);
+            }
+        }
+    }
+
+    private void ensureNoResultVariable(@NotNull CBodyBuilder bodyBuilder,
+                                        @Nullable String resultId,
+                                        @NotNull String insnName) {
+        if (resultId == null || resultId.isBlank()) {
+            return;
+        }
+        throw bodyBuilder.invalidInsn("Index store instruction '" + insnName +
+                "' must not have result variable ID, but got '" + resultId + "'");
+    }
+
+    private @NotNull LirVariable resolveOperandVariable(@NotNull CBodyBuilder bodyBuilder,
+                                                        @NotNull String variableId,
+                                                        @NotNull String role) {
+        var variable = bodyBuilder.func().getVariableById(variableId);
+        if (variable == null) {
+            throw bodyBuilder.invalidInsn("Index store " + role + " operand variable ID '" + variableId +
+                    "' not found in function");
+        }
+        return variable;
+    }
+
+    private @NotNull LirVariable resolveStringNameOperandVariable(@NotNull CBodyBuilder bodyBuilder,
+                                                                  @NotNull String nameId) {
+        var nameVar = resolveOperandVariable(bodyBuilder, nameId, "name");
+        if (!(nameVar.type() instanceof GdStringNameType)) {
+            throw bodyBuilder.invalidInsn("Index store name operand variable ID '" + nameId +
+                    "' must be StringName, got '" + nameVar.type().getTypeName() + "'");
+        }
+        return nameVar;
+    }
+
+    private @NotNull LirVariable resolveIndexedOperandVariable(@NotNull CBodyBuilder bodyBuilder,
+                                                               @NotNull String indexId) {
+        var indexVar = resolveOperandVariable(bodyBuilder, indexId, "index");
+        if (!(indexVar.type() instanceof GdIntType)) {
+            throw bodyBuilder.invalidInsn("Index store index operand variable ID '" + indexId +
+                    "' must be int, got '" + indexVar.type().getTypeName() + "'");
+        }
+        return indexVar;
+    }
+
+    private enum SelfMode {
+        VARIANT_SET("variant_set"),
+        VARIANT_SET_KEYED("variant_set_keyed"),
+        VARIANT_SET_NAMED("variant_set_named"),
+        VARIANT_SET_INDEXED("variant_set_indexed");
+
+        private final @NotNull String insnName;
+
+        SelfMode(@NotNull String insnName) {
+            this.insnName = insnName;
+        }
+    }
+
+    private enum SelfStrategy {
+        REFERENCE_SEMANTIC,
+        VALUE_SEMANTIC
+    }
+
+    private record SelfOperand(@NotNull CBodyBuilder.ValueRef variantValue,
+                               @Nullable CBodyBuilder.TempVar tempVar,
+                               boolean requiresWriteback) {
+        private SelfOperand {
+            Objects.requireNonNull(variantValue);
+        }
+    }
+
+    private record VariantOperand(@NotNull CBodyBuilder.ValueRef variantValue,
+                                  @Nullable CBodyBuilder.TempVar tempVar) {
+        private VariantOperand {
+            Objects.requireNonNull(variantValue);
+        }
+    }
+}

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/InsnGenSupport.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/InsnGenSupport.java
@@ -1,0 +1,61 @@
+package dev.superice.gdcc.backend.c.gen.insn;
+
+import dev.superice.gdcc.backend.c.gen.CBodyBuilder;
+import dev.superice.gdcc.lir.LirVariable;
+import dev.superice.gdcc.type.GdVariantType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/// Shared helper for instruction generators.
+///
+/// Centralizes:
+/// - variant operand materialization (pack non-Variant to temporary Variant)
+/// - argument code rendering with preCode handling and temp-guard validation
+final class InsnGenSupport {
+    private InsnGenSupport() {
+    }
+
+    static @NotNull VariantOperand materializeVariantOperand(@NotNull CBodyBuilder bodyBuilder,
+                                                             @NotNull LirVariable operandVar,
+                                                             @NotNull String tempPrefix) {
+        if (operandVar.type() instanceof GdVariantType) {
+            return new VariantOperand(bodyBuilder.valueOfVar(operandVar), null);
+        }
+
+        var tempVariant = bodyBuilder.newTempVariable(tempPrefix, GdVariantType.VARIANT);
+        bodyBuilder.declareTempVar(tempVariant);
+        var packFunctionName = bodyBuilder.helper().renderPackFunctionName(operandVar.type());
+        bodyBuilder.callAssign(
+                tempVariant,
+                packFunctionName,
+                GdVariantType.VARIANT,
+                List.of(bodyBuilder.valueOfVar(operandVar))
+        );
+        return new VariantOperand(tempVariant, tempVariant);
+    }
+
+    static @NotNull String renderArgumentCode(@NotNull CBodyBuilder bodyBuilder,
+                                              @NotNull CBodyBuilder.ValueRef valueRef,
+                                              @NotNull String instructionContext) {
+        var rendered = bodyBuilder.renderArgument(valueRef, false);
+        if (rendered.preCode() != null && !rendered.preCode().isBlank()) {
+            bodyBuilder.appendRaw(rendered.preCode());
+        }
+        if (!rendered.temps().isEmpty()) {
+            throw bodyBuilder.invalidInsn("Unexpected temporary variables in argument code for " +
+                    instructionContext + ": " +
+                    rendered.temps().stream().map(CBodyBuilder.TempVar::name).toList());
+        }
+        return rendered.code();
+    }
+
+    record VariantOperand(@NotNull CBodyBuilder.ValueRef variantValue,
+                          @Nullable CBodyBuilder.TempVar tempVar) {
+        VariantOperand {
+            Objects.requireNonNull(variantValue);
+        }
+    }
+}

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/OperatorInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/OperatorInsnGen.java
@@ -17,7 +17,6 @@ import dev.superice.gdcc.type.GdType;
 import dev.superice.gdcc.type.GdVariantType;
 import dev.superice.gdcc.type.GdVoidType;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -279,18 +278,20 @@ public final class OperatorInsnGen implements CInsnGen<LirInstruction> {
                                            @NotNull GodotOperator op,
                                            @NotNull LirVariable leftVar,
                                            @NotNull LirVariable rightVar) {
-        var leftOperand = materializeVariantOperand(bodyBuilder, leftVar, "left");
-        var rightOperand = materializeVariantOperand(bodyBuilder, rightVar, "right");
+        var leftOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, leftVar, "op_left_variant");
+        var rightOperand = InsnGenSupport.materializeVariantOperand(bodyBuilder, rightVar, "op_right_variant");
 
         var resultVariant = bodyBuilder.newTempVariable("op_eval_result", GdVariantType.VARIANT);
         bodyBuilder.declareUninitializedTempVar(resultVariant);
         var validFlag = bodyBuilder.newTempVariable("op_eval_valid", GdBoolType.BOOL, "false");
         bodyBuilder.declareTempVar(validFlag);
+        var leftArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, leftOperand.variantValue(), "operator instruction");
+        var rightArgCode = InsnGenSupport.renderArgumentCode(bodyBuilder, rightOperand.variantValue(), "operator instruction");
         bodyBuilder.appendLine(
                 "godot_variant_evaluate(" +
                         resolver.resolveVariantOperatorEnumLiteral(op) +
-                        ", &" + leftOperand.variantValue().generateCode() +
-                        ", &" + rightOperand.variantValue().generateCode() +
+                        ", " + leftArgCode +
+                        ", " + rightArgCode +
                         ", &" + resultVariant.name() +
                         ", &" + validFlag.name() +
                         ");"
@@ -344,8 +345,8 @@ public final class OperatorInsnGen implements CInsnGen<LirInstruction> {
                                             @NotNull GodotOperator op,
                                             @NotNull CBodyBuilder.TempVar resultVariant,
                                             @NotNull GdType targetType,
-                                            @NotNull VariantOperand leftOperand,
-                                            @NotNull VariantOperand rightOperand) {
+                                            @NotNull InsnGenSupport.VariantOperand leftOperand,
+                                            @NotNull InsnGenSupport.VariantOperand rightOperand) {
         var typeCheckExpr = renderVariantUnpackTypeCheckExpr(bodyBuilder, resultVariant, targetType);
         bodyBuilder.appendLine("if (!(" + typeCheckExpr + ")) {");
         bodyBuilder.appendLine(
@@ -384,8 +385,8 @@ public final class OperatorInsnGen implements CInsnGen<LirInstruction> {
 
     private void emitVariantEvaluateTypeCheckFailureReturn(@NotNull CBodyBuilder bodyBuilder,
                                                            @NotNull CBodyBuilder.TempVar resultVariant,
-                                                           @NotNull VariantOperand leftOperand,
-                                                           @NotNull VariantOperand rightOperand) {
+                                                           @NotNull InsnGenSupport.VariantOperand leftOperand,
+                                                           @NotNull InsnGenSupport.VariantOperand rightOperand) {
         bodyBuilder.destroyTempVar(resultVariant);
         if (rightOperand.tempVar() != null) {
             bodyBuilder.destroyTempVar(rightOperand.tempVar());
@@ -397,29 +398,10 @@ public final class OperatorInsnGen implements CInsnGen<LirInstruction> {
         bodyBuilder.returnDefault();
     }
 
-    private @NotNull VariantOperand materializeVariantOperand(@NotNull CBodyBuilder bodyBuilder,
-                                                              @NotNull LirVariable operandVar,
-                                                              @NotNull String role) {
-        if (operandVar.type() instanceof GdVariantType) {
-            return new VariantOperand(bodyBuilder.valueOfVar(operandVar), null);
-        }
-
-        var tempVariant = bodyBuilder.newTempVariable("op_" + role + "_variant", GdVariantType.VARIANT);
-        bodyBuilder.declareTempVar(tempVariant);
-        var packFunctionName = bodyBuilder.helper().renderPackFunctionName(operandVar.type());
-        bodyBuilder.callAssign(
-                tempVariant,
-                packFunctionName,
-                GdVariantType.VARIANT,
-                List.of(bodyBuilder.valueOfVar(operandVar))
-        );
-        return new VariantOperand(tempVariant, tempVariant);
-    }
-
     private void emitVariantEvaluateFailureReturn(@NotNull CBodyBuilder bodyBuilder,
                                                   @NotNull CBodyBuilder.TempVar resultVariant,
-                                                  @NotNull VariantOperand leftOperand,
-                                                  @NotNull VariantOperand rightOperand) {
+                                                  @NotNull InsnGenSupport.VariantOperand leftOperand,
+                                                  @NotNull InsnGenSupport.VariantOperand rightOperand) {
         bodyBuilder.assignExpr(resultVariant, "godot_new_Variant_nil()", GdVariantType.VARIANT);
         bodyBuilder.destroyTempVar(resultVariant);
         if (rightOperand.tempVar() != null) {
@@ -579,13 +561,6 @@ public final class OperatorInsnGen implements CInsnGen<LirInstruction> {
             throw bodyBuilder.invalidInsn("Operator " + role + " operand variable ID '" + variableId + "' not found in function");
         }
         return variable;
-    }
-
-    private record VariantOperand(@NotNull CBodyBuilder.ValueRef variantValue,
-                                  @Nullable CBodyBuilder.TempVar tempVar) {
-        private VariantOperand {
-            Objects.requireNonNull(variantValue);
-        }
     }
 
     private record PrimitiveFastPathGuardRule(@NotNull String invalidConditionExpr,

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/OperatorInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/OperatorInsnGen.java
@@ -212,18 +212,8 @@ public final class OperatorInsnGen implements CInsnGen<LirInstruction> {
                 "GDCC_PRINT_RUNTIME_ERROR(\"Primitive fast path guard failed for operator '" +
                         op.name() + "': " + reason + "\", __func__, __FILE__, __LINE__);"
         );
-        emitPrimitiveFastPathFailureReturn(bodyBuilder);
+        bodyBuilder.returnDefault();
         bodyBuilder.appendLine("}");
-    }
-
-    private void emitPrimitiveFastPathFailureReturn(@NotNull CBodyBuilder bodyBuilder) {
-        var returnType = bodyBuilder.func().getReturnType();
-        if (returnType instanceof GdVoidType) {
-            bodyBuilder.returnVoid();
-            return;
-        }
-        var defaultExpr = CBodyBuilder.renderDefaultValueExpr(returnType);
-        bodyBuilder.returnValue(bodyBuilder.valueOfExpr(defaultExpr, returnType));
     }
 
     private @NotNull String renderPowerFastPathExpr(@NotNull CBodyBuilder bodyBuilder,
@@ -404,13 +394,7 @@ public final class OperatorInsnGen implements CInsnGen<LirInstruction> {
             bodyBuilder.destroyTempVar(leftOperand.tempVar());
         }
 
-        var returnType = bodyBuilder.func().getReturnType();
-        if (returnType instanceof GdVoidType) {
-            bodyBuilder.returnVoid();
-            return;
-        }
-        var defaultExpr = CBodyBuilder.renderDefaultValueExpr(returnType);
-        bodyBuilder.returnValue(bodyBuilder.valueOfExpr(defaultExpr, returnType));
+        bodyBuilder.returnDefault();
     }
 
     private @NotNull VariantOperand materializeVariantOperand(@NotNull CBodyBuilder bodyBuilder,
@@ -445,13 +429,7 @@ public final class OperatorInsnGen implements CInsnGen<LirInstruction> {
             bodyBuilder.destroyTempVar(leftOperand.tempVar());
         }
 
-        var returnType = bodyBuilder.func().getReturnType();
-        if (returnType instanceof GdVoidType) {
-            bodyBuilder.returnVoid();
-            return;
-        }
-        var defaultExpr = CBodyBuilder.renderDefaultValueExpr(returnType);
-        bodyBuilder.returnValue(bodyBuilder.valueOfExpr(defaultExpr, returnType));
+        bodyBuilder.returnDefault();
     }
 
     private void emitPrimitiveComparison(@NotNull CBodyBuilder bodyBuilder,

--- a/src/main/java/dev/superice/gdcc/enums/GdInstruction.java
+++ b/src/main/java/dev/superice/gdcc/enums/GdInstruction.java
@@ -33,12 +33,12 @@ public enum GdInstruction {
     // Indexing
     VARIANT_GET("variant_get", ReturnKind.REQUIRED, List.of(OperandKind.VARIABLE, OperandKind.VARIABLE), 2, 2),
     VARIANT_GET_KEYED("variant_get_keyed", ReturnKind.REQUIRED, List.of(OperandKind.VARIABLE, OperandKind.VARIABLE), 2, 2),
-    VARIANT_GET_NAMED("variant_get_named", ReturnKind.REQUIRED, List.of(OperandKind.VARIABLE, OperandKind.STRING), 2, 2),
-    VARIANT_GET_INDEXED("variant_get_indexed", ReturnKind.REQUIRED, List.of(OperandKind.VARIABLE, OperandKind.INT), 2, 2),
+    VARIANT_GET_NAMED("variant_get_named", ReturnKind.REQUIRED, List.of(OperandKind.VARIABLE, OperandKind.VARIABLE), 2, 2),
+    VARIANT_GET_INDEXED("variant_get_indexed", ReturnKind.REQUIRED, List.of(OperandKind.VARIABLE, OperandKind.VARIABLE), 2, 2),
     VARIANT_SET("variant_set", ReturnKind.NONE, List.of(OperandKind.VARIABLE, OperandKind.VARIABLE, OperandKind.VARIABLE), 3, 3),
     VARIANT_SET_KEYED("variant_set_keyed", ReturnKind.NONE, List.of(OperandKind.VARIABLE, OperandKind.VARIABLE, OperandKind.VARIABLE), 3, 3),
-    VARIANT_SET_NAMED("variant_set_named", ReturnKind.NONE, List.of(OperandKind.VARIABLE, OperandKind.STRING, OperandKind.VARIABLE), 3, 3),
-    VARIANT_SET_INDEXED("variant_set_indexed", ReturnKind.NONE, List.of(OperandKind.VARIABLE, OperandKind.INT, OperandKind.VARIABLE), 3, 3),
+    VARIANT_SET_NAMED("variant_set_named", ReturnKind.NONE, List.of(OperandKind.VARIABLE, OperandKind.VARIABLE, OperandKind.VARIABLE), 3, 3),
+    VARIANT_SET_INDEXED("variant_set_indexed", ReturnKind.NONE, List.of(OperandKind.VARIABLE, OperandKind.VARIABLE, OperandKind.VARIABLE), 3, 3),
 
     // Type Instructions
     GET_VARIANT_TYPE("get_variant_type", ReturnKind.REQUIRED, List.of(OperandKind.VARIABLE), 1, 1),
@@ -92,11 +92,25 @@ public enum GdInstruction {
         this(opcode, returnKind, operandKinds, operandKinds.size(), operandKinds.size());
     }
 
-    public String opcode() { return opcode; }
-    public ReturnKind returnKind() { return returnKind; }
-    public List<OperandKind> operandKinds() { return operandKinds; }
-    public int minOperands() { return minOperands; }
-    public int maxOperands() { return maxOperands; }
+    public String opcode() {
+        return opcode;
+    }
+
+    public ReturnKind returnKind() {
+        return returnKind;
+    }
+
+    public List<OperandKind> operandKinds() {
+        return operandKinds;
+    }
+
+    public int minOperands() {
+        return minOperands;
+    }
+
+    public int maxOperands() {
+        return maxOperands;
+    }
 
     public enum ReturnKind {
         NONE,

--- a/src/main/java/dev/superice/gdcc/lir/insn/VariantGetIndexedInsn.java
+++ b/src/main/java/dev/superice/gdcc/lir/insn/VariantGetIndexedInsn.java
@@ -1,14 +1,13 @@
 package dev.superice.gdcc.lir.insn;
 
 import dev.superice.gdcc.enums.GdInstruction;
-import dev.superice.gdcc.lir.LirInstruction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public record VariantGetIndexedInsn(@Nullable String resultId, @NotNull String variantId,
-                                    int index) implements IndexingInstruction {
+                                    @NotNull String indexId) implements IndexingInstruction {
 
     @Override
     public GdInstruction opcode() {
@@ -17,7 +16,7 @@ public record VariantGetIndexedInsn(@Nullable String resultId, @NotNull String v
 
     @Override
     public @NotNull List<Operand> operands() {
-        return List.of(new VariableOperand(variantId), new IntOperand(index));
+        return List.of(new VariableOperand(variantId), new VariableOperand(indexId));
     }
 }
 

--- a/src/main/java/dev/superice/gdcc/lir/insn/VariantGetNamedInsn.java
+++ b/src/main/java/dev/superice/gdcc/lir/insn/VariantGetNamedInsn.java
@@ -1,14 +1,13 @@
 package dev.superice.gdcc.lir.insn;
 
 import dev.superice.gdcc.enums.GdInstruction;
-import dev.superice.gdcc.lir.LirInstruction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public record VariantGetNamedInsn(@Nullable String resultId, @NotNull String namedVariantId,
-                                  @NotNull String name) implements IndexingInstruction {
+                                  @NotNull String nameId) implements IndexingInstruction {
 
     @Override
     public GdInstruction opcode() {
@@ -17,7 +16,7 @@ public record VariantGetNamedInsn(@Nullable String resultId, @NotNull String nam
 
     @Override
     public @NotNull List<Operand> operands() {
-        return List.of(new VariableOperand(namedVariantId), new StringOperand(name));
+        return List.of(new VariableOperand(namedVariantId), new VariableOperand(nameId));
     }
 }
 

--- a/src/main/java/dev/superice/gdcc/lir/insn/VariantSetIndexedInsn.java
+++ b/src/main/java/dev/superice/gdcc/lir/insn/VariantSetIndexedInsn.java
@@ -1,12 +1,11 @@
 package dev.superice.gdcc.lir.insn;
 
 import dev.superice.gdcc.enums.GdInstruction;
-import dev.superice.gdcc.lir.LirInstruction;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public record VariantSetIndexedInsn(@NotNull String variantId, int index,
+public record VariantSetIndexedInsn(@NotNull String variantId, @NotNull String indexId,
                                     @NotNull String valueId) implements IndexingInstruction {
 
     @Override
@@ -21,7 +20,7 @@ public record VariantSetIndexedInsn(@NotNull String variantId, int index,
 
     @Override
     public @NotNull List<Operand> operands() {
-        return List.of(new VariableOperand(variantId), new IntOperand(index), new VariableOperand(valueId));
+        return List.of(new VariableOperand(variantId), new VariableOperand(indexId), new VariableOperand(valueId));
     }
 }
 

--- a/src/main/java/dev/superice/gdcc/lir/insn/VariantSetNamedInsn.java
+++ b/src/main/java/dev/superice/gdcc/lir/insn/VariantSetNamedInsn.java
@@ -1,12 +1,11 @@
 package dev.superice.gdcc.lir.insn;
 
 import dev.superice.gdcc.enums.GdInstruction;
-import dev.superice.gdcc.lir.LirInstruction;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public record VariantSetNamedInsn(@NotNull String namedVariantId, @NotNull String name,
+public record VariantSetNamedInsn(@NotNull String namedVariantId, @NotNull String nameId,
                                   @NotNull String valueId) implements IndexingInstruction {
 
     @Override
@@ -21,7 +20,7 @@ public record VariantSetNamedInsn(@NotNull String namedVariantId, @NotNull Strin
 
     @Override
     public @NotNull List<Operand> operands() {
-        return List.of(new VariableOperand(namedVariantId), new StringOperand(name), new VariableOperand(valueId));
+        return List.of(new VariableOperand(namedVariantId), new VariableOperand(nameId), new VariableOperand(valueId));
     }
 }
 

--- a/src/main/java/dev/superice/gdcc/lir/parser/ParsedLirInstruction.java
+++ b/src/main/java/dev/superice/gdcc/lir/parser/ParsedLirInstruction.java
@@ -101,26 +101,39 @@ public record ParsedLirInstruction(
                     yield new BinaryOpInsn(resultId, op, left, right);
                 }
 
-                case VARIANT_GET -> new VariantGetInsn(resultId, ((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id());
-                case VARIANT_GET_KEYED -> new VariantGetKeyedInsn(resultId, ((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id());
-                case VARIANT_GET_NAMED -> new VariantGetNamedInsn(resultId, ((VariableOperand) operands.getFirst()).id(), ((StringOperand) operands.get(1)).value());
-                case VARIANT_GET_INDEXED -> new VariantGetIndexedInsn(resultId, ((VariableOperand) operands.getFirst()).id(), ((IntOperand) operands.get(1)).value());
-                case VARIANT_SET -> new VariantSetInsn(((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id(), ((VariableOperand) operands.get(2)).id());
-                case VARIANT_SET_KEYED -> new VariantSetKeyedInsn(((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id(), ((VariableOperand) operands.get(2)).id());
-                case VARIANT_SET_NAMED -> new VariantSetNamedInsn(((VariableOperand) operands.getFirst()).id(), ((StringOperand) operands.get(1)).value(), ((VariableOperand) operands.get(2)).id());
-                case VARIANT_SET_INDEXED -> new VariantSetIndexedInsn(((VariableOperand) operands.getFirst()).id(), ((IntOperand) operands.get(1)).value(), ((VariableOperand) operands.get(2)).id());
+                case VARIANT_GET ->
+                        new VariantGetInsn(resultId, ((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id());
+                case VARIANT_GET_KEYED ->
+                        new VariantGetKeyedInsn(resultId, ((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id());
+                case VARIANT_GET_NAMED ->
+                        new VariantGetNamedInsn(resultId, ((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id());
+                case VARIANT_GET_INDEXED ->
+                        new VariantGetIndexedInsn(resultId, ((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id());
+                case VARIANT_SET ->
+                        new VariantSetInsn(((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id(), ((VariableOperand) operands.get(2)).id());
+                case VARIANT_SET_KEYED ->
+                        new VariantSetKeyedInsn(((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id(), ((VariableOperand) operands.get(2)).id());
+                case VARIANT_SET_NAMED ->
+                        new VariantSetNamedInsn(((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id(), ((VariableOperand) operands.get(2)).id());
+                case VARIANT_SET_INDEXED ->
+                        new VariantSetIndexedInsn(((VariableOperand) operands.getFirst()).id(), ((VariableOperand) operands.get(1)).id(), ((VariableOperand) operands.get(2)).id());
 
                 case GET_VARIANT_TYPE -> new GetVariantTypeInsn(resultId, ((VariableOperand) operands.getFirst()).id());
                 case GET_CLASS_NAME -> new GetClassNameInsn(resultId, ((VariableOperand) operands.getFirst()).id());
-                case OBJECT_CAST -> new ObjectCastInsn(resultId, ((StringOperand) operands.getFirst()).value(), ((VariableOperand) operands.get(1)).id());
-                case IS_INSTANCE_OF -> new IsInstanceOfInsn(resultId, ((StringOperand) operands.getFirst()).value(), ((VariableOperand) operands.get(1)).id());
-                case PACK_VARIANT -> new PackVariantInsn(Objects.requireNonNull(resultId), ((VariableOperand) operands.getFirst()).id());
-                case UNPACK_VARIANT -> new UnpackVariantInsn(Objects.requireNonNull(resultId), ((VariableOperand) operands.getFirst()).id());
+                case OBJECT_CAST ->
+                        new ObjectCastInsn(resultId, ((StringOperand) operands.getFirst()).value(), ((VariableOperand) operands.get(1)).id());
+                case IS_INSTANCE_OF ->
+                        new IsInstanceOfInsn(resultId, ((StringOperand) operands.getFirst()).value(), ((VariableOperand) operands.get(1)).id());
+                case PACK_VARIANT ->
+                        new PackVariantInsn(Objects.requireNonNull(resultId), ((VariableOperand) operands.getFirst()).id());
+                case UNPACK_VARIANT ->
+                        new UnpackVariantInsn(Objects.requireNonNull(resultId), ((VariableOperand) operands.getFirst()).id());
                 case VARIANT_IS_NIL -> new VariantIsNilInsn(resultId, ((VariableOperand) operands.getFirst()).id());
                 case OBJECT_IS_NULL -> new ObjectIsNullInsn(resultId, ((VariableOperand) operands.getFirst()).id());
 
                 case GOTO -> new GotoInsn(((BasicBlockOperand) operands.getFirst()).bbId());
-                case GO_IF -> new GoIfInsn(((VariableOperand) operands.getFirst()).id(), ((BasicBlockOperand) operands.get(1)).bbId(), ((BasicBlockOperand) operands.get(2)).bbId());
+                case GO_IF ->
+                        new GoIfInsn(((VariableOperand) operands.getFirst()).id(), ((BasicBlockOperand) operands.get(1)).bbId(), ((BasicBlockOperand) operands.get(2)).bbId());
                 case RETURN -> {
                     if (operands.isEmpty()) yield new ReturnInsn(null);
                     yield new ReturnInsn(((VariableOperand) operands.getFirst()).id());
@@ -160,10 +173,14 @@ public record ParsedLirInstruction(
                     yield new CallIntrinsicInsn(resultId, iname, args);
                 }
 
-                case LOAD_PROPERTY -> new LoadPropertyInsn(resultId, ((StringOperand) operands.getFirst()).value(), ((VariableOperand) operands.get(1)).id());
-                case STORE_PROPERTY -> new StorePropertyInsn(((StringOperand) operands.getFirst()).value(), ((VariableOperand) operands.get(1)).id(), ((VariableOperand) operands.get(2)).id());
-                case LOAD_STATIC -> new LoadStaticInsn(resultId, ((StringOperand) operands.getFirst()).value(), ((StringOperand) operands.get(1)).value());
-                case STORE_STATIC -> new StoreStaticInsn(((StringOperand) operands.getFirst()).value(), ((StringOperand) operands.get(1)).value(), ((VariableOperand) operands.get(2)).id());
+                case LOAD_PROPERTY ->
+                        new LoadPropertyInsn(resultId, ((StringOperand) operands.getFirst()).value(), ((VariableOperand) operands.get(1)).id());
+                case STORE_PROPERTY ->
+                        new StorePropertyInsn(((StringOperand) operands.getFirst()).value(), ((VariableOperand) operands.get(1)).id(), ((VariableOperand) operands.get(2)).id());
+                case LOAD_STATIC ->
+                        new LoadStaticInsn(resultId, ((StringOperand) operands.getFirst()).value(), ((StringOperand) operands.get(1)).value());
+                case STORE_STATIC ->
+                        new StoreStaticInsn(((StringOperand) operands.getFirst()).value(), ((StringOperand) operands.get(1)).value(), ((VariableOperand) operands.get(2)).id());
 
                 case NOP -> new NopInsn();
                 case LINE_NUMBER -> new LineNumberInsn(((IntOperand) operands.getFirst()).value());

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
@@ -17,12 +17,14 @@ import dev.superice.gdcc.lir.LirPropertyDef;
 import dev.superice.gdcc.lir.insn.BinaryOpInsn;
 import dev.superice.gdcc.lir.insn.ReturnInsn;
 import dev.superice.gdcc.lir.insn.UnaryOpInsn;
+import dev.superice.gdcc.lir.insn.VariantGetInsn;
 import dev.superice.gdcc.scope.ClassRegistry;
 import dev.superice.gdcc.type.GdBoolType;
 import dev.superice.gdcc.type.GdFloatType;
 import dev.superice.gdcc.type.GdIntType;
 import dev.superice.gdcc.type.GdObjectType;
 import dev.superice.gdcc.type.GdStringType;
+import dev.superice.gdcc.type.GdVariantType;
 import dev.superice.gdcc.type.GdVoidType;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +40,44 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CCodegenTest {
+    @Test
+    public void variantGetOpcodeIsRegisteredAndGeneratesBody() {
+        var workerClass = new LirClassDef("Worker", "RefCounted");
+        var func = new LirFunctionDef("index_load_codegen");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("self", GdVariantType.VARIANT);
+        func.createAndAddVariable("key", GdVariantType.VARIANT);
+        func.createAndAddVariable("result", GdVariantType.VARIANT);
+
+        var entry = new LirBasicBlock("entry");
+        entry.instructions().add(new VariantGetInsn("result", "self", "key"));
+        func.addBasicBlock(entry);
+        func.setEntryBlockId("entry");
+        workerClass.addFunction(func);
+
+        var module = new LirModule("index_load_module", List.of(workerClass));
+        var classRegistry = new ClassRegistry(new ExtensionAPI(
+                null,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+        ));
+        ProjectInfo projectInfo = new ProjectInfo("test", GodotVersion.V451, Path.of(".")) {
+        };
+        var ctx = new CodegenContext(projectInfo, classRegistry);
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("godot_variant_get(&$self, &$key"), body);
+        assertTrue(body.contains("$result = godot_new_Variant_with_Variant"), body);
+    }
+
     @Test
     public void binaryOperatorOpcodeIsRegisteredAndFailFastIsControlled() {
         var workerClass = new LirClassDef("Worker", "RefCounted");

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CCodegenTest.java
@@ -18,6 +18,7 @@ import dev.superice.gdcc.lir.insn.BinaryOpInsn;
 import dev.superice.gdcc.lir.insn.ReturnInsn;
 import dev.superice.gdcc.lir.insn.UnaryOpInsn;
 import dev.superice.gdcc.lir.insn.VariantGetInsn;
+import dev.superice.gdcc.lir.insn.VariantSetInsn;
 import dev.superice.gdcc.scope.ClassRegistry;
 import dev.superice.gdcc.type.GdBoolType;
 import dev.superice.gdcc.type.GdFloatType;
@@ -76,6 +77,43 @@ public class CCodegenTest {
         var body = codegen.generateFuncBody(workerClass, func);
         assertTrue(body.contains("godot_variant_get(&$self, &$key"), body);
         assertTrue(body.contains("$result = godot_new_Variant_with_Variant"), body);
+    }
+
+    @Test
+    public void variantSetOpcodeIsRegisteredAndGeneratesBody() {
+        var workerClass = new LirClassDef("Worker", "RefCounted");
+        var func = new LirFunctionDef("index_store_codegen");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("self", GdVariantType.VARIANT);
+        func.createAndAddVariable("key", GdVariantType.VARIANT);
+        func.createAndAddVariable("value", GdVariantType.VARIANT);
+
+        var entry = new LirBasicBlock("entry");
+        entry.instructions().add(new VariantSetInsn("self", "key", "value"));
+        func.addBasicBlock(entry);
+        func.setEntryBlockId("entry");
+        workerClass.addFunction(func);
+
+        var module = new LirModule("index_store_module", List.of(workerClass));
+        var classRegistry = new ClassRegistry(new ExtensionAPI(
+                null,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+        ));
+        ProjectInfo projectInfo = new ProjectInfo("test", GodotVersion.V451, Path.of(".")) {
+        };
+        var ctx = new CodegenContext(projectInfo, classRegistry);
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("godot_variant_set(&$self, &$key, &$value"), body);
     }
 
     @Test

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java
@@ -288,6 +288,21 @@ class IndexLoadInsnGenTest {
     }
 
     @Test
+    @DisplayName("variant_get_indexed should accept ref int index")
+    void variantGetIndexedRefIntIndex() {
+        var body = generateBody(
+                new VariantGetIndexedInsn("result", "self", "idx_ref"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("idx_ref", GdIntType.INT, true),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_get_indexed(&$self, (GDExtensionInt)$idx_ref"), body);
+    }
+
+    @Test
     @DisplayName("variant_get_indexed should pack non-Variant self and unpack non-Variant result")
     void variantGetIndexedNonVariantSelf() {
         var body = generateBody(

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/IndexLoadInsnGenTest.java
@@ -1,0 +1,513 @@
+package dev.superice.gdcc.backend.c.gen;
+
+import dev.superice.gdcc.backend.CodegenContext;
+import dev.superice.gdcc.backend.ProjectInfo;
+import dev.superice.gdcc.backend.c.gen.insn.IndexLoadInsnGen;
+import dev.superice.gdcc.enums.GodotVersion;
+import dev.superice.gdcc.exception.InvalidInsnException;
+import dev.superice.gdcc.gdextension.ExtensionAPI;
+import dev.superice.gdcc.lir.LirBasicBlock;
+import dev.superice.gdcc.lir.LirClassDef;
+import dev.superice.gdcc.lir.LirFunctionDef;
+import dev.superice.gdcc.lir.LirInstruction;
+import dev.superice.gdcc.lir.insn.VariantGetIndexedInsn;
+import dev.superice.gdcc.lir.insn.VariantGetInsn;
+import dev.superice.gdcc.lir.insn.VariantGetKeyedInsn;
+import dev.superice.gdcc.lir.insn.VariantGetNamedInsn;
+import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdIntType;
+import dev.superice.gdcc.type.GdStringNameType;
+import dev.superice.gdcc.type.GdType;
+import dev.superice.gdcc.type.GdVariantType;
+import dev.superice.gdcc.type.GdVoidType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IndexLoadInsnGenTest {
+    @Test
+    @DisplayName("variant_get with Variant self/key/result should avoid operand pack and use variant copy back")
+    void variantGetVariantKeyVariantResult() {
+        var body = generateBody(
+                new VariantGetInsn("result", "self", "key"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_get(&$self, &$key"), body);
+        assertTrue(body.contains("$result = godot_new_Variant_with_Variant(&__gdcc_tmp_idx_ret_"), body);
+        assertFalse(body.contains("__gdcc_tmp_idx_self_variant_"), body);
+        assertFalse(body.contains("__gdcc_tmp_idx_key_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get should pack non-Variant self operand")
+    void variantGetNonVariantSelfPack() {
+        var body = generateBody(
+                new VariantGetInsn("result", "self", "key"),
+                List.of(
+                        new VariableSpec("self", new GdArrayType(GdVariantType.VARIANT), false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Array(&$self)"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_self_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get should pack non-Variant key operand")
+    void variantGetNonVariantKeyPack() {
+        var body = generateBody(
+                new VariantGetInsn("result", "self", "key"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_int($key)"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_key_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get should unpack to non-Variant result type")
+    void variantGetNonVariantResultUnpack() {
+        var body = generateBody(
+                new VariantGetInsn("result", "self", "key"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("result", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("$result = godot_new_int_with_Variant(&__gdcc_tmp_idx_ret_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get should fail-fast when resultId is missing")
+    void variantGetMissingResultFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantGetInsn(null, "self", "key"),
+                        List.of(
+                                new VariableSpec("self", GdVariantType.VARIANT, false),
+                                new VariableSpec("key", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("missing required result variable ID"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_get should fail-fast when result variable is ref")
+    void variantGetRefResultFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantGetInsn("result", "self", "key"),
+                        List.of(
+                                new VariableSpec("self", GdVariantType.VARIANT, false),
+                                new VariableSpec("key", GdVariantType.VARIANT, false),
+                                new VariableSpec("result", GdVariantType.VARIANT, true)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("cannot be a reference"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_get should fail-fast when self operand does not exist")
+    void variantGetMissingVariantOperandFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantGetInsn("result", "missing_self", "key"),
+                        List.of(
+                                new VariableSpec("key", GdVariantType.VARIANT, false),
+                                new VariableSpec("result", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("self operand variable ID 'missing_self'"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_get should fail-fast when key operand does not exist")
+    void variantGetMissingKeyOperandFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantGetInsn("result", "self", "missing_key"),
+                        List.of(
+                                new VariableSpec("self", GdVariantType.VARIANT, false),
+                                new VariableSpec("result", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("key operand variable ID 'missing_key'"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_get_keyed should emit godot_variant_get_keyed call")
+    void variantGetKeyedBasic() {
+        var body = generateBody(
+                new VariantGetKeyedInsn("result", "self", "key"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_get_keyed(&$self, &$key"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get_keyed should support ref key variable without extra address-of")
+    void variantGetKeyedRefKeyVar() {
+        var body = generateBody(
+                new VariantGetKeyedInsn("result", "self", "key_ref"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key_ref", GdVariantType.VARIANT, true),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_get_keyed(&$self, $key_ref"), body);
+        assertFalse(body.contains("__gdcc_tmp_idx_key_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get_named should emit StringName variable call")
+    void variantGetNamedBasic() {
+        var body = generateBody(
+                new VariantGetNamedInsn("result", "self", "name"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("name", GdStringNameType.STRING_NAME, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_get_named(&$self, &$name"), body);
+        assertFalse(body.contains("GD_STATIC_SN("), body);
+    }
+
+    @Test
+    @DisplayName("variant_get_named should support ref StringName variable without extra address-of")
+    void variantGetNamedRefNameVar() {
+        var body = generateBody(
+                new VariantGetNamedInsn("result", "self", "name_ref"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("name_ref", GdStringNameType.STRING_NAME, true),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_get_named(&$self, $name_ref"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get_named should pack non-Variant self and unpack non-Variant result")
+    void variantGetNamedNonVariantSelf() {
+        var body = generateBody(
+                new VariantGetNamedInsn("result", "self", "name"),
+                List.of(
+                        new VariableSpec("self", new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT), false),
+                        new VariableSpec("name", GdStringNameType.STRING_NAME, false),
+                        new VariableSpec("result", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Dictionary(&$self)"), body);
+        assertTrue(body.contains("$result = godot_new_int_with_Variant(&__gdcc_tmp_idx_ret_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get_named should fail-fast when name operand is not StringName")
+    void variantGetNamedNonStringNameFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantGetNamedInsn("result", "self", "name"),
+                        List.of(
+                                new VariableSpec("self", GdVariantType.VARIANT, false),
+                                new VariableSpec("name", GdVariantType.VARIANT, false),
+                                new VariableSpec("result", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("must be StringName"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_get_indexed should emit indexed call and oob check")
+    void variantGetIndexedBasic() {
+        var body = generateBody(
+                new VariantGetIndexedInsn("result", "self", "idx"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_get_indexed(&$self, (GDExtensionInt)$idx"), body);
+        assertTrue(body.contains("if (__gdcc_tmp_idx_oob_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get_indexed should pack non-Variant self and unpack non-Variant result")
+    void variantGetIndexedNonVariantSelf() {
+        var body = generateBody(
+                new VariantGetIndexedInsn("result", "self", "idx"),
+                List.of(
+                        new VariableSpec("self", new GdArrayType(GdVariantType.VARIANT), false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("result", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Array(&$self)"), body);
+        assertTrue(body.contains("$result = godot_new_int_with_Variant(&__gdcc_tmp_idx_ret_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get should emit r_valid check and runtime error branch")
+    void variantGetEmitsValidCheck() {
+        var body = generateBody(
+                new VariantGetInsn("result", "self", "key"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("if (!__gdcc_tmp_idx_valid_"), body);
+        assertTrue(body.contains("GDCC_PRINT_RUNTIME_ERROR(\"variant_get failed: self=$self, key=$key, result=$result\""), body);
+        assertTrue(body.contains("goto __finally__;"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get invalid branch should destroy temps in reverse init order")
+    void variantGetInvalidBranchDestroyOrder() {
+        var body = generateBody(
+                new VariantGetInsn("result", "self", "key"),
+                List.of(
+                        new VariableSpec("self", new GdArrayType(GdVariantType.VARIANT), false),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertInOrder(
+                body,
+                "GDCC_PRINT_RUNTIME_ERROR(\"variant_get failed: self=$self, key=$key, result=$result\"",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_ret_",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_key_variant_",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_self_variant_",
+                "goto __finally__;"
+        );
+    }
+
+    @Test
+    @DisplayName("variant_get_indexed should emit r_oob check and runtime error branch")
+    void variantGetIndexedEmitsOobCheck() {
+        var body = generateBody(
+                new VariantGetIndexedInsn("result", "self", "idx"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("if (__gdcc_tmp_idx_oob_"), body);
+        assertTrue(body.contains("variant_get_indexed index out of bounds: index=$idx"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get_indexed oob branch should destroy return then self temp")
+    void variantGetIndexedOobDestroyOrder() {
+        var body = generateBody(
+                new VariantGetIndexedInsn("result", "self", "idx"),
+                List.of(
+                        new VariableSpec("self", new GdArrayType(GdVariantType.VARIANT), false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertInOrder(
+                body,
+                "variant_get_indexed index out of bounds: index=$idx",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_ret_",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_self_variant_",
+                "goto __finally__;"
+        );
+    }
+
+    @Test
+    @DisplayName("variant_get_indexed should fail-fast when index operand is not int")
+    void variantGetIndexedNonIntIndexFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantGetIndexedInsn("result", "self", "idx"),
+                        List.of(
+                                new VariableSpec("self", GdVariantType.VARIANT, false),
+                                new VariableSpec("idx", GdVariantType.VARIANT, false),
+                                new VariableSpec("result", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("must be int"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_get should destroy temporary packed operands")
+    void variantGetDestroysTempPackVars() {
+        var body = generateBody(
+                new VariantGetInsn("result", "self", "key"),
+                List.of(
+                        new VariableSpec("self", new GdArrayType(GdVariantType.VARIANT), false),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_key_variant_"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_self_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_get should destroy temporary return variant")
+    void variantGetDestroysRetVariant() {
+        var body = generateBody(
+                new VariantGetInsn("result", "self", "key"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("result", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_ret_"), body);
+    }
+
+    private @NotNull String generateBody(@NotNull LirInstruction instruction,
+                                         @NotNull List<VariableSpec> variableSpecs) {
+        return generateBody(instruction, variableSpecs, GdVoidType.VOID);
+    }
+
+    private @NotNull String generateBody(@NotNull LirInstruction instruction,
+                                         @NotNull List<VariableSpec> variableSpecs,
+                                         @NotNull GdType returnType) {
+        var workerClass = newTestClass();
+        var func = newFunction("index_load_test", returnType);
+        for (var variableSpec : variableSpecs) {
+            if (variableSpec.ref()) {
+                func.createAndAddRefVariable(variableSpec.id(), variableSpec.type());
+            } else {
+                func.createAndAddVariable(variableSpec.id(), variableSpec.type());
+            }
+        }
+
+        var entry = entry(func);
+        entry.instructions().add(instruction);
+        workerClass.addFunction(func);
+
+        var bodyBuilder = newBodyBuilder(workerClass, func);
+        bodyBuilder.beginBasicBlock(entry.id());
+        bodyBuilder.setCurrentPosition(entry, 0, instruction);
+        new IndexLoadInsnGen().generateCCode(bodyBuilder);
+        return bodyBuilder.build();
+    }
+
+    private @NotNull LirClassDef newTestClass() {
+        return new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+    }
+
+    private @NotNull LirFunctionDef newFunction(@NotNull String name, @NotNull GdType returnType) {
+        var func = new LirFunctionDef(name);
+        func.setReturnType(returnType);
+        return func;
+    }
+
+    private @NotNull LirBasicBlock entry(@NotNull LirFunctionDef func) {
+        var entry = new LirBasicBlock("entry");
+        func.addBasicBlock(entry);
+        func.setEntryBlockId("entry");
+        return entry;
+    }
+
+    private @NotNull CBodyBuilder newBodyBuilder(@NotNull LirClassDef clazz, @NotNull LirFunctionDef func) {
+        var classRegistry = new ClassRegistry(emptyApi());
+        classRegistry.addGdccClass(clazz);
+        ProjectInfo projectInfo = new ProjectInfo("TestProject", GodotVersion.V451, Path.of(".")) {
+        };
+        var ctx = new CodegenContext(projectInfo, classRegistry);
+        var helper = new CGenHelper(ctx, List.of(clazz));
+        return new CBodyBuilder(helper, clazz, func);
+    }
+
+    private void assertInOrder(@NotNull String body, @NotNull String... fragments) {
+        var from = -1;
+        for (var fragment : fragments) {
+            var idx = body.indexOf(fragment, from + 1);
+            assertTrue(idx >= 0, "Missing fragment: " + fragment + "\n" + body);
+            from = idx;
+        }
+    }
+
+    private @NotNull ExtensionAPI emptyApi() {
+        return new ExtensionAPI(
+                null,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+        );
+    }
+
+    private record VariableSpec(@NotNull String id, @NotNull GdType type, boolean ref) {
+    }
+}

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenEngineTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenEngineTest.java
@@ -1,0 +1,340 @@
+package dev.superice.gdcc.backend.c.gen;
+
+import dev.superice.gdcc.backend.CodegenContext;
+import dev.superice.gdcc.backend.c.build.COptimizationLevel;
+import dev.superice.gdcc.backend.c.build.CProjectBuilder;
+import dev.superice.gdcc.backend.c.build.CProjectInfo;
+import dev.superice.gdcc.backend.c.build.GodotGdextensionTestRunner;
+import dev.superice.gdcc.backend.c.build.TargetPlatform;
+import dev.superice.gdcc.backend.c.build.ZigUtil;
+import dev.superice.gdcc.enums.GodotVersion;
+import dev.superice.gdcc.gdextension.ExtensionApiLoader;
+import dev.superice.gdcc.lir.LirBasicBlock;
+import dev.superice.gdcc.lir.LirClassDef;
+import dev.superice.gdcc.lir.LirFunctionDef;
+import dev.superice.gdcc.lir.LirModule;
+import dev.superice.gdcc.lir.LirParameterDef;
+import dev.superice.gdcc.lir.insn.LiteralIntInsn;
+import dev.superice.gdcc.lir.insn.PackVariantInsn;
+import dev.superice.gdcc.lir.insn.ReturnInsn;
+import dev.superice.gdcc.lir.insn.UnpackVariantInsn;
+import dev.superice.gdcc.lir.insn.VariantGetInsn;
+import dev.superice.gdcc.lir.insn.VariantGetIndexedInsn;
+import dev.superice.gdcc.lir.insn.VariantGetKeyedInsn;
+import dev.superice.gdcc.lir.insn.VariantGetNamedInsn;
+import dev.superice.gdcc.lir.insn.VariantSetInsn;
+import dev.superice.gdcc.lir.insn.VariantSetIndexedInsn;
+import dev.superice.gdcc.lir.insn.VariantSetKeyedInsn;
+import dev.superice.gdcc.lir.insn.VariantSetNamedInsn;
+import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdIntType;
+import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdPackedNumericArrayType;
+import dev.superice.gdcc.type.GdStringNameType;
+import dev.superice.gdcc.type.GdStringType;
+import dev.superice.gdcc.type.GdType;
+import dev.superice.gdcc.type.GdVariantType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IndexStoreInsnGenEngineTest {
+
+    @Test
+    @DisplayName("index store ref semantics should read back correctly in real engine")
+    void variantSetRefContainersShouldReadBackWithoutWritebackInRealGodot() throws IOException, InterruptedException {
+        if (!hasZig()) {
+            Assumptions.abort("Zig not found; skipping integration test");
+            return;
+        }
+
+        var tempDir = Path.of("tmp/test/index_store_engine_ref_container");
+        Files.createDirectories(tempDir);
+
+        var projectInfo = new CProjectInfo(
+                "index_store_engine_ref_container",
+                GodotVersion.V451,
+                tempDir,
+                COptimizationLevel.DEBUG,
+                TargetPlatform.getNativePlatform()
+        );
+        var builder = new CProjectBuilder();
+        builder.initProject(projectInfo);
+
+        var testClass = newIndexStoreEngineClass();
+        var module = new LirModule("index_store_engine_ref_container_module", List.of(testClass));
+        var api = ExtensionApiLoader.loadVersion(GodotVersion.V451);
+        var codegen = new CCodegen();
+        codegen.prepare(new CodegenContext(projectInfo, new ClassRegistry(api)), module);
+
+        var buildResult = builder.buildProject(projectInfo, codegen);
+        assertTrue(buildResult.success(), "Compilation should succeed. Build log:\n" + buildResult.buildLog());
+        assertFalse(buildResult.artifacts().isEmpty(), "Compilation should produce extension artifacts.");
+
+        var entrySource = Files.readString(tempDir.resolve("entry.c"));
+        assertTrue(entrySource.contains("godot_new_Variant_with_Array($arr)"), entrySource);
+        assertTrue(entrySource.contains("godot_new_Variant_with_Dictionary($dict)"), entrySource);
+        assertTrue(entrySource.contains("godot_new_Variant_with_PackedInt32Array($packed)"), entrySource);
+        assertTrue(entrySource.contains("(GDExtensionInt)$idx"), entrySource);
+        assertTrue(entrySource.contains("godot_new_Variant_with_int($value)"), entrySource);
+        assertTrue(entrySource.contains("godot_new_Variant_with_String($key)"), entrySource);
+        assertTrue(entrySource.contains("godot_new_Variant_with_String($value)"), entrySource);
+        assertTrue(entrySource.contains("godot_variant_set_named("), entrySource);
+        assertTrue(entrySource.contains("godot_variant_set_indexed("), entrySource);
+        assertTrue(entrySource.contains("godot_variant_set("), entrySource);
+        assertFalse(entrySource.contains("$arr = godot_new_Array_with_Variant("), entrySource);
+        assertFalse(entrySource.contains("$dict = godot_new_Dictionary_with_Variant("), entrySource);
+        assertTrue(entrySource.contains("$packed_local = godot_new_PackedInt32Array_with_Variant(&__gdcc_tmp_idx_self_variant_"), entrySource);
+        assertFalse(entrySource.contains("*$packed ="), entrySource);
+
+        var runner = new GodotGdextensionTestRunner(Path.of("test_project"));
+        runner.prepareProject(new GodotGdextensionTestRunner.ProjectSetup(
+                buildResult.artifacts(),
+                List.of(new GodotGdextensionTestRunner.SceneNodeSpec(
+                        "IndexStoreNode",
+                        testClass.getName(),
+                        ".",
+                        Map.of()
+                )),
+                new GodotGdextensionTestRunner.TestScriptSpec(testScript())
+        ));
+
+        var runResult = runner.run(true);
+        var combinedOutput = runResult.combinedOutput();
+
+        assertTrue(runResult.stopSignalSeen(), "Godot run should emit stop signal.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("index store array ref check passed."), "Array check should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("index store dictionary ref check passed."), "Dictionary check should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("index store array ref index/value check passed."), "Array ref index/value check should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("index store dictionary ref key/value check passed."), "Dictionary ref key/value check should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("index store dictionary named ref check passed."), "Dictionary named ref check should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("index store dictionary string ref check passed."), "Dictionary string ref check should pass.\nOutput:\n" + combinedOutput);
+        assertTrue(combinedOutput.contains("index store packed ref check passed."), "Packed array check should pass.\nOutput:\n" + combinedOutput);
+        assertFalse(combinedOutput.contains("check failed"), "No check should fail.\nOutput:\n" + combinedOutput);
+    }
+
+    private static boolean hasZig() {
+        return ZigUtil.findZig() != null;
+    }
+
+    private static @NotNull LirClassDef newIndexStoreEngineClass() {
+        var clazz = new LirClassDef("GDIndexStoreEngineNode", "Node");
+        clazz.setSourceFile("index_store_engine.gd");
+
+        var selfType = new GdObjectType(clazz.getName());
+        clazz.addFunction(newArrayRefSetGetFunction(selfType));
+        clazz.addFunction(newDictionaryRefSetGetFunction(selfType));
+        clazz.addFunction(newArrayRefSetGetWithRefIndexValueFunction(selfType));
+        clazz.addFunction(newDictionaryRefSetGetWithRefKeyValueFunction(selfType));
+        clazz.addFunction(newDictionaryRefSetNamedGetWithRefNameValueFunction(selfType));
+        clazz.addFunction(newDictionaryRefSetKeyedWithRefStringKeyValueFunction(selfType));
+        clazz.addFunction(newPackedInt32RefSetGetFunction(selfType));
+        return clazz;
+    }
+
+    private static @NotNull LirFunctionDef newArrayRefSetGetFunction(@NotNull GdObjectType selfType) {
+        var func = newMethod("array_ref_set_get", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("arr", new GdArrayType(GdVariantType.VARIANT), null, func));
+        func.createAndAddVariable("idx", GdIntType.INT);
+        func.createAndAddVariable("value", GdIntType.INT);
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        var entry = entry(func);
+        entry.instructions().add(new LiteralIntInsn("idx", 1));
+        entry.instructions().add(new LiteralIntInsn("value", 77));
+        entry.instructions().add(new VariantSetIndexedInsn("arr", "idx", "value"));
+        entry.instructions().add(new VariantGetIndexedInsn("result", "arr", "idx"));
+        entry.instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static @NotNull LirFunctionDef newDictionaryRefSetGetFunction(@NotNull GdObjectType selfType) {
+        var func = newMethod("dictionary_ref_set_get", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("dict", new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT), null, func));
+        func.createAndAddVariable("key", GdIntType.INT);
+        func.createAndAddVariable("value", GdIntType.INT);
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        var entry = entry(func);
+        entry.instructions().add(new LiteralIntInsn("key", 123));
+        entry.instructions().add(new LiteralIntInsn("value", 456));
+        entry.instructions().add(new VariantSetKeyedInsn("dict", "key", "value"));
+        entry.instructions().add(new VariantGetKeyedInsn("result", "dict", "key"));
+        entry.instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static @NotNull LirFunctionDef newArrayRefSetGetWithRefIndexValueFunction(@NotNull GdObjectType selfType) {
+        var func = newMethod("array_ref_set_get_with_ref_index_value", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("arr", new GdArrayType(GdVariantType.VARIANT), null, func));
+        func.addParameter(new LirParameterDef("idx", GdIntType.INT, null, func));
+        func.addParameter(new LirParameterDef("value", GdIntType.INT, null, func));
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        var entry = entry(func);
+        entry.instructions().add(new VariantSetIndexedInsn("arr", "idx", "value"));
+        entry.instructions().add(new VariantGetIndexedInsn("result", "arr", "idx"));
+        entry.instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static @NotNull LirFunctionDef newDictionaryRefSetGetWithRefKeyValueFunction(@NotNull GdObjectType selfType) {
+        var func = newMethod("dictionary_ref_set_get_with_ref_key_value", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("dict", new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT), null, func));
+        func.addParameter(new LirParameterDef("key", GdIntType.INT, null, func));
+        func.addParameter(new LirParameterDef("value", GdIntType.INT, null, func));
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        var entry = entry(func);
+        entry.instructions().add(new VariantSetInsn("dict", "key", "value"));
+        entry.instructions().add(new VariantGetInsn("result", "dict", "key"));
+        entry.instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static @NotNull LirFunctionDef newDictionaryRefSetNamedGetWithRefNameValueFunction(@NotNull GdObjectType selfType) {
+        var func = newMethod("dictionary_ref_set_named_get_with_ref_name_value", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("dict", new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT), null, func));
+        func.addParameter(new LirParameterDef("name", GdStringNameType.STRING_NAME, null, func));
+        func.addParameter(new LirParameterDef("value", GdIntType.INT, null, func));
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        var entry = entry(func);
+        entry.instructions().add(new VariantSetNamedInsn("dict", "name", "value"));
+        entry.instructions().add(new VariantGetNamedInsn("result", "dict", "name"));
+        entry.instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static @NotNull LirFunctionDef newDictionaryRefSetKeyedWithRefStringKeyValueFunction(@NotNull GdObjectType selfType) {
+        var func = newMethod("dictionary_ref_set_keyed_with_ref_string_key_value", GdStringType.STRING, selfType);
+        func.addParameter(new LirParameterDef("dict", new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT), null, func));
+        func.addParameter(new LirParameterDef("key", GdStringType.STRING, null, func));
+        func.addParameter(new LirParameterDef("value", GdStringType.STRING, null, func));
+        func.createAndAddVariable("result", GdStringType.STRING);
+
+        var entry = entry(func);
+        entry.instructions().add(new VariantSetKeyedInsn("dict", "key", "value"));
+        entry.instructions().add(new VariantGetKeyedInsn("result", "dict", "key"));
+        entry.instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static @NotNull LirFunctionDef newPackedInt32RefSetGetFunction(@NotNull GdObjectType selfType) {
+        var func = newMethod("packed_int32_ref_set_get", GdIntType.INT, selfType);
+        func.addParameter(new LirParameterDef("packed", GdPackedNumericArrayType.PACKED_INT32_ARRAY, null, func));
+        func.createAndAddVariable("packed_variant", GdVariantType.VARIANT);
+        func.createAndAddVariable("packed_local", GdPackedNumericArrayType.PACKED_INT32_ARRAY);
+        func.createAndAddVariable("idx", GdIntType.INT);
+        func.createAndAddVariable("value", GdIntType.INT);
+        func.createAndAddVariable("result", GdIntType.INT);
+
+        var entry = entry(func);
+        entry.instructions().add(new LiteralIntInsn("idx", 0));
+        entry.instructions().add(new LiteralIntInsn("value", 66));
+        entry.instructions().add(new PackVariantInsn("packed_variant", "packed"));
+        entry.instructions().add(new UnpackVariantInsn("packed_local", "packed_variant"));
+        entry.instructions().add(new VariantSetIndexedInsn("packed_local", "idx", "value"));
+        entry.instructions().add(new VariantGetIndexedInsn("result", "packed_local", "idx"));
+        entry.instructions().add(new ReturnInsn("result"));
+        return func;
+    }
+
+    private static @NotNull LirFunctionDef newMethod(@NotNull String name,
+                                                     @NotNull GdType returnType,
+                                                     @NotNull GdObjectType selfType) {
+        var func = new LirFunctionDef(name);
+        func.setReturnType(returnType);
+        func.addParameter(new LirParameterDef("self", selfType, null, func));
+        func.addBasicBlock(new LirBasicBlock("entry"));
+        func.setEntryBlockId("entry");
+        return func;
+    }
+
+    private static @NotNull LirBasicBlock entry(@NotNull LirFunctionDef functionDef) {
+        return functionDef.getBasicBlock("entry");
+    }
+
+    private static @NotNull String testScript() {
+        return """
+                extends Node
+                
+                const TARGET_NODE_NAME = "IndexStoreNode"
+                
+                func _ready() -> void:
+                    var target = get_parent().get_node_or_null(TARGET_NODE_NAME)
+                    if target == null:
+                        push_error("Target node missing.")
+                        return
+                
+                    var arr = [10, 20, 30]
+                    var arr_result = int(target.call("array_ref_set_get", arr))
+                    if arr_result == 77 and int(arr[1]) == 77:
+                        print("index store array ref check passed.")
+                    else:
+                        push_error("index store array ref check failed.")
+                
+                    var dict = {1: 5}
+                    var dict_result = int(target.call("dictionary_ref_set_get", dict))
+                    if dict_result == 456 and int(dict[123]) == 456:
+                        print("index store dictionary ref check passed.")
+                    else:
+                        push_error("index store dictionary ref check failed.")
+                
+                    var arr_ref_args = [1, 2, 3]
+                    var arr_ref_idx = 2
+                    var arr_ref_value = 88
+                    var arr_ref_args_result = int(target.call("array_ref_set_get_with_ref_index_value", arr_ref_args, arr_ref_idx, arr_ref_value))
+                    if arr_ref_args_result == 88 and int(arr_ref_args[2]) == 88:
+                        print("index store array ref index/value check passed.")
+                    else:
+                        push_error("index store array ref index/value check failed.")
+                
+                    var dict_ref_args = {4: 40}
+                    var dict_ref_key = 9
+                    var dict_ref_value = 333
+                    var dict_ref_args_result = int(target.call("dictionary_ref_set_get_with_ref_key_value", dict_ref_args, dict_ref_key, dict_ref_value))
+                    if dict_ref_args_result == 333 and dict_ref_args.has(9) and int(dict_ref_args[9]) == 333:
+                        print("index store dictionary ref key/value check passed.")
+                    else:
+                        push_error("index store dictionary ref key/value check failed.")
+                
+                    var dict_named = {}
+                    var prop_name = &"hp"
+                    var named_value = 999
+                    var dict_named_result = int(target.call("dictionary_ref_set_named_get_with_ref_name_value", dict_named, prop_name, named_value))
+                    if dict_named_result == 999 and dict_named.has(&"hp") and int(dict_named[&"hp"]) == 999:
+                        print("index store dictionary named ref check passed.")
+                    else:
+                        push_error("index store dictionary named ref check failed.")
+                
+                    var dict_str = {}
+                    var str_key = "title"
+                    var str_value = "gdcc"
+                    var dict_str_result = str(target.call("dictionary_ref_set_keyed_with_ref_string_key_value", dict_str, str_key, str_value))
+                    if dict_str_result == "gdcc" and dict_str.has("title") and str(dict_str["title"]) == "gdcc":
+                        print("index store dictionary string ref check passed.")
+                    else:
+                        push_error("index store dictionary string ref check failed.")
+                
+                    var packed = PackedInt32Array([9, 8, 7])
+                    var packed_result = int(target.call("packed_int32_ref_set_get", packed))
+                    if packed_result == 66:
+                        print("index store packed ref check passed.")
+                    else:
+                        push_error("index store packed ref check failed.")
+                """;
+    }
+}

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/IndexStoreInsnGenTest.java
@@ -1,0 +1,702 @@
+package dev.superice.gdcc.backend.c.gen;
+
+import dev.superice.gdcc.backend.CodegenContext;
+import dev.superice.gdcc.backend.ProjectInfo;
+import dev.superice.gdcc.backend.c.gen.insn.IndexStoreInsnGen;
+import dev.superice.gdcc.enums.GodotVersion;
+import dev.superice.gdcc.exception.InvalidInsnException;
+import dev.superice.gdcc.gdextension.ExtensionAPI;
+import dev.superice.gdcc.lir.LirBasicBlock;
+import dev.superice.gdcc.lir.LirClassDef;
+import dev.superice.gdcc.lir.LirFunctionDef;
+import dev.superice.gdcc.lir.LirInstruction;
+import dev.superice.gdcc.lir.insn.VariantSetIndexedInsn;
+import dev.superice.gdcc.lir.insn.VariantSetInsn;
+import dev.superice.gdcc.lir.insn.VariantSetKeyedInsn;
+import dev.superice.gdcc.lir.insn.VariantSetNamedInsn;
+import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdFloatVectorType;
+import dev.superice.gdcc.type.GdIntType;
+import dev.superice.gdcc.type.GdPackedNumericArrayType;
+import dev.superice.gdcc.type.GdStringNameType;
+import dev.superice.gdcc.type.GdStringType;
+import dev.superice.gdcc.type.GdType;
+import dev.superice.gdcc.type.GdVariantType;
+import dev.superice.gdcc.type.GdVoidType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IndexStoreInsnGenTest {
+    @Test
+    @DisplayName("variant_set with Variant self/key/value should avoid operand pack")
+    void variantSetVariantKeyVariantValue() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_set(&$self, &$key, &$value"), body);
+        assertFalse(body.contains("__gdcc_tmp_idx_self_variant_"), body);
+        assertFalse(body.contains("__gdcc_tmp_idx_key_variant_"), body);
+        assertFalse(body.contains("__gdcc_tmp_idx_val_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should pack non-Variant key operand")
+    void variantSetNonVariantKeyPack() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_int($key)"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_key_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should pack ref int key operand")
+    void variantSetRefIntKeyPack() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key_ref", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key_ref", GdIntType.INT, true),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_int($key_ref)"), body);
+        assertTrue(body.contains("godot_variant_set(&$self, &__gdcc_tmp_idx_key_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should pack non-Variant value operand")
+    void variantSetNonVariantValuePack() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_int($value)"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_val_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should pack ref String value operand")
+    void variantSetRefStringValuePack() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value_ref"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("value_ref", GdStringType.STRING, true)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_String($value_ref)"), body);
+        assertTrue(body.contains("godot_variant_set(&$self, &$key, &__gdcc_tmp_idx_val_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should allow Array self with pack and without writeback")
+    void variantSetArraySelfPackSucceeds() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", new GdArrayType(GdVariantType.VARIANT), false),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Array(&$self)"), body);
+        assertTrue(body.contains("godot_new_Variant_with_int($key)"), body);
+        assertFalse(body.contains("$self = godot_new_Array_with_Variant("), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should allow ref Array self without writeback")
+    void variantSetRefArraySelfPackSucceedsWithoutWriteback() {
+        var body = generateBody(
+                new VariantSetInsn("self_ref", "key", "value"),
+                List.of(
+                        new VariableSpec("self_ref", new GdArrayType(GdVariantType.VARIANT), true),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Array($self_ref)"), body);
+        assertFalse(body.contains("$self_ref = godot_new_Array_with_Variant("), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should allow ref Dictionary self without writeback")
+    void variantSetRefDictionarySelfPackSucceedsWithoutWriteback() {
+        var body = generateBody(
+                new VariantSetInsn("self_ref", "key", "value"),
+                List.of(
+                        new VariableSpec("self_ref", new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT), true),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Dictionary($self_ref)"), body);
+        assertFalse(body.contains("$self_ref = godot_new_Dictionary_with_Variant("), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should emit writeback for value-semantic self")
+    void variantSetValueSemanticSelfEmitsWriteback() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", GdFloatVectorType.VECTOR3, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Vector3(&$self)"), body);
+        assertTrue(body.contains("$self = godot_new_Vector3_with_Variant(&__gdcc_tmp_idx_self_variant_"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_self_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should fail-fast when ref self requires writeback")
+    void variantSetRefValueSemanticSelfFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantSetInsn("self_ref", "key", "value"),
+                        List.of(
+                                new VariableSpec("self_ref", GdStringType.STRING, true),
+                                new VariableSpec("key", GdVariantType.VARIANT, false),
+                                new VariableSpec("value", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("requires writeback"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_set should fail-fast on unsupported self type")
+    void variantSetUnsupportedSelfFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantSetInsn("self", "key", "value"),
+                        List.of(
+                                new VariableSpec("self", GdIntType.INT, false),
+                                new VariableSpec("key", GdVariantType.VARIANT, false),
+                                new VariableSpec("value", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("unsupported type"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_set should fail-fast when self operand does not exist")
+    void variantSetMissingVariantOperandFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantSetInsn("missing_self", "key", "value"),
+                        List.of(
+                                new VariableSpec("key", GdVariantType.VARIANT, false),
+                                new VariableSpec("value", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("self operand variable ID 'missing_self'"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_set should fail-fast when key operand does not exist")
+    void variantSetMissingKeyOperandFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantSetInsn("self", "missing_key", "value"),
+                        List.of(
+                                new VariableSpec("self", GdVariantType.VARIANT, false),
+                                new VariableSpec("value", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("key operand variable ID 'missing_key'"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_set should fail-fast when value operand does not exist")
+    void variantSetMissingValueOperandFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantSetInsn("self", "key", "missing_value"),
+                        List.of(
+                                new VariableSpec("self", GdVariantType.VARIANT, false),
+                                new VariableSpec("key", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("value operand variable ID 'missing_value'"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_set_keyed should emit godot_variant_set_keyed call")
+    void variantSetKeyedBasic() {
+        var body = generateBody(
+                new VariantSetKeyedInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_set_keyed(&$self, &$key, &$value"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_keyed should allow ref Dictionary self without writeback")
+    void variantSetKeyedRefDictionarySelfPackSucceedsWithoutWriteback() {
+        var body = generateBody(
+                new VariantSetKeyedInsn("self_ref", "key", "value"),
+                List.of(
+                        new VariableSpec("self_ref", new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT), true),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Dictionary($self_ref)"), body);
+        assertFalse(body.contains("$self_ref = godot_new_Dictionary_with_Variant("), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_named should emit StringName variable call")
+    void variantSetNamedBasic() {
+        var body = generateBody(
+                new VariantSetNamedInsn("self", "name", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("name", GdStringNameType.STRING_NAME, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_set_named(&$self, &$name, &$value"), body);
+        assertFalse(body.contains("GD_STATIC_SN("), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_named should pack non-Variant value operand")
+    void variantSetNamedNonVariantValue() {
+        var body = generateBody(
+                new VariantSetNamedInsn("self", "name", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("name", GdStringNameType.STRING_NAME, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_int($value)"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_val_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_named should fail-fast when name operand is not StringName")
+    void variantSetNamedNonStringNameFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantSetNamedInsn("self", "name", "value"),
+                        List.of(
+                                new VariableSpec("self", GdVariantType.VARIANT, false),
+                                new VariableSpec("name", GdVariantType.VARIANT, false),
+                                new VariableSpec("value", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("must be StringName"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_set_named should fail-fast when self does not support named-set")
+    void variantSetNamedUnsupportedSelfFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantSetNamedInsn("self", "name", "value"),
+                        List.of(
+                                new VariableSpec("self", GdIntType.INT, false),
+                                new VariableSpec("name", GdStringNameType.STRING_NAME, false),
+                                new VariableSpec("value", GdVariantType.VARIANT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("unsupported type"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed should emit indexed call and oob check")
+    void variantSetIndexedBasic() {
+        var body = generateBody(
+                new VariantSetIndexedInsn("self", "idx", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_set_indexed(&$self, (GDExtensionInt)$idx, &$value"), body);
+        assertTrue(body.contains("if (__gdcc_tmp_idx_oob_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed should accept ref int index")
+    void variantSetIndexedRefIntIndex() {
+        var body = generateBody(
+                new VariantSetIndexedInsn("self", "idx_ref", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("idx_ref", GdIntType.INT, true),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_variant_set_indexed(&$self, (GDExtensionInt)$idx_ref, &$value"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed should pack non-Variant value operand")
+    void variantSetIndexedNonVariantValue() {
+        var body = generateBody(
+                new VariantSetIndexedInsn("self", "idx", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_int($value)"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_val_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed should allow Array self with pack and without writeback")
+    void variantSetIndexedArraySelfPackSucceeds() {
+        var body = generateBody(
+                new VariantSetIndexedInsn("self", "idx", "value"),
+                List.of(
+                        new VariableSpec("self", new GdArrayType(GdVariantType.VARIANT), false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Array(&$self)"), body);
+        assertFalse(body.contains("$self = godot_new_Array_with_Variant("), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed should allow ref Array self with pack and without writeback")
+    void variantSetIndexedRefArraySelfPackSucceeds() {
+        var body = generateBody(
+                new VariantSetIndexedInsn("self_ref", "idx", "value"),
+                List.of(
+                        new VariableSpec("self_ref", new GdArrayType(GdVariantType.VARIANT), true),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Array($self_ref)"), body);
+        assertFalse(body.contains("$self_ref = godot_new_Array_with_Variant("), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed should allow Dictionary self with pack and without writeback")
+    void variantSetIndexedDictionarySelfPackSucceeds() {
+        var body = generateBody(
+                new VariantSetIndexedInsn("self", "idx", "value"),
+                List.of(
+                        new VariableSpec("self", new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT), false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_Dictionary(&$self)"), body);
+        assertFalse(body.contains("$self = godot_new_Dictionary_with_Variant("), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed should write back PackedInt32Array self")
+    void variantSetIndexedPackedInt32ArraySelfWritesBack() {
+        var body = generateBody(
+                new VariantSetIndexedInsn("self", "idx", "value"),
+                List.of(
+                        new VariableSpec("self", GdPackedNumericArrayType.PACKED_INT32_ARRAY, false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_new_Variant_with_PackedInt32Array(&$self)"), body);
+        assertTrue(body.contains("$self = godot_new_PackedInt32Array_with_Variant(&__gdcc_tmp_idx_self_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed should fail-fast when ref PackedInt32Array self requires writeback")
+    void variantSetIndexedRefPackedInt32ArraySelfFails() {
+        var ex = assertThrows(
+                InvalidInsnException.class,
+                () -> generateBody(
+                        new VariantSetIndexedInsn("self_ref", "idx", "value"),
+                        List.of(
+                                new VariableSpec("self_ref", GdPackedNumericArrayType.PACKED_INT32_ARRAY, true),
+                                new VariableSpec("idx", GdIntType.INT, false),
+                                new VariableSpec("value", GdIntType.INT, false)
+                        )
+                )
+        );
+
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("requires writeback"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("variant_set should emit r_valid check and runtime error branch")
+    void variantSetEmitsValidCheck() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("if (!__gdcc_tmp_idx_valid_"), body);
+        assertTrue(body.contains("GDCC_PRINT_RUNTIME_ERROR(\"variant_set failed: self=$self, key=$key, value=$value\""), body);
+        assertTrue(body.contains("goto __finally__;"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed should emit r_oob check and runtime error branch")
+    void variantSetIndexedEmitsOobCheck() {
+        var body = generateBody(
+                new VariantSetIndexedInsn("self", "idx", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("value", GdVariantType.VARIANT, false)
+                )
+        );
+
+        assertTrue(body.contains("if (__gdcc_tmp_idx_oob_"), body);
+        assertTrue(body.contains("variant_set_indexed index out of bounds: index=$idx"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set invalid branch should destroy temps in reverse init order")
+    void variantSetInvalidBranchDestroyOrder() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", new GdArrayType(GdVariantType.VARIANT), false),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertInOrder(
+                body,
+                "GDCC_PRINT_RUNTIME_ERROR(\"variant_set failed: self=$self, key=$key, value=$value\"",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_val_variant_",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_key_variant_",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_self_variant_",
+                "goto __finally__;"
+        );
+    }
+
+    @Test
+    @DisplayName("variant_set_indexed oob branch should destroy value then self temp")
+    void variantSetIndexedOobDestroyOrder() {
+        var body = generateBody(
+                new VariantSetIndexedInsn("self", "idx", "value"),
+                List.of(
+                        new VariableSpec("self", new GdArrayType(GdVariantType.VARIANT), false),
+                        new VariableSpec("idx", GdIntType.INT, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertInOrder(
+                body,
+                "variant_set_indexed index out of bounds: index=$idx",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_val_variant_",
+                "godot_Variant_destroy(&__gdcc_tmp_idx_self_variant_",
+                "goto __finally__;"
+        );
+    }
+
+    @Test
+    @DisplayName("variant_set should destroy temporary packed key and value variants")
+    void variantSetDestroysTempPackVars() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", GdVariantType.VARIANT, false),
+                        new VariableSpec("key", GdIntType.INT, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_key_variant_"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_val_variant_"), body);
+    }
+
+    @Test
+    @DisplayName("variant_set should destroy self temp in value-semantic writeback path")
+    void variantSetValueSemanticWritebackPathDestroysSelfTemp() {
+        var body = generateBody(
+                new VariantSetInsn("self", "key", "value"),
+                List.of(
+                        new VariableSpec("self", GdFloatVectorType.VECTOR3, false),
+                        new VariableSpec("key", GdVariantType.VARIANT, false),
+                        new VariableSpec("value", GdIntType.INT, false)
+                )
+        );
+
+        assertTrue(body.contains("$self = godot_new_Vector3_with_Variant(&__gdcc_tmp_idx_self_variant_"), body);
+        assertTrue(body.contains("godot_Variant_destroy(&__gdcc_tmp_idx_self_variant_"), body);
+    }
+
+    private @NotNull String generateBody(@NotNull LirInstruction instruction,
+                                         @NotNull List<VariableSpec> variableSpecs) {
+        return generateBody(instruction, variableSpecs, GdVoidType.VOID);
+    }
+
+    private @NotNull String generateBody(@NotNull LirInstruction instruction,
+                                         @NotNull List<VariableSpec> variableSpecs,
+                                         @NotNull GdType returnType) {
+        var workerClass = newTestClass();
+        var func = newFunction("index_store_test", returnType);
+        for (var variableSpec : variableSpecs) {
+            if (variableSpec.ref()) {
+                func.createAndAddRefVariable(variableSpec.id(), variableSpec.type());
+            } else {
+                func.createAndAddVariable(variableSpec.id(), variableSpec.type());
+            }
+        }
+
+        var entry = entry(func);
+        entry.instructions().add(instruction);
+        workerClass.addFunction(func);
+
+        var bodyBuilder = newBodyBuilder(workerClass, func);
+        bodyBuilder.beginBasicBlock(entry.id());
+        bodyBuilder.setCurrentPosition(entry, 0, instruction);
+        new IndexStoreInsnGen().generateCCode(bodyBuilder);
+        return bodyBuilder.build();
+    }
+
+    private @NotNull LirClassDef newTestClass() {
+        return new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+    }
+
+    private @NotNull LirFunctionDef newFunction(@NotNull String name, @NotNull GdType returnType) {
+        var func = new LirFunctionDef(name);
+        func.setReturnType(returnType);
+        return func;
+    }
+
+    private @NotNull LirBasicBlock entry(@NotNull LirFunctionDef func) {
+        var entry = new LirBasicBlock("entry");
+        func.addBasicBlock(entry);
+        func.setEntryBlockId("entry");
+        return entry;
+    }
+
+    private @NotNull CBodyBuilder newBodyBuilder(@NotNull LirClassDef clazz, @NotNull LirFunctionDef func) {
+        var classRegistry = new ClassRegistry(emptyApi());
+        classRegistry.addGdccClass(clazz);
+        ProjectInfo projectInfo = new ProjectInfo("TestProject", GodotVersion.V451, Path.of(".")) {
+        };
+        var ctx = new CodegenContext(projectInfo, classRegistry);
+        var helper = new CGenHelper(ctx, List.of(clazz));
+        return new CBodyBuilder(helper, clazz, func);
+    }
+
+    private void assertInOrder(@NotNull String body, @NotNull String... fragments) {
+        var from = -1;
+        for (var fragment : fragments) {
+            var idx = body.indexOf(fragment, from + 1);
+            assertTrue(idx >= 0, "Missing fragment: " + fragment + "\n" + body);
+            from = idx;
+        }
+    }
+
+    private @NotNull ExtensionAPI emptyApi() {
+        return new ExtensionAPI(
+                null,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+        );
+    }
+
+    private record VariableSpec(@NotNull String id, @NotNull GdType type, boolean ref) {
+    }
+}

--- a/src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnParserTest.java
+++ b/src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnParserTest.java
@@ -88,6 +88,46 @@ public class SimpleLirBlockInsnParserTest {
         assertInstanceOf(BinaryOpInsn.class, insns.get(4));
     }
 
+    @Test
+    public void parse_indexedInstructionsUseVariableIndexOperand() {
+        var input = """
+                $result = variant_get_indexed $arr $idx;
+                variant_set_indexed $arr $idx $value;
+                """;
+        var insns = parse(input);
+        assertEquals(2, insns.size());
+
+        var getInsn = assertInstanceOf(VariantGetIndexedInsn.class, insns.getFirst());
+        assertEquals("result", getInsn.resultId());
+        assertEquals("arr", getInsn.variantId());
+        assertEquals("idx", getInsn.indexId());
+
+        var setInsn = assertInstanceOf(VariantSetIndexedInsn.class, insns.getLast());
+        assertEquals("arr", setInsn.variantId());
+        assertEquals("idx", setInsn.indexId());
+        assertEquals("value", setInsn.valueId());
+    }
+
+    @Test
+    public void parse_namedInstructionsUseStringNameVariableOperand() {
+        var input = """
+                $result = variant_get_named $obj $name;
+                variant_set_named $obj $name $value;
+                """;
+        var insns = parse(input);
+        assertEquals(2, insns.size());
+
+        var getInsn = assertInstanceOf(VariantGetNamedInsn.class, insns.getFirst());
+        assertEquals("result", getInsn.resultId());
+        assertEquals("obj", getInsn.namedVariantId());
+        assertEquals("name", getInsn.nameId());
+
+        var setInsn = assertInstanceOf(VariantSetNamedInsn.class, insns.getLast());
+        assertEquals("obj", setInsn.namedVariantId());
+        assertEquals("name", setInsn.nameId());
+        assertEquals("value", setInsn.valueId());
+    }
+
     @SuppressWarnings("TrailingWhitespacesInTextBlock")
     @Test
     public void parse_whitespaceVariants() {

--- a/src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnSerializerTest.java
+++ b/src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnSerializerTest.java
@@ -57,4 +57,36 @@ public class SimpleLirBlockInsnSerializerTest {
         // Unknown stays backward-compatible with old syntax.
         assertTrue(out.contains("destruct $1;"));
     }
+
+    @Test
+    public void serialize_indexedInstructionsUseVariableIndexOperand() throws Exception {
+        var insnList = List.<LirInstruction>of(
+                new VariantGetIndexedInsn("result", "arr", "idx"),
+                new VariantSetIndexedInsn("arr", "idx", "value")
+        );
+
+        var serializer = new SimpleLirBlockInsnSerializer();
+        var sw = new StringWriter();
+        serializer.serialize(insnList, sw);
+        var out = sw.toString();
+
+        assertTrue(out.contains("$result = variant_get_indexed $arr $idx;"), out);
+        assertTrue(out.contains("variant_set_indexed $arr $idx $value;"), out);
+    }
+
+    @Test
+    public void serialize_namedInstructionsUseStringNameVariableOperand() throws Exception {
+        var insnList = List.<LirInstruction>of(
+                new VariantGetNamedInsn("result", "obj", "name"),
+                new VariantSetNamedInsn("obj", "name", "value")
+        );
+
+        var serializer = new SimpleLirBlockInsnSerializer();
+        var sw = new StringWriter();
+        serializer.serialize(insnList, sw);
+        var out = sw.toString();
+
+        assertTrue(out.contains("$result = variant_get_named $obj $name;"), out);
+        assertTrue(out.contains("variant_set_named $obj $name $value;"), out);
+    }
 }


### PR DESCRIPTION
## What changed
- Implemented indexing instruction code generation for all 8 LIR instructions in C backend:
  - `variant_get`, `variant_get_keyed`, `variant_get_named`, `variant_get_indexed`
  - `variant_set`, `variant_set_keyed`, `variant_set_named`, `variant_set_indexed`
- Added new generators and registration:
  - `IndexLoadInsnGen`
  - `IndexStoreInsnGen`
  - opcode registration in `CCodegen`
- Aligned named/indexed operand modeling to variable operands (`StringName`/`int`) in LIR parse/serialize path.
- Added broad test coverage:
  - unit tests for GET/SET generators
  - `CCodegen` dispatch/registration tests
  - engine integration tests focused on ref semantics execution paths
- Archived and normalized module implementation document as the long-term source of truth:
  - `doc/module_impl/index_insn_implementation.md`

## Why
- Complete backend support for Indexing Instructions with explicit lifecycle/error-handling behavior.
- Validate ref semantics in real engine execution (self/key/value/index combinations) to prevent regressions in writeback and runtime behavior.

## Affected areas
- `dev.superice.gdcc.backend.c.gen`
- `dev.superice.gdcc.backend.c.gen.insn`
- `dev.superice.gdcc.lir.insn`
- `dev.superice.gdcc.lir.parser`
- `src/test/java/dev/superice/gdcc/backend/c/gen`
- `src/test/java/dev/superice/gdcc/lir/parser`
- `doc/module_impl` and related backend/LIR docs

## Test commands run
- `./gradlew classes --no-daemon --info --console=plain`
- `./gradlew test --tests IndexLoadInsnGenTest --tests IndexStoreInsnGenTest --tests IndexStoreInsnGenEngineTest --tests CCodegenTest --no-daemon --info --console=plain`