### PR TITLE
feat(backend): implement assign instruction and global container covariance

### DIFF
--- a/doc/gdcc_c_backend.md
+++ b/doc/gdcc_c_backend.md
@@ -122,8 +122,13 @@ Object category rules:
 - CGenHelper has many helper functions to generate C code snippets, read all the code and use them when possible.
 - When generating variable assignments in C code, always check the followings:
   - If the result variable exists and its type is compatible with the assigned value type. (`ClassRegistry#checkAssignable` helps)
-    - For built-in types, types are compatible only if they are exactly the same type.
-    - For engine types and GDCC types, types are compatible if the assigned value type is the same or a subclass of the result variable type.
+    - By default, non-object built-in types are compatible only when exactly the same type.
+    - For engine types and GDCC types, compatibility includes inheritance upcast.
+    - `ClassRegistry#checkAssignable` globally supports limited container covariance:
+      - `Array[T]` -> `Array` / `Array[Variant]`
+      - `Array[SubClass]` -> `Array[SuperClass]`
+      - `Dictionary[K, V]` -> `Dictionary` / `Dictionary[Variant, Variant]`
+      - `Dictionary[K1, V1]` -> `Dictionary[K2, V2]` when both key/value directions are assignable.
     - Always remember if the value that is assigning into a result variable whose type is a GDCC object is returned from a GDExtension function, it is always a `godot_Object*` that needs to be converted to the correct GDCC type.
 - When assigning a value to a variable, it implies that we destroy the old value in the variable and replace it with the new value. 
   If they are `Object`, that means we have to release the ownership of the old value and obtain the ownership of the new value properly, 

--- a/doc/gdcc_low_ir.md
+++ b/doc/gdcc_low_ir.md
@@ -75,6 +75,13 @@ Create a new Object null constant.
 $<result_id> = literal_null
 ```
 
+#### assign
+Assign one variable to another. 
+The source variable must be of the same type as the result variable or be implicitly convertible to the result variable type.
+```
+$<result_id> = assign $<source_id>
+```
+
 ### Construction & Destruction Instructions
 
 #### construct_builtin

--- a/doc/gdcc_low_ir.md
+++ b/doc/gdcc_low_ir.md
@@ -77,7 +77,15 @@ $<result_id> = literal_null
 
 #### assign
 Assign one variable to another. 
-The source variable must be of the same type as the result variable or be implicitly convertible to the result variable type.
+The source variable must be assignable to the result variable type.
+Current assignability rules in backend codegen are:
+- Same type.
+- Object inheritance upcast.
+- Container covariance (limited):
+  - `Array[T]` to `Array` / `Array[Variant]`.
+  - `Array[SubClass]` to `Array[SuperClass]`.
+  - `Dictionary[K, V]` to `Dictionary` / `Dictionary[Variant, Variant]`.
+  - `Dictionary[K1, V1]` to `Dictionary[K2, V2]` when `K1` is assignable to `K2` and `V1` is assignable to `V2`.
 ```
 $<result_id> = assign $<source_id>
 ```

--- a/doc/gdcc_type_system.md
+++ b/doc/gdcc_type_system.md
@@ -52,11 +52,15 @@
 - Packed arrays aim for compact binary layout for memory/disk efficiency.
 
 ## Compatibility & Promotion Rules
-- Each type implementation provides compatibility rules. Common rules:
-    - `GdVariantType` is compatible with any type.
-    - Numeric promotion: e.g., `int` promoted to `float` when required by an operation; reverse may require explicit cast.
-    - Containers: arrays with compatible element types can be assigned (e.g., `Array<int>` to `Array<variant>`).
-    - Object types: compatibility is typically by class name or inheritance relationship; `GdObjectType` can include class constraints.
+- Backend assignment compatibility (used by `ClassRegistry#checkAssignable` globally):
+    - Same type is assignable.
+    - Object types support inheritance upcast.
+    - Container covariance is limited to:
+      - `Array[T]` -> `Array` / `Array[Variant]`
+      - `Array[SubClass]` -> `Array[SuperClass]`
+      - `Dictionary[K, V]` -> `Dictionary` / `Dictionary[Variant, Variant]`
+      - `Dictionary[K1, V1]` -> `Dictionary[K2, V2]` when both key/value directions are assignable.
+    - Other implicit promotions (for example numeric promotion) are not part of generic assignment compatibility and must be handled by dedicated lowering/instruction semantics.
 - For "TypeType", which is a type representing another type:
   - e.g. `var N = Node` where `N` is a "TypeType" representing the `Node` type.
   - We do not explicitly model "TypeType" in the type system; instead, we use a `StringName` to represent the type name as the implementation detail.

--- a/doc/module_impl/assign_insn_implementation.md
+++ b/doc/module_impl/assign_insn_implementation.md
@@ -1,0 +1,214 @@
+# `assign` 指令（Low IR）C 后端实现计划
+
+> 目标：为 Low IR 新增 `assign` 指令补齐从 **IR 解析/序列化 → LIR 指令模型 → C 后端指令生成器 → 单测验收** 的完整链路。
+>
+> 校对基线：2026-03-05（以当前代码库为准；本文是实施计划，不包含实现产物）
+
+---
+
+## 1. 背景与语义锚点
+
+### 1.1 Low IR 语义（规范来源）
+
+`doc/gdcc_low_ir.md` 定义：
+
+- `assign`：把一个变量赋值给另一个变量。
+- 约束：source 类型必须与 result 类型一致，或 **可隐式转换** 到 result 类型。
+
+语法：
+
+```text
+$<result_id> = assign $<source_id>
+```
+
+### 1.2 C 后端槽位写入语义（实现事实源）
+
+`CBodyBuilder#assignVar(...)` 已落地统一槽位写入模型（详见 `doc/module_impl/cbodybuilder_implementation.md` 与 `doc/gdcc_c_backend.md`）：
+
+- 对象槽位写入：`capture old -> assign(convert ptr if needed) -> own(BORROWED only) -> release captured old`
+- 非对象槽位写入：`prepare/copy rhs -> destroy old (if needed) -> assign`
+
+结论：`assign` 指令生成应尽量 **薄封装**，把生命周期/ownership/指针转换统一交给 `CBodyBuilder#assignVar(...)`。
+
+---
+
+## 2. 现状调研（差距清单）
+
+基于当前代码库（2026-03-05）检索结果：
+
+1. 文档已出现 `assign`（`doc/gdcc_low_ir.md`），但 **代码侧缺口**：
+   - `src/main/java/dev/superice/gdcc/enums/GdInstruction.java` 中 **没有** `ASSIGN` opcode。
+   - `src/main/java/dev/superice/gdcc/lir/insn/` 中 **没有** `AssignInsn`（或等价 record）。
+   - `src/main/java/dev/superice/gdcc/lir/parser/ParsedLirInstruction.java` 的 `toConcrete()` switch 中 **没有** `ASSIGN` 分支。
+   - C 后端 `src/main/java/dev/superice/gdcc/backend/c/gen/insn/` 中 **没有**对应 `CInsnGen`。
+2. 但后端已有成熟“赋值语义管道”：
+   - `CBodyBuilder#assignVar(...)` 已集中实现对象/非对象写入、类型可赋值性校验与 ptr 转换。
+
+因此：本次实现需要补齐“指令建模 + 解析/序列化 + generator + 单测”，而不是重写赋值语义。
+
+---
+
+## 3. 设计决策（实施前先定）
+
+### 3.1 `assign` 的生成策略
+
+- **唯一推荐路径**：`AssignInsnGen` 调用 `CBodyBuilder#assignVar(targetOfVar(resultVar), valueOfVar(sourceVar))`。
+- 不在生成器中手写：
+  - destroy/own/release 顺序
+  - GDCC/Godot ptr 转换
+  - destroyable builtin copy 规则
+
+### 3.2 `ref` 变量写入范围（必须明确）
+
+当前 `CBodyBuilder#targetOfVar(...)` 明确拒绝 `ref=true` 目标（会 fail-fast）。
+
+实施选择（建议）：
+
+- **MVP：`assign` 禁止写入 `ref=true` 变量**，与现有 `assignVar/targetOfVar` 契约一致。
+- 若未来确实需要“写入 ref 变量（out-parameter 形式）”：
+  - 不建议扩大 `assign` 语义；
+  - 更建议新增单独的 IR 指令（如 `copy_to_ref` / `store_ref`）或新增 Builder API 专门处理 out-init 模式，避免把通用 assign 变成语义大杂烩。
+
+---
+
+## 4. 分步骤实施计划（含验收细则）
+
+### Phase A：补齐 IR opcode 与 LIR 指令模型
+
+**A1. 新增 opcode**
+
+- 修改：`src/main/java/dev/superice/gdcc/enums/GdInstruction.java`
+- 新增：
+  - `ASSIGN("assign", ReturnKind.REQUIRED, List.of(OperandKind.VARIABLE), 1, 1)`
+- 验收：
+  - `SimpleLirBlockInsnParser` 能通过 `OPCODE_MAP` 识别 `assign`。
+  - 不影响既有 opcode 的 operandKinds/min/max 约束。
+
+**A2. 新增 LIR 指令 record**
+
+- 新增：`src/main/java/dev/superice/gdcc/lir/insn/AssignInsn.java`
+- 建议形态：
+  - `public record AssignInsn(@NotNull String resultId, @NotNull String sourceId) implements LirInstruction { ... }`
+  - `operands()` 返回 `List.of(new VariableOperand(sourceId))`
+  - `opcode()` 返回 `GdInstruction.ASSIGN`
+- 验收：
+  - `AssignInsn.resultId()` 非空（由 record 字段保障）。
+  - `operands()` 与 `GdInstruction.ASSIGN` 的 operandKinds 严格匹配。
+
+**A3. 解析器 concrete 映射**
+
+- 修改：`src/main/java/dev/superice/gdcc/lir/parser/ParsedLirInstruction.java`
+- 在 `toConcrete()` 的 switch 增加：
+  - `case ASSIGN -> new AssignInsn(Objects.requireNonNull(resultId), ((VariableOperand) operands.getFirst()).id());`
+- 验收：
+  - `$a = assign $b;` 可解析为 `AssignInsn("a","b")`。
+  - `resultId` 缺失时 parser 报错位置与现有行为一致（由 ReturnKind.REQUIRED 驱动）。
+
+**A4. Parser/Serializer 单测补齐**
+
+- 修改/新增：
+  - `src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnParserTest.java`
+  - `src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnSerializerTest.java`
+- 建议新增用例：
+  - parse：`$a = assign $b;` -> `AssignInsn`，字段正确。
+  - serialize：`new AssignInsn("a","b")` -> 包含 `$a = assign $b;`
+- 验收命令：
+  - `./gradlew.bat test --tests SimpleLirBlockInsnParserTest --no-daemon --info --console=plain`
+  - `./gradlew.bat test --tests SimpleLirBlockInsnSerializerTest --no-daemon --info --console=plain`
+
+---
+
+### Phase B：实现 C 后端 `AssignInsnGen`
+
+**B1. 新增生成器类**
+
+- 新增：`src/main/java/dev/superice/gdcc/backend/c/gen/insn/AssignInsnGen.java`
+- 实现要点：
+  - `getInsnOpcodes()` 返回 `EnumSet.of(GdInstruction.ASSIGN)`
+  - `generateCCode(CBodyBuilder bodyBuilder)`：
+    1. 校验 `resultId != null`（按惯例：缺失 resultId 直接 `invalidInsn`）
+    2. resolve `resultVar` / `sourceVar` 存在性
+    3. 调用：
+       - `var target = bodyBuilder.targetOfVar(resultVar);`（自动拒绝 ref 目标）
+       - `bodyBuilder.assignVar(target, bodyBuilder.valueOfVar(sourceVar));`
+- 验收：
+  - 类型不兼容时 fail-fast（最终由 `CBodyBuilder#checkAssignable(...)` 抛 `InvalidInsnException`）
+  - 不出现任何手写 own/release/destroy/ptr-convert 字符串拼接
+
+**B2. 注册到 CCodegen**
+
+- 修改：`src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java`
+- 在 static 注册区增加 `registerInsnGen(new AssignInsnGen());`（建议放在 `NewDataInsnGen()` 之后、property/store 之前，保持分类清晰）
+- 验收：
+  - `CCodegen.generateFuncBody(...)` 遇到 `ASSIGN` 不再抛 `Unsupported instruction opcode: assign`
+
+**B3. 生成器单测（核心验收）**
+
+- 新增：`src/test/java/dev/superice/gdcc/backend/c/gen/CAssignInsnGenTest.java`
+- 覆盖建议（最小但要“抓语义”）：
+  1. `int`：`$a = assign $b` 生成 `$a = $b;`
+  2. destroyable builtin（如 `String`）：
+     - 构造 `b`（literal_string 或其他路径）后 `assign` 到 `a`
+     - 断言生成代码走 copy/construct，而不是浅赋值（具体断言以当前 `CBodyBuilder#prepareRhsValue(...)` 产物为准）
+  3. `Object`（RefCounted/Node 等）：
+     - 至少断言生成代码进入对象槽位写入路径（出现 `try_own_object` / `try_release_object` 或对应 helper 调用）
+     - 若要断言顺序：使用“两次写入同一目标”触发 `capture old -> ... -> release old` 的分支
+  4. 负例：source/target 类型不可赋值时抛 `InvalidInsnException`
+- 验收命令：
+  - `./gradlew.bat test --tests CAssignInsnGenTest --no-daemon --info --console=plain`
+  - （可选回归）`./gradlew.bat test --tests CBodyBuilderPhaseCTest --no-daemon --info --console=plain`
+
+---
+
+### Phase C：文档同步与回归门禁
+
+**C1. 文档一致性检查**
+
+- 确认以下文档与实现一致：
+  - `doc/gdcc_low_ir.md`：`assign` 仍为 `$result = assign $source`（result 必须存在）
+  - `doc/gdcc_c_backend.md`、`doc/module_impl/cbodybuilder_implementation.md`：槽位写入顺序不被 `assign` 绕过
+- 若发现文档与实现冲突：优先修正文档（或在实现计划中记录决策），避免“文档先行但行为漂移”。
+
+**C2. 最终回归建议**
+
+实现完成后（合入前）建议至少跑：
+
+```bash
+./gradlew.bat classes --no-daemon --info --console=plain
+./gradlew.bat test --tests SimpleLirBlockInsnParserTest --no-daemon --info --console=plain
+./gradlew.bat test --tests SimpleLirBlockInsnSerializerTest --no-daemon --info --console=plain
+./gradlew.bat test --tests CAssignInsnGenTest --no-daemon --info --console=plain
+```
+
+---
+
+## 5. 风险点与防御性策略
+
+1. **`ref` 变量写入语义不清**：
+   - 本计划明确 MVP 禁止。
+   - 若未来需求出现，建议新增专用指令/Builder API，而不是扩写 `assign`。
+2. **隐式转换矩阵的归属**：
+   - `assign` 不负责定义“哪些类型可隐式转换”；
+   - 统一以 `ClassRegistry#checkAssignable(...)` 为准（生成器只触发 fail-fast）。
+3. **对象 ptrKind 与 helper 匹配**：
+   - 生成器必须只用 `valueOfVar(...)` + `assignVar(...)`，避免手写转换导致 helper 不匹配或 NULL 解引用风险。
+4. **回归断言过于脆弱**：
+   - 单测优先断言“关键语义点”（是否走对象/非对象写槽、是否出现 own/release、是否出现 destroyable copy），
+     避免对格式化细节（空格、临时变量名）做硬编码。
+
+---
+
+## 6. 关键实现锚点（便于落地）
+
+| 用途 | 文件路径 |
+|---|---|
+| opcode 枚举 | `src/main/java/dev/superice/gdcc/enums/GdInstruction.java` |
+| LIR 基类 | `src/main/java/dev/superice/gdcc/lir/LirInstruction.java` |
+| 文本解析入口 | `src/main/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnParser.java` |
+| concrete 映射 | `src/main/java/dev/superice/gdcc/lir/parser/ParsedLirInstruction.java` |
+| 文本序列化 | `src/main/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnSerializer.java` |
+| CCodegen opcode 分发 | `src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java` |
+| CBodyBuilder 赋值管道 | `src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java` |
+| 参考生成器（Pack/Unpack） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/PackUnpackVariantInsnGen.java` |
+| 参考生成器（NewData） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/NewDataInsnGen.java` |
+

--- a/doc/module_impl/assign_insn_implementation.md
+++ b/doc/module_impl/assign_insn_implementation.md
@@ -1,8 +1,10 @@
-# `assign` 指令（Low IR）C 后端实现计划
+# `assign` 指令（Low IR）C 后端实现记录
 
 > 目标：为 Low IR 新增 `assign` 指令补齐从 **IR 解析/序列化 → LIR 指令模型 → C 后端指令生成器 → 单测验收** 的完整链路。
 >
-> 校对基线：2026-03-05（以当前代码库为准；本文是实施计划，不包含实现产物）
+> 状态：Phase A/B/C 已落地，本文按当前代码库更新为实现记录。
+>
+> 校对基线：2026-03-05（以当前代码库为准）
 
 ---
 
@@ -32,19 +34,23 @@ $<result_id> = assign $<source_id>
 
 ---
 
-## 2. 现状调研（差距清单）
+## 2. 当前实现状态（2026-03-05）
 
 基于当前代码库（2026-03-05）检索结果：
 
-1. 文档已出现 `assign`（`doc/gdcc_low_ir.md`），但 **代码侧缺口**：
-   - `src/main/java/dev/superice/gdcc/enums/GdInstruction.java` 中 **没有** `ASSIGN` opcode。
-   - `src/main/java/dev/superice/gdcc/lir/insn/` 中 **没有** `AssignInsn`（或等价 record）。
-   - `src/main/java/dev/superice/gdcc/lir/parser/ParsedLirInstruction.java` 的 `toConcrete()` switch 中 **没有** `ASSIGN` 分支。
-   - C 后端 `src/main/java/dev/superice/gdcc/backend/c/gen/insn/` 中 **没有**对应 `CInsnGen`。
-2. 但后端已有成熟“赋值语义管道”：
-   - `CBodyBuilder#assignVar(...)` 已集中实现对象/非对象写入、类型可赋值性校验与 ptr 转换。
-
-因此：本次实现需要补齐“指令建模 + 解析/序列化 + generator + 单测”，而不是重写赋值语义。
+1. `assign` 链路已完整落地：
+   - `src/main/java/dev/superice/gdcc/enums/GdInstruction.java` 已包含 `ASSIGN` opcode。
+   - `src/main/java/dev/superice/gdcc/lir/insn/AssignInsn.java` 已实现。
+   - `src/main/java/dev/superice/gdcc/lir/parser/ParsedLirInstruction.java` 已包含 `case ASSIGN` concrete 映射。
+   - C 后端 `src/main/java/dev/superice/gdcc/backend/c/gen/insn/AssignInsnGen.java` 已实现并注册到 `CCodegen`。
+2. 赋值语义继续收敛到 `CBodyBuilder#assignVar(...)`：
+   - 对象/非对象写槽、生命周期、ptr 转换由 Builder 单点管理。
+   - `assign` 生成器保持薄封装，不重复实现生命周期细节。
+3. `ClassRegistry#checkAssignable(...)` 现已承载全局可赋值语义扩展：
+   - `Array[T] -> Array` / `Array[Variant]`
+   - `Array[SubClass] -> Array[SuperClass]`
+   - `Dictionary[K, V] -> Dictionary` / `Dictionary[Variant, Variant]`
+   - `Dictionary[K1, V1] -> Dictionary[K2, V2]`（key/value 均可赋值）
 
 ---
 
@@ -189,7 +195,7 @@ $<result_id> = assign $<source_id>
    - 若未来需求出现，建议新增专用指令/Builder API，而不是扩写 `assign`。
 2. **隐式转换矩阵的归属**：
    - `assign` 不负责定义“哪些类型可隐式转换”；
-   - 统一以 `ClassRegistry#checkAssignable(...)` 为准（生成器只触发 fail-fast）。
+   - 统一以 `ClassRegistry#checkAssignable(...)` 为准（包含对象上行与容器协变规则），生成器只做 fail-fast 触发。
 3. **对象 ptrKind 与 helper 匹配**：
    - 生成器必须只用 `valueOfVar(...)` + `assignVar(...)`，避免手写转换导致 helper 不匹配或 NULL 解引用风险。
 4. **回归断言过于脆弱**：
@@ -211,4 +217,3 @@ $<result_id> = assign $<source_id>
 | CBodyBuilder 赋值管道 | `src/main/java/dev/superice/gdcc/backend/c/gen/CBodyBuilder.java` |
 | 参考生成器（Pack/Unpack） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/PackUnpackVariantInsnGen.java` |
 | 参考生成器（NewData） | `src/main/java/dev/superice/gdcc/backend/c/gen/insn/NewDataInsnGen.java` |
-

--- a/doc/module_impl/cbodybuilder_implementation.md
+++ b/doc/module_impl/cbodybuilder_implementation.md
@@ -55,6 +55,19 @@
   - 返回 `ExprValueRef`（表达式值），不可作为赋值目标使用。
   - 用于生成器中的“按目标类型强制转换后参与调用参数”的场景，避免手工拼接 cast 字符串。
 
+### 2.4 赋值可兼容性（`ClassRegistry#checkAssignable`）
+
+- `assignVar` / `assignExpr` / `callAssign` / `returnValue` 的可赋值性检查由 `CBodyBuilder#checkAssignable` 触发，并委托给 `ClassRegistry#checkAssignable`。
+- 基础规则：
+  - 同类型可赋值。
+  - 对象类型允许继承上行转换。
+- 容器协变扩展（全局语义，不限于 CBodyBuilder）：
+  - `Array[T] -> Array`（等价 `Array[Variant]`）允许。
+  - `Array[SubClass] -> Array[SuperClass]` 允许。
+  - `Dictionary[K, V] -> Dictionary`（等价 `Dictionary[Variant, Variant]`）允许。
+  - `Dictionary[K1, V1] -> Dictionary[K2, V2]` 在 key/value 均可赋值时允许。
+  - 除上述规则外，不引入其他容器协变或数值提升。
+
 ## 3. GDCC/Godot 对象指针转换规则（已落地）
 
 ### 3.1 统一约束

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/CCodegen.java
@@ -34,6 +34,7 @@ public class CCodegen implements Codegen {
         registerInsnGen(new LineNumberInsnGen());
         registerInsnGen(new ControlFlowInsnGen());
         registerInsnGen(new NewDataInsnGen());
+        registerInsnGen(new AssignInsnGen());
         registerInsnGen(new LoadPropertyInsnGen());
         registerInsnGen(new StorePropertyInsnGen());
         registerInsnGen(new OwnReleaseObjectInsnGen());

--- a/src/main/java/dev/superice/gdcc/backend/c/gen/insn/AssignInsnGen.java
+++ b/src/main/java/dev/superice/gdcc/backend/c/gen/insn/AssignInsnGen.java
@@ -1,0 +1,37 @@
+package dev.superice.gdcc.backend.c.gen.insn;
+
+import dev.superice.gdcc.backend.c.gen.CBodyBuilder;
+import dev.superice.gdcc.backend.c.gen.CInsnGen;
+import dev.superice.gdcc.enums.GdInstruction;
+import dev.superice.gdcc.lir.insn.AssignInsn;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.EnumSet;
+import java.util.Objects;
+
+public final class AssignInsnGen implements CInsnGen<AssignInsn> {
+    @Override
+    public @NotNull EnumSet<GdInstruction> getInsnOpcodes() {
+        return EnumSet.of(GdInstruction.ASSIGN);
+    }
+
+    @Override
+    public void generateCCode(@NotNull CBodyBuilder bodyBuilder) {
+        var insn = bodyBuilder.getCurrentInsn(this);
+        var resultId = insn.resultId();
+
+        var func = bodyBuilder.func();
+        var resultVar = func.getVariableById(Objects.requireNonNull(resultId));
+        if (resultVar == null) {
+            throw bodyBuilder.invalidInsn("Result variable ID " + resultId + " does not exist");
+        }
+        var sourceVar = func.getVariableById(insn.sourceId());
+        if (sourceVar == null) {
+            throw bodyBuilder.invalidInsn("Source variable ID " + insn.sourceId() + " does not exist");
+        }
+
+        var target = bodyBuilder.targetOfVar(resultVar);
+        bodyBuilder.assignVar(target, bodyBuilder.valueOfVar(sourceVar));
+    }
+}
+

--- a/src/main/java/dev/superice/gdcc/enums/GdInstruction.java
+++ b/src/main/java/dev/superice/gdcc/enums/GdInstruction.java
@@ -67,6 +67,7 @@ public enum GdInstruction {
     STORE_PROPERTY("store_property", ReturnKind.NONE, List.of(OperandKind.STRING, OperandKind.VARIABLE, OperandKind.VARIABLE), 3, 3),
     LOAD_STATIC("load_static", ReturnKind.REQUIRED, List.of(OperandKind.STRING, OperandKind.STRING), 2, 2),
     STORE_STATIC("store_static", ReturnKind.NONE, List.of(OperandKind.STRING, OperandKind.STRING, OperandKind.VARIABLE), 3, 3),
+    ASSIGN("assign", ReturnKind.REQUIRED, List.of(OperandKind.VARIABLE), 1, 1),
 
     // Misc
     NOP("nop", ReturnKind.NONE, List.of(), 0, 0),

--- a/src/main/java/dev/superice/gdcc/lir/insn/AssignInsn.java
+++ b/src/main/java/dev/superice/gdcc/lir/insn/AssignInsn.java
@@ -1,0 +1,20 @@
+package dev.superice.gdcc.lir.insn;
+
+import dev.superice.gdcc.enums.GdInstruction;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public record AssignInsn(@NotNull String resultId, @NotNull String sourceId) implements LoadStoreInstruction {
+
+    @Override
+    public GdInstruction opcode() {
+        return GdInstruction.ASSIGN;
+    }
+
+    @Override
+    public @NotNull List<Operand> operands() {
+        return List.of(new VariableOperand(sourceId));
+    }
+}
+

--- a/src/main/java/dev/superice/gdcc/lir/parser/ParsedLirInstruction.java
+++ b/src/main/java/dev/superice/gdcc/lir/parser/ParsedLirInstruction.java
@@ -181,6 +181,8 @@ public record ParsedLirInstruction(
                         new LoadStaticInsn(resultId, ((StringOperand) operands.getFirst()).value(), ((StringOperand) operands.get(1)).value());
                 case STORE_STATIC ->
                         new StoreStaticInsn(((StringOperand) operands.getFirst()).value(), ((StringOperand) operands.get(1)).value(), ((VariableOperand) operands.get(2)).id());
+                case ASSIGN ->
+                        new AssignInsn(Objects.requireNonNull(resultId), ((VariableOperand) operands.getFirst()).id());
 
                 case NOP -> new NopInsn();
                 case LINE_NUMBER -> new LineNumberInsn(((IntOperand) operands.getFirst()).value());

--- a/src/main/java/dev/superice/gdcc/scope/ClassRegistry.java
+++ b/src/main/java/dev/superice/gdcc/scope/ClassRegistry.java
@@ -42,25 +42,39 @@ public final class ClassRegistry {
     }
 
     /// Check whether a name refers to a builtin class from API.
-    public boolean isBuiltinClass(@NotNull String name) { return builtinByName.containsKey(name); }
+    public boolean isBuiltinClass(@NotNull String name) {
+        return builtinByName.containsKey(name);
+    }
 
     /// Return a builtin class definition by name if present.
-    public @Nullable ExtensionBuiltinClass findBuiltinClass(@NotNull String name) { return builtinByName.get(name); }
+    public @Nullable ExtensionBuiltinClass findBuiltinClass(@NotNull String name) {
+        return builtinByName.get(name);
+    }
 
     /// Check whether a name refers to a GdClass (script-exposed Godot class from API).
-    public boolean isGdClass(@NotNull String name) { return gdClassByName.containsKey(name); }
+    public boolean isGdClass(@NotNull String name) {
+        return gdClassByName.containsKey(name);
+    }
 
     /// Check whether a name refers to a global utility function.
-    public boolean isUtilityFunction(@NotNull String name) { return utilityByName.containsKey(name); }
+    public boolean isUtilityFunction(@NotNull String name) {
+        return utilityByName.containsKey(name);
+    }
 
     /// Check whether a name refers to a global enum.
-    public boolean isGlobalEnum(@NotNull String name) { return globalEnumByName.containsKey(name); }
+    public boolean isGlobalEnum(@NotNull String name) {
+        return globalEnumByName.containsKey(name);
+    }
 
     /// Check whether a name refers to a singleton.
-    public boolean isSingleton(@NotNull String name) { return singletonByName.containsKey(name); }
+    public boolean isSingleton(@NotNull String name) {
+        return singletonByName.containsKey(name);
+    }
 
     /// Check whether a name refers to a user-defined gdcc class.
-    public boolean isGdccClass(@NotNull String name) { return gdccClassByName.containsKey(name); }
+    public boolean isGdccClass(@NotNull String name) {
+        return gdccClassByName.containsKey(name);
+    }
 
     public boolean isContainerClass(@NotNull String name) {
         return name.equals("Array") || name.equals("Dictionary") || name.startsWith("Array[") || name.startsWith("Dictionary[");
@@ -127,47 +141,90 @@ public final class ClassRegistry {
         var t = typeName.trim();
         if (t.isEmpty()) return null;
         switch (t) {
-            case "AABB": return GdAABBType.AABB;
-            case "Array": return new GdArrayType(GdVariantType.VARIANT);
-            case "Basis": return GdBasisType.BASIS;
-            case "bool": return GdBoolType.BOOL;
-            case "Callable": return new GdCallableType();
-            case "Color": return GdColorType.COLOR;
-            case "Dictionary": return new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT);
-            case "float": return GdFloatType.FLOAT;
-            case "Vector2": return GdFloatVectorType.VECTOR2;
-            case "Vector2i": return GdIntVectorType.VECTOR2I;
-            case "Vector3": return GdFloatVectorType.VECTOR3;
-            case "Vector3i": return GdIntVectorType.VECTOR3I;
-            case "Vector4": return GdFloatVectorType.VECTOR4;
-            case "Vector4i": return GdIntVectorType.VECTOR4I;
-            case "int": return GdIntType.INT;
-            case "Nil": case "null": return GdNilType.NIL;
-            case "NodePath": return GdNodePathType.NODE_PATH;
-            case "Object": return GdObjectType.OBJECT;
-            case "PackedByteArray": return GdPackedNumericArrayType.PACKED_BYTE_ARRAY;
-            case "PackedInt32Array": return GdPackedNumericArrayType.PACKED_INT32_ARRAY;
-            case "PackedInt64Array": return GdPackedNumericArrayType.PACKED_INT64_ARRAY;
-            case "PackedFloat32Array": return GdPackedNumericArrayType.PACKED_FLOAT32_ARRAY;
-            case "PackedFloat64Array": return GdPackedNumericArrayType.PACKED_FLOAT64_ARRAY;
-            case "PackedStringArray": return GdPackedStringArrayType.PACKED_STRING_ARRAY;
-            case "PackedVector2Array": return GdPackedVectorArrayType.PACKED_VECTOR2_ARRAY;
-            case "PackedVector3Array": return GdPackedVectorArrayType.PACKED_VECTOR3_ARRAY;
-            case "PackedVector4Array": return GdPackedVectorArrayType.PACKED_VECTOR4_ARRAY;
-            case "PackedColorArray": return GdPackedVectorArrayType.PACKED_COLOR_ARRAY;
-            case "Plane": return GdPlaneType.PLANE;
-            case "Projection": return GdProjectionType.PROJECTION;
-            case "Quaternion": return GdQuaternionType.QUATERNION;
-            case "Rect2": return GdRect2Type.RECT2;
-            case "Rect2i": return GdRect2iType.RECT2I;
-            case "RID": return GdRidType.RID;
-            case "Signal": return new GdSignalType();
-            case "String": return GdStringType.STRING;
-            case "StringName": return GdStringNameType.STRING_NAME;
-            case "Transform2D": return GdTransform2DType.TRANSFORM2D;
-            case "Transform3D": return GdTransform3DType.TRANSFORM3D;
-            case "void": case "Void": return GdVoidType.VOID;
-            case "Variant": return GdVariantType.VARIANT;
+            case "AABB":
+                return GdAABBType.AABB;
+            case "Array":
+                return new GdArrayType(GdVariantType.VARIANT);
+            case "Basis":
+                return GdBasisType.BASIS;
+            case "bool":
+                return GdBoolType.BOOL;
+            case "Callable":
+                return new GdCallableType();
+            case "Color":
+                return GdColorType.COLOR;
+            case "Dictionary":
+                return new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT);
+            case "float":
+                return GdFloatType.FLOAT;
+            case "Vector2":
+                return GdFloatVectorType.VECTOR2;
+            case "Vector2i":
+                return GdIntVectorType.VECTOR2I;
+            case "Vector3":
+                return GdFloatVectorType.VECTOR3;
+            case "Vector3i":
+                return GdIntVectorType.VECTOR3I;
+            case "Vector4":
+                return GdFloatVectorType.VECTOR4;
+            case "Vector4i":
+                return GdIntVectorType.VECTOR4I;
+            case "int":
+                return GdIntType.INT;
+            case "Nil":
+            case "null":
+                return GdNilType.NIL;
+            case "NodePath":
+                return GdNodePathType.NODE_PATH;
+            case "Object":
+                return GdObjectType.OBJECT;
+            case "PackedByteArray":
+                return GdPackedNumericArrayType.PACKED_BYTE_ARRAY;
+            case "PackedInt32Array":
+                return GdPackedNumericArrayType.PACKED_INT32_ARRAY;
+            case "PackedInt64Array":
+                return GdPackedNumericArrayType.PACKED_INT64_ARRAY;
+            case "PackedFloat32Array":
+                return GdPackedNumericArrayType.PACKED_FLOAT32_ARRAY;
+            case "PackedFloat64Array":
+                return GdPackedNumericArrayType.PACKED_FLOAT64_ARRAY;
+            case "PackedStringArray":
+                return GdPackedStringArrayType.PACKED_STRING_ARRAY;
+            case "PackedVector2Array":
+                return GdPackedVectorArrayType.PACKED_VECTOR2_ARRAY;
+            case "PackedVector3Array":
+                return GdPackedVectorArrayType.PACKED_VECTOR3_ARRAY;
+            case "PackedVector4Array":
+                return GdPackedVectorArrayType.PACKED_VECTOR4_ARRAY;
+            case "PackedColorArray":
+                return GdPackedVectorArrayType.PACKED_COLOR_ARRAY;
+            case "Plane":
+                return GdPlaneType.PLANE;
+            case "Projection":
+                return GdProjectionType.PROJECTION;
+            case "Quaternion":
+                return GdQuaternionType.QUATERNION;
+            case "Rect2":
+                return GdRect2Type.RECT2;
+            case "Rect2i":
+                return GdRect2iType.RECT2I;
+            case "RID":
+                return GdRidType.RID;
+            case "Signal":
+                return new GdSignalType();
+            case "String":
+                return GdStringType.STRING;
+            case "StringName":
+                return GdStringNameType.STRING_NAME;
+            case "Transform2D":
+                return GdTransform2DType.TRANSFORM2D;
+            case "Transform3D":
+                return GdTransform3DType.TRANSFORM3D;
+            case "void":
+            case "Void":
+                return GdVoidType.VOID;
+            case "Variant":
+                return GdVariantType.VARIANT;
         }
 
         // Generic forms: Array[T], Dictionary[K, V]
@@ -262,10 +319,35 @@ public final class ClassRegistry {
         return classDef;
     }
 
+    /// Global assignability rules used across backend validation/codegen:
+    /// - same type
+    /// - object inheritance upcast
+    /// - limited container covariance for Array/Dictionary
     public boolean checkAssignable(@NotNull GdType from, @NotNull GdType to) {
         if (from.getTypeName().equals(to.getTypeName())) {
             return true;
         }
+        if (from instanceof GdArrayType fromArray && to instanceof GdArrayType toArray) {
+            return checkContainerCovariantAssignable(fromArray.getValueType(), toArray.getValueType());
+        }
+        if (from instanceof GdDictionaryType fromDictionary && to instanceof GdDictionaryType toDictionary) {
+            return checkContainerCovariantAssignable(fromDictionary.getKeyType(), toDictionary.getKeyType()) &&
+                    checkContainerCovariantAssignable(fromDictionary.getValueType(), toDictionary.getValueType());
+        }
+        return checkObjectAssignable(from, to);
+    }
+
+    /// Container covariance:
+    /// - target `Variant` accepts any source element/key/value type.
+    /// - otherwise delegate to the general assignability rules recursively.
+    private boolean checkContainerCovariantAssignable(@NotNull GdType fromType, @NotNull GdType toType) {
+        if (toType instanceof GdVariantType) {
+            return true;
+        }
+        return checkAssignable(fromType, toType);
+    }
+
+    private boolean checkObjectAssignable(@NotNull GdType from, @NotNull GdType to) {
         if (!(from instanceof GdObjectType(var fromClassName)) || !(to instanceof GdObjectType(var toClassName))) {
             return false;
         }

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CAssignInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CAssignInsnGenTest.java
@@ -13,9 +13,14 @@ import dev.superice.gdcc.lir.LirModule;
 import dev.superice.gdcc.lir.insn.AssignInsn;
 import dev.superice.gdcc.lir.insn.ReturnInsn;
 import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdFloatType;
 import dev.superice.gdcc.type.GdIntType;
 import dev.superice.gdcc.type.GdObjectType;
 import dev.superice.gdcc.type.GdStringType;
+import dev.superice.gdcc.type.GdStringNameType;
+import dev.superice.gdcc.type.GdVariantType;
 import dev.superice.gdcc.type.GdVoidType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -130,6 +135,210 @@ public class CAssignInsnGenTest {
         assertInstanceOf(InvalidInsnException.class, ex);
     }
 
+    @Test
+    @DisplayName("assign should fail-fast when target variable is ref")
+    void assignShouldFailWhenTargetIsRefVariable() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_ref_target");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddRefVariable("a", GdIntType.INT);
+        func.createAndAddVariable("b", GdIntType.INT);
+        addEntryAssignAndReturn(func, new AssignInsn("a", "b"));
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var ex = assertThrows(InvalidInsnException.class, () -> codegen.generateFuncBody(workerClass, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+        assertTrue(ex.getMessage().contains("Cannot assign to reference variable"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("assign GDCC object to engine object should convert pointer kind")
+    void assignGdccObjectToEngineObjectShouldConvertPointerKind() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var gdccNodeClass = new LirClassDef("MyGdccNode", "Node", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_gdcc_to_engine");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dst", new GdObjectType("Node"));
+        func.createAndAddVariable("src", new GdObjectType("MyGdccNode"));
+        addEntryAssignAndReturn(func, new AssignInsn("dst", "src"));
+        workerClass.addFunction(func);
+
+        var nodeClass = new ExtensionGdClass(
+                "Node", false, true, "Object", "core",
+                List.of(), List.of(), List.of(), List.of(), List.of()
+        );
+        var api = new ExtensionAPI(
+                null, List.of(), List.of(), List.of(), List.of(), List.of(),
+                List.of(nodeClass), List.of(), List.of()
+        );
+        var module = new LirModule("test_module", List.of(workerClass, gdccNodeClass));
+        var codegen = newCodegen(module, api, List.of(workerClass, gdccNodeClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("gdcc_object_to_godot_object_ptr($src, MyGdccNode_object_ptr)"), body);
+        assertTrue(body.contains("$dst = gdcc_object_to_godot_object_ptr($src, MyGdccNode_object_ptr);"), body);
+    }
+
+    @Test
+    @DisplayName("assign unknown object should use try_own_object and try_release_object")
+    void assignUnknownObjectShouldUseTryOwnRelease() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_unknown_object");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dst", new GdObjectType("UnknownObject"));
+        func.createAndAddVariable("src", new GdObjectType("UnknownObject"));
+        addEntryAssignAndReturn(func, new AssignInsn("dst", "src"));
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("try_own_object($dst);"), body);
+        assertTrue(body.contains("try_release_object(__gdcc_tmp_old_obj_"), body);
+        assertFalse(body.contains("\nown_object($dst);\n"), body);
+        assertFalse(body.contains("\nrelease_object(__gdcc_tmp_old_obj_"), body);
+    }
+
+    @Test
+    @DisplayName("assign should allow Array[T] to Array[Variant] covariance")
+    void assignShouldAllowArrayToVariantArrayCovariance() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_array_to_variant_array");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dst", new GdArrayType(GdVariantType.VARIANT));
+        func.createAndAddVariable("src", new GdArrayType(GdIntType.INT));
+        addEntryAssignAndReturn(func, new AssignInsn("dst", "src"));
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("godot_new_Array_with_Array(&$src);"), body);
+        assertTrue(body.contains("$dst = __gdcc_tmp_array_"), body);
+    }
+
+    @Test
+    @DisplayName("assign should allow Array[SubClass] to Array[SuperClass] covariance")
+    void assignShouldAllowArrayObjectCovariance() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_array_object_covariance");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dst", new GdArrayType(new GdObjectType("Node")));
+        func.createAndAddVariable("src", new GdArrayType(new GdObjectType("Node3D")));
+        addEntryAssignAndReturn(func, new AssignInsn("dst", "src"));
+        workerClass.addFunction(func);
+
+        var nodeClass = new ExtensionGdClass(
+                "Node", false, true, "Object", "core",
+                List.of(), List.of(), List.of(), List.of(), List.of()
+        );
+        var node3dClass = new ExtensionGdClass(
+                "Node3D", false, true, "Node", "core",
+                List.of(), List.of(), List.of(), List.of(), List.of()
+        );
+        var api = new ExtensionAPI(
+                null, List.of(), List.of(), List.of(), List.of(), List.of(),
+                List.of(nodeClass, node3dClass), List.of(), List.of()
+        );
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, api, List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("godot_new_Array_with_Array(&$src);"), body);
+        assertTrue(body.contains("$dst = __gdcc_tmp_array_"), body);
+    }
+
+    @Test
+    @DisplayName("assign should still reject non-covariant Array element mismatch")
+    void assignShouldRejectNonCovariantArrayElementMismatch() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_array_mismatch");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dst", new GdArrayType(GdFloatType.FLOAT));
+        func.createAndAddVariable("src", new GdArrayType(GdIntType.INT));
+        addEntryAssignAndReturn(func, new AssignInsn("dst", "src"));
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var ex = assertThrows(InvalidInsnException.class, () -> codegen.generateFuncBody(workerClass, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+    }
+
+    @Test
+    @DisplayName("assign should allow Dictionary[K, V] to Dictionary[Variant, Variant] covariance")
+    void assignShouldAllowDictionaryToVariantDictionaryCovariance() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_dictionary_to_variant_dictionary");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dst", new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT));
+        func.createAndAddVariable("src", new GdDictionaryType(GdStringNameType.STRING_NAME, GdIntType.INT));
+        addEntryAssignAndReturn(func, new AssignInsn("dst", "src"));
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("godot_new_Dictionary_with_Dictionary(&$src);"), body);
+        assertTrue(body.contains("$dst = __gdcc_tmp_dictionary_"), body);
+    }
+
+    @Test
+    @DisplayName("assign should allow Dictionary value object covariance")
+    void assignShouldAllowDictionaryObjectValueCovariance() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_dictionary_object_covariance");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dst", new GdDictionaryType(GdStringNameType.STRING_NAME, new GdObjectType("Node")));
+        func.createAndAddVariable("src", new GdDictionaryType(GdStringNameType.STRING_NAME, new GdObjectType("Node3D")));
+        addEntryAssignAndReturn(func, new AssignInsn("dst", "src"));
+        workerClass.addFunction(func);
+
+        var nodeClass = new ExtensionGdClass(
+                "Node", false, true, "Object", "core",
+                List.of(), List.of(), List.of(), List.of(), List.of()
+        );
+        var node3dClass = new ExtensionGdClass(
+                "Node3D", false, true, "Node", "core",
+                List.of(), List.of(), List.of(), List.of(), List.of()
+        );
+        var api = new ExtensionAPI(
+                null, List.of(), List.of(), List.of(), List.of(), List.of(),
+                List.of(nodeClass, node3dClass), List.of(), List.of()
+        );
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, api, List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("godot_new_Dictionary_with_Dictionary(&$src);"), body);
+        assertTrue(body.contains("$dst = __gdcc_tmp_dictionary_"), body);
+    }
+
+    @Test
+    @DisplayName("assign should still reject non-covariant Dictionary key/value mismatch")
+    void assignShouldRejectNonCovariantDictionaryMismatch() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_dictionary_mismatch");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dst", new GdDictionaryType(GdStringType.STRING, GdFloatType.FLOAT));
+        func.createAndAddVariable("src", new GdDictionaryType(GdIntType.INT, GdIntType.INT));
+        addEntryAssignAndReturn(func, new AssignInsn("dst", "src"));
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var ex = assertThrows(InvalidInsnException.class, () -> codegen.generateFuncBody(workerClass, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+    }
+
     private void addEntryAssignAndReturn(LirFunctionDef func, AssignInsn assignInsn) {
         var entry = new LirBasicBlock("entry");
         entry.instructions().add(assignInsn);
@@ -155,4 +364,3 @@ public class CAssignInsnGenTest {
         return codegen;
     }
 }
-

--- a/src/test/java/dev/superice/gdcc/backend/c/gen/CAssignInsnGenTest.java
+++ b/src/test/java/dev/superice/gdcc/backend/c/gen/CAssignInsnGenTest.java
@@ -1,0 +1,158 @@
+package dev.superice.gdcc.backend.c.gen;
+
+import dev.superice.gdcc.backend.CodegenContext;
+import dev.superice.gdcc.backend.ProjectInfo;
+import dev.superice.gdcc.enums.GodotVersion;
+import dev.superice.gdcc.exception.InvalidInsnException;
+import dev.superice.gdcc.gdextension.ExtensionAPI;
+import dev.superice.gdcc.gdextension.ExtensionGdClass;
+import dev.superice.gdcc.lir.LirBasicBlock;
+import dev.superice.gdcc.lir.LirClassDef;
+import dev.superice.gdcc.lir.LirFunctionDef;
+import dev.superice.gdcc.lir.LirModule;
+import dev.superice.gdcc.lir.insn.AssignInsn;
+import dev.superice.gdcc.lir.insn.ReturnInsn;
+import dev.superice.gdcc.scope.ClassRegistry;
+import dev.superice.gdcc.type.GdIntType;
+import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdStringType;
+import dev.superice.gdcc.type.GdVoidType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CAssignInsnGenTest {
+    @Test
+    @DisplayName("assign int should generate direct assignment")
+    void assignIntShouldGenerateDirectAssignment() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_int");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("a", GdIntType.INT);
+        func.createAndAddVariable("b", GdIntType.INT);
+        addEntryAssignAndReturn(func, new AssignInsn("a", "b"));
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("$a = $b;"), body);
+    }
+
+    @Test
+    @DisplayName("assign String should copy rhs and destroy old target value")
+    void assignStringShouldCopyAndDestroyOldValue() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_string");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("a", GdStringType.STRING);
+        func.createAndAddVariable("b", GdStringType.STRING);
+        addEntryAssignAndReturn(func, new AssignInsn("a", "b"));
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("godot_String_destroy(&$a);"), body);
+        assertTrue(body.contains("godot_new_String_with_String(&$b);"), body);
+        assertTrue(body.contains("$a = __gdcc_tmp_string_"), body);
+    }
+
+    @Test
+    @DisplayName("assign RefCounted object should follow capture-assign-own-release order")
+    void assignRefCountedObjectShouldFollowObjectSlotWriteSemantics() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_object");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("dst", new GdObjectType("RefCounted"));
+        func.createAndAddVariable("src", new GdObjectType("RefCounted"));
+        addEntryAssignAndReturn(func, new AssignInsn("dst", "src"));
+        workerClass.addFunction(func);
+
+        var refCountedClass = new ExtensionGdClass(
+                "RefCounted", true, true, "Object", "core",
+                List.of(), List.of(), List.of(), List.of(), List.of()
+        );
+        var api = new ExtensionAPI(
+                null, List.of(), List.of(), List.of(), List.of(), List.of(),
+                List.of(refCountedClass), List.of(), List.of()
+        );
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, api, List.of(workerClass));
+
+        var body = codegen.generateFuncBody(workerClass, func);
+        assertTrue(body.contains("__gdcc_tmp_old_obj_"), body);
+        assertTrue(body.contains(" = $dst;"), body);
+        assertTrue(body.contains("$dst = $src;"), body);
+        assertTrue(body.contains("own_object($dst);"), body);
+        assertTrue(body.contains("release_object(__gdcc_tmp_old_obj_"), body);
+        assertFalse(body.contains("try_own_object($dst);"), body);
+        assertFalse(body.contains("try_release_object(__gdcc_tmp_old_obj_"), body);
+
+        var captureIndex = body.indexOf(" = $dst;");
+        var assignIndex = body.indexOf("$dst = $src;");
+        var ownIndex = body.indexOf("own_object($dst);");
+        var releaseIndex = body.indexOf("release_object(__gdcc_tmp_old_obj_");
+        assertTrue(captureIndex >= 0, body);
+        assertTrue(assignIndex >= 0, body);
+        assertTrue(ownIndex >= 0, body);
+        assertTrue(releaseIndex >= 0, body);
+        assertTrue(captureIndex < assignIndex, body);
+        assertTrue(assignIndex < ownIndex, body);
+        assertTrue(ownIndex < releaseIndex, body);
+    }
+
+    @Test
+    @DisplayName("assign should fail-fast when source type is not assignable to target type")
+    void assignShouldFailWhenTypesAreNotAssignable() {
+        var workerClass = new LirClassDef("Worker", "RefCounted", false, false, Map.of(), List.of(), List.of(), List.of());
+        var func = new LirFunctionDef("assign_mismatch");
+        func.setReturnType(GdVoidType.VOID);
+        func.createAndAddVariable("a", GdIntType.INT);
+        func.createAndAddVariable("b", GdStringType.STRING);
+        addEntryAssignAndReturn(func, new AssignInsn("a", "b"));
+        workerClass.addFunction(func);
+
+        var module = new LirModule("test_module", List.of(workerClass));
+        var codegen = newCodegen(module, emptyApi(), List.of(workerClass));
+
+        var ex = assertThrows(InvalidInsnException.class, () -> codegen.generateFuncBody(workerClass, func));
+        assertInstanceOf(InvalidInsnException.class, ex);
+    }
+
+    private void addEntryAssignAndReturn(LirFunctionDef func, AssignInsn assignInsn) {
+        var entry = new LirBasicBlock("entry");
+        entry.instructions().add(assignInsn);
+        entry.instructions().add(new ReturnInsn(null));
+        func.addBasicBlock(entry);
+        func.setEntryBlockId("entry");
+    }
+
+    private ExtensionAPI emptyApi() {
+        return new ExtensionAPI(null, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
+    }
+
+    private CCodegen newCodegen(LirModule module, ExtensionAPI api, List<LirClassDef> gdccClasses) {
+        var classRegistry = new ClassRegistry(api);
+        for (var gdccClass : gdccClasses) {
+            classRegistry.addGdccClass(gdccClass);
+        }
+        ProjectInfo projectInfo = new ProjectInfo("TestProject", GodotVersion.V451, Path.of(".")) {
+        };
+        var ctx = new CodegenContext(projectInfo, classRegistry);
+        var codegen = new CCodegen();
+        codegen.prepare(ctx, module);
+        return codegen;
+    }
+}
+

--- a/src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnParserTest.java
+++ b/src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnParserTest.java
@@ -128,6 +128,17 @@ public class SimpleLirBlockInsnParserTest {
         assertEquals("value", setInsn.valueId());
     }
 
+    @Test
+    public void parse_assignInstruction() {
+        var input = "$a = assign $b;";
+        var insns = parse(input);
+        assertEquals(1, insns.size());
+
+        var assignInsn = assertInstanceOf(AssignInsn.class, insns.getFirst());
+        assertEquals("a", assignInsn.resultId());
+        assertEquals("b", assignInsn.sourceId());
+    }
+
     @SuppressWarnings("TrailingWhitespacesInTextBlock")
     @Test
     public void parse_whitespaceVariants() {

--- a/src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnSerializerTest.java
+++ b/src/test/java/dev/superice/gdcc/lir/parser/SimpleLirBlockInsnSerializerTest.java
@@ -89,4 +89,16 @@ public class SimpleLirBlockInsnSerializerTest {
         assertTrue(out.contains("$result = variant_get_named $obj $name;"), out);
         assertTrue(out.contains("variant_set_named $obj $name $value;"), out);
     }
+
+    @Test
+    public void serialize_assignInstruction() throws Exception {
+        var insnList = List.<LirInstruction>of(new AssignInsn("a", "b"));
+
+        var serializer = new SimpleLirBlockInsnSerializer();
+        var sw = new StringWriter();
+        serializer.serialize(insnList, sw);
+        var out = sw.toString();
+
+        assertTrue(out.contains("$a = assign $b;"), out);
+    }
 }

--- a/src/test/java/dev/superice/gdcc/scope/ClassRegistryTest.java
+++ b/src/test/java/dev/superice/gdcc/scope/ClassRegistryTest.java
@@ -1,7 +1,14 @@
 package dev.superice.gdcc.scope;
 
 import dev.superice.gdcc.gdextension.ExtensionApiLoader;
+import dev.superice.gdcc.type.GdArrayType;
+import dev.superice.gdcc.type.GdDictionaryType;
+import dev.superice.gdcc.type.GdFloatType;
+import dev.superice.gdcc.type.GdIntType;
 import dev.superice.gdcc.type.GdObjectType;
+import dev.superice.gdcc.type.GdStringNameType;
+import dev.superice.gdcc.type.GdStringType;
+import dev.superice.gdcc.type.GdVariantType;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -26,7 +33,7 @@ public class ClassRegistryTest {
         // builtin types should resolve to concrete GdType singletons, but some names may resolve to GdObjectType as engine classes
         if (t instanceof GdObjectType) {
             assertInstanceOf(GdObjectType.class, t);
-            assertTrue(((GdObjectType)t).checkEngineType(registry));
+            assertTrue(((GdObjectType) t).checkEngineType(registry));
         }
 
         // Check a known gd class exists (take first class from API)
@@ -37,7 +44,7 @@ public class ClassRegistryTest {
         assertNotNull(tg, () -> "GdClass type for " + someGd.name() + " should be resolvable");
         assertEquals(someGd.name(), tg.getTypeName());
         assertInstanceOf(GdObjectType.class, tg);
-        assertTrue(((GdObjectType)tg).checkEngineType(registry));
+        assertTrue(((GdObjectType) tg).checkEngineType(registry));
 
         // Utility function signature (if present)
         if (!api.utilityFunctions().isEmpty()) {
@@ -131,6 +138,44 @@ public class ClassRegistryTest {
         for (var expectName : expectSet) {
             assertTrue(vMethodMap.containsKey(expectName), () -> "Expected virtual method not found: " + expectName);
         }
+    }
+
+    @Test
+    void checkAssignableSupportsContainerCovariance() throws IOException {
+        var registry = new ClassRegistry(ExtensionApiLoader.loadDefault());
+        assertTrue(registry.checkAssignable(
+                new GdArrayType(GdIntType.INT),
+                new GdArrayType(GdVariantType.VARIANT)
+        ));
+        assertTrue(registry.checkAssignable(
+                new GdArrayType(new GdObjectType("Node3D")),
+                new GdArrayType(new GdObjectType("Node"))
+        ));
+        assertTrue(registry.checkAssignable(
+                new GdDictionaryType(GdStringNameType.STRING_NAME, GdIntType.INT),
+                new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT)
+        ));
+        assertTrue(registry.checkAssignable(
+                new GdDictionaryType(GdStringNameType.STRING_NAME, new GdObjectType("Node3D")),
+                new GdDictionaryType(GdStringNameType.STRING_NAME, new GdObjectType("Node"))
+        ));
+    }
+
+    @Test
+    void checkAssignableRejectsNonCovariantContainerMismatch() throws IOException {
+        var registry = new ClassRegistry(ExtensionApiLoader.loadDefault());
+        assertFalse(registry.checkAssignable(
+                new GdArrayType(GdIntType.INT),
+                new GdArrayType(GdFloatType.FLOAT)
+        ));
+        assertFalse(registry.checkAssignable(
+                new GdDictionaryType(GdIntType.INT, GdIntType.INT),
+                new GdDictionaryType(GdStringType.STRING, GdIntType.INT)
+        ));
+        assertFalse(registry.checkAssignable(
+                new GdDictionaryType(GdStringNameType.STRING_NAME, GdFloatType.FLOAT),
+                new GdDictionaryType(GdStringNameType.STRING_NAME, GdIntType.INT)
+        ));
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR completes the `assign` Low IR pipeline and aligns assignability semantics across parser/model/backend/docs.

## What changed
- Added Low IR `assign` opcode and concrete instruction model:
  - `GdInstruction.ASSIGN`
  - `AssignInsn`
  - `ParsedLirInstruction` concrete mapping
  - parser/serializer test coverage for `assign`
- Added C backend instruction generation:
  - new `AssignInsnGen`
  - registered in `CCodegen`
  - assignment path reuses `CBodyBuilder.assignVar(...)` for lifecycle/ownership/pointer conversion
- Promoted assignability rules to global `ClassRegistry#checkAssignable(...)`:
  - object inheritance upcast
  - container covariance for `Array` and `Dictionary`
- Synced docs to the implemented semantics:
  - `doc/gdcc_low_ir.md`
  - `doc/gdcc_type_system.md`
  - `doc/gdcc_c_backend.md`
  - `doc/module_impl/cbodybuilder_implementation.md`
  - `doc/module_impl/assign_insn_implementation.md`
- Added key tests:
  - `CAssignInsnGenTest` (assign flow, ref target fail-fast, ptr conversion, object own/release path, array/dictionary covariance)
  - `ClassRegistryTest` (global container covariance rules)

## Why
- Close the `assign` implementation gap end-to-end.
- Avoid semantic drift by using one global assignability source (`ClassRegistry`) instead of backend-local special cases.

## Affected packages
- `dev.superice.gdcc.enums`
- `dev.superice.gdcc.lir.insn`
- `dev.superice.gdcc.lir.parser`
- `dev.superice.gdcc.backend.c.gen`
- `dev.superice.gdcc.backend.c.gen.insn`
- `dev.superice.gdcc.scope`

## Tests run
- `./gradlew.bat test --tests SimpleLirBlockInsnParserTest --tests SimpleLirBlockInsnSerializerTest --no-daemon --info --console=plain`
- `./gradlew.bat test --tests CAssignInsnGenTest --no-daemon --info --console=plain`
- `./gradlew.bat test --tests ClassRegistryTest --no-daemon --info --console=plain`
- `./gradlew.bat test --tests CBodyBuilderPhaseCTest --no-daemon --info --console=plain`
- `./gradlew.bat test --tests CallGlobalInsnGenTest --tests CLoadPropertyInsnGenTest --tests CStorePropertyInsnGenTest --no-daemon --info --console=plain`
- `./gradlew.bat classes --no-daemon --info --console=plain`

All commands completed successfully.
