### PR TITLE
fix(frontend): align dictionary subscript keys with shared variant boundary

### DIFF
--- a/doc/module_impl/frontend/frontend_chain_binding_expr_type_implementation.md
+++ b/doc/module_impl/frontend/frontend_chain_binding_expr_type_implementation.md
@@ -5,7 +5,7 @@
 ## 文档状态
 
 - 状态：事实源维护中（`resolvedMembers()` / `resolvedCalls()` / `expressionTypes()`、shared expression semantic support、unary/binary expression semantics、class property initializer support island、subscript / assignment typed contract、`:=` 最小回填与 expr-owned diagnostics 已落地）
-- 更新时间：2026-04-14
+- 更新时间：2026-04-21
 - 适用范围：
   - `src/main/java/dev/superice/gdcc/frontend/sema/**`
   - `src/main/java/dev/superice/gdcc/frontend/sema/analyzer/**`
@@ -370,7 +370,9 @@
 稳定规则为：
 
 - receiver 为上述 `GdContainerType`
-  - 使用 `ClassRegistry.checkAssignable(...)` 做 strict key/index 校验
+  - key/index compatibility 统一复用 `FrontendVariantBoundaryCompatibility`
+  - 因此 plain `Dictionary`（`Dictionary[Variant, Variant]`）现在接受 stable key 写入 `Variant` key slot
+  - 但不额外支持 Godot keyed/index widened conversion，例如 `String` / `StringName` 互通或 float index
   - 成功后发布 element/value type
 - receiver 为 `Variant`
   - 发布 `DYNAMIC(Variant)`

--- a/doc/module_impl/frontend/frontend_implicit_conversion_matrix.md
+++ b/doc/module_impl/frontend/frontend_implicit_conversion_matrix.md
@@ -5,7 +5,7 @@
 ## 文档状态
 
 - 状态：事实源维护中（Godot 规则已梳理，GDCC 当前支持面已对齐到现有实现）
-- 更新时间：2026-04-14
+- 更新时间：2026-04-21
 - 适用范围：
   - `doc/module_impl/frontend/**`
   - `src/main/java/dev/superice/gdcc/frontend/**`
@@ -262,13 +262,19 @@ Godot strict implicit conversion 表里没有 `Dictionary` 到其他 builtin con
 - same type
 - `Variant` boundary
 
-### 6.3 subscript key/index 的额外 Godot 兼容
+### 6.3 subscript key/index 的 frontend 基线与剩余 Godot widened conversion
 
-这些不是 `Variant::can_convert_strict(...)` 的 generic assignment rule，而是 Godot keyed/index 路径上的更宽兼容；当前 GDCC frontend 也仍未支持：
+当前 GDCC subscript key/index 已复用 ordinary typed-boundary helper `FrontendVariantBoundaryCompatibility`。这意味着：
+
+- same type / object hierarchy / recursive container assignability 继续按 shared frontend boundary 处理
+- ordinary `Variant` boundary 也已经适用于 subscript key/index
+- 因此 plain `Dictionary`（`Dictionary[Variant, Variant]`）现在接受 `String` 等 stable key 写入 `Variant` key slot；对应 keyed lowering / backend codegen 会继续把 key 物化到真实 `Variant` 调用面
+
+当前仍未支持的，是 Godot keyed/index 路径上的额外 widened compatibility：
 
 | 场景 | Godot | GDCC | 备注 |
 | --- | --- | --- | --- |
-| `String` key 用于 `StringName` keyed access | Y | N | 当前 `FrontendSubscriptSemanticSupport` 仍直接回退 `ClassRegistry.checkAssignable(...)` |
+| `String` key 用于 `StringName` keyed access | Y | N | GDCC subscript 当前只复用 ordinary boundary helper，不单独追加 keyed widened conversion |
 | `float` index 用于 `Array` / packed array | Y | N | 本质上依赖 `float -> int` 兼容 |
 
 ---
@@ -335,6 +341,10 @@ Godot strict implicit conversion 表里没有 `Dictionary` 到其他 builtin con
 - `FrontendExpressionSemanticSupport.matchesCallableArguments(...)`
   - call-site fixed argument compatibility gate
   - 只能复用 shared helper，不得在 call path 单独放宽 conversion
+- `FrontendSubscriptSemanticSupport.resolveSubscriptType(...)`
+  - subscript key/index 的 public semantic gate
+  - 只能复用 `FrontendVariantBoundaryCompatibility` 提供的 ordinary boundary compatibility
+  - 不得在 subscript path 单独追加 keyed/index widened conversion
 - `FrontendTypeCheckAnalyzer`
   - 只消费已发布稳定类型事实，并通过 shared helper 执行 typed gate
   - 不得在 type-check phase 私自添加平行 conversion 规则

--- a/doc/module_impl/frontend/frontend_rules.md
+++ b/doc/module_impl/frontend/frontend_rules.md
@@ -58,7 +58,7 @@
 - class constant 的收集、注册、继承可见性与绑定不在 MVP 范围内，整体延后到 MVP 之后再实施。
 - callable scope / block scope 中手动声明或发布的类型别名不在 MVP 范围内；frontend body phase 必须对这类 scope-local `type-meta` 采用 fail-closed 的 deferred / unsupported 处理，而不是把它们当成普通 class-like `TYPE_META` 消费。
 - H1 subscript MVP 只正式支持 container family 的最小 typed contract：`Array[T]`、`Dictionary[K, V]`、packed array family。
-- 上述 container-family subscript 当前故意复用 `ClassRegistry.checkAssignable(...)` 做 key/index 校验；MVP 不追求复刻 Godot 更宽的 keyed/index 兼容规则，例如 `String` / `StringName` 互通、`int -> float`、以及 `Array` / packed array 的 float index 兼容。
+- 上述 container-family subscript 当前统一复用 `FrontendVariantBoundaryCompatibility` 做 key/index typed-boundary 校验；因此 plain `Dictionary`（`Dictionary[Variant, Variant]`）已接受 `String` 等 stable key 写入 `Variant` key slot。MVP 仍不追求复刻 Godot 更宽的 keyed/index 兼容规则，例如 `String` / `StringName` 互通、`int -> float`、以及 `Array` / packed array 的 float index 兼容。
 - builtin instance property access 与 builtin keyed access 必须继续严格区分：`vector.x`、`Color(...).r`、`Basis.IDENTITY.x` 当前属于 compile-ready ordinary property route；`vector["x"]` 仍保持 unsupported。
 - builtin keyed access 即使在 extension metadata 中声明了 `isKeyed`，当前也不属于 MVP 支持面；frontend 必须发出显式 `UNSUPPORTED`，而不是猜测 `String` / `Vector*` / `Color` / `Basis` / `Transform*` / `Object` 等 builtin keyed route 的结果类型。
 - `DYNAMIC` target 的 runtime-open 处理仍属于 assignment semantic helper 的内聚语义；其他 frontend 路径若只需要 concrete slot 兼容判断，必须调用 `checkAssignmentCompatible(...)`，不要各自硬编码 `Variant` 分支。

--- a/doc/test_error/test_suite_engine_integration_known_limits.md
+++ b/doc/test_error/test_suite_engine_integration_known_limits.md
@@ -55,25 +55,22 @@
 - 正向资源脚本统一改写为 `Array()` / `Dictionary()` 无参构造，再用 `push_back(...)` 和 subscript 逐步填充
 - 这是一条当前 compile surface 的真实边界，后续若 frontend 为 literal lowering 开口，应补专门 regression case
 
-## 4. plain `Dictionary` keyed subscript 当前要求显式 `Variant` key slot
+## 4. 已修复：plain `Dictionary` keyed subscript 不再要求显式 `Variant` key slot
 
-本轮第一次 targeted run 还暴露出 plain `Dictionary` 的 keyed route 现状：
+- shared subscript semantic gate 现在统一复用 `FrontendVariantBoundaryCompatibility`
+- plain `Dictionary`（`Dictionary[Variant, Variant]`）的字符串 key 正向写法已经恢复为：
+  - `scores["alpha"] = 2`
+  - `int(scores["alpha"])`
+- keyed lowering 路由保持不变：plain `Dictionary` + `String` key 继续冻结为 `VariantSetKeyedInsn` / `VariantGetKeyedInsn`，backend codegen 再把 key 物化到真实 `Variant` 调用面
+- test-suite 资源脚本已去掉历史 workaround，不再需要显式 `var alpha_key: Variant = "alpha"`
+- 当前剩余 gap 只在 Godot 更宽的 keyed/index widened conversion，例如 `String` / `StringName` 互通、以及 `Array` / packed array 的 float index
 
-- 直接写 `scores["alpha"] = 2`
-- 直接读 `scores["alpha"]`
+当前回归锚点包括：
 
-当前会在 compile surface 失败，错误形如：
-
-- `subscript assignment target key/index type 'String' is not assignable to expected 'Variant' for receiver 'Dictionary'`
-
-对 test suite 的直接影响：
-
-- 不能把 plain `Dictionary` 的常见字符串 key 用法原样写进正向 compile-run 资源脚本
-
-当前处理结论：
-
-- 正向资源脚本改为显式 `var alpha_key: Variant = "alpha"` 后再做 `scores[alpha_key]`
-- 这是当前实现的可工作 surface，不代表 Godot 原生最自然写法已经完全闭环
+- `src/test/test_suite/unit_test/script/collection/dictionary_mutation_and_lookup.gd`
+- `src/test/java/dev/superice/gdcc/frontend/sema/analyzer/support/FrontendSubscriptSemanticSupportTest.java`
+- `src/test/java/dev/superice/gdcc/frontend/lowering/FrontendLoweringBodyInsnPassTest.java`
+- `src/test/java/dev/superice/gdcc/test_suite/GdScriptUnitTestCompileRunnerTest.java` 的 collection category
 
 ## 5. 已修复：GDScript 可执行 body 中的 `CommentStatement` 不再阻断 CFG builder
 

--- a/src/main/java/dev/superice/gdcc/frontend/sema/analyzer/support/FrontendSubscriptSemanticSupport.java
+++ b/src/main/java/dev/superice/gdcc/frontend/sema/analyzer/support/FrontendSubscriptSemanticSupport.java
@@ -19,8 +19,9 @@ import java.util.Objects;
 /// - keyed builtin metadata outside the container family as explicit `UNSUPPORTED`
 /// - everything else as explicit `FAILED`
 /// Key/index compatibility details are owned by
-/// `doc/module_impl/frontend/frontend_implicit_conversion_matrix.md`; this helper currently keeps
-/// subscript rules narrower than Godot's wider keyed/index conversion surface on purpose.
+/// `doc/module_impl/frontend/frontend_implicit_conversion_matrix.md`; this helper reuses the shared
+/// frontend typed-boundary matrix and still intentionally rejects Godot's wider keyed/index-only
+/// conversions outside that matrix.
 public final class FrontendSubscriptSemanticSupport {
     private final @NotNull ClassRegistry classRegistry;
 
@@ -51,10 +52,14 @@ public final class FrontendSubscriptSemanticSupport {
         if (receiver instanceof GdContainerType containerType) {
             var keyType = containerType.getKeyType();
             var providedKeyType = arguments.getFirst();
-            if (!classRegistry.checkAssignable(providedKeyType, keyType)) {
+            if (!FrontendVariantBoundaryCompatibility.isFrontendBoundaryCompatible(
+                    classRegistry,
+                    providedKeyType,
+                    keyType
+            )) {
                 return FrontendExpressionType.failed(
                         description + " key/index type '" + providedKeyType.getTypeName()
-                                + "' is not assignable to expected '" + keyType.getTypeName()
+                                + "' is not frontend-boundary compatible with expected '" + keyType.getTypeName()
                                 + "' for receiver '" + receiver.getTypeName() + "'"
                 );
             }

--- a/src/test/java/dev/superice/gdcc/frontend/lowering/FrontendLoweringBodyInsnPassTest.java
+++ b/src/test/java/dev/superice/gdcc/frontend/lowering/FrontendLoweringBodyInsnPassTest.java
@@ -886,6 +886,45 @@ class FrontendLoweringBodyInsnPassTest {
     }
 
     @Test
+    void runAllowsPlainDictionaryStringKeysThroughSharedVariantBoundary() throws Exception {
+        var prepared = prepareContext(
+                "body_insn_plain_dictionary_string_key.gd",
+                """
+                        class_name BodyInsnPlainDictionaryStringKey
+                        extends RefCounted
+                        
+                        func ping(box: Dictionary, key: String) -> int:
+                            box[key] = 7
+                            return int(box[key])
+                        """,
+                Map.of("BodyInsnPlainDictionaryStringKey", "RuntimeBodyInsnPlainDictionaryStringKey"),
+                true
+        );
+        var pingContext = requireContext(
+                prepared.context().requireFunctionLoweringContexts(),
+                FunctionLoweringContext.Kind.EXECUTABLE_BODY,
+                "RuntimeBodyInsnPlainDictionaryStringKey",
+                "ping"
+        );
+
+        new FrontendLoweringBodyInsnPass().run(prepared.context());
+
+        var instructions = allInstructions(pingContext.targetFunction());
+
+        assertAll(
+                () -> assertFalse(prepared.diagnostics().hasErrors()),
+                () -> assertEquals(1, countInstructions(instructions, VariantSetKeyedInsn.class)),
+                () -> assertEquals(1, countInstructions(instructions, VariantGetKeyedInsn.class)),
+                () -> assertEquals(0, countInstructions(instructions, VariantSetIndexedInsn.class)),
+                () -> assertEquals(0, countInstructions(instructions, VariantGetIndexedInsn.class)),
+                () -> assertEquals(0, countInstructions(instructions, VariantSetNamedInsn.class)),
+                () -> assertEquals(0, countInstructions(instructions, VariantGetNamedInsn.class)),
+                () -> assertFalse(instructions.stream().anyMatch(VariantSetInsn.class::isInstance)),
+                () -> assertFalse(instructions.stream().anyMatch(VariantGetInsn.class::isInstance))
+        );
+    }
+
+    @Test
     void runMaterializesVariantBoundariesForLocalInitializersAndOrdinaryPropertyAssignments() throws Exception {
         var prepared = prepareContext(
                 "body_insn_assignment_variant_boundary.gd",

--- a/src/test/java/dev/superice/gdcc/frontend/sema/analyzer/support/FrontendSubscriptSemanticSupportTest.java
+++ b/src/test/java/dev/superice/gdcc/frontend/sema/analyzer/support/FrontendSubscriptSemanticSupportTest.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +30,7 @@ class FrontendSubscriptSemanticSupportTest {
                 "subscript expression"
         );
         assertEquals(FrontendExpressionTypeStatus.RESOLVED, arrayResult.status());
-        assertEquals("int", arrayResult.publishedType().getTypeName());
+        assertEquals("int", Objects.requireNonNull(arrayResult.publishedType()).getTypeName());
 
         var dictionaryResult = support.resolveSubscriptType(
                 new GdDictionaryType(GdStringType.STRING, GdIntType.INT),
@@ -37,7 +38,7 @@ class FrontendSubscriptSemanticSupportTest {
                 "subscript expression"
         );
         assertEquals(FrontendExpressionTypeStatus.RESOLVED, dictionaryResult.status());
-        assertEquals("int", dictionaryResult.publishedType().getTypeName());
+        assertEquals("int", Objects.requireNonNull(dictionaryResult.publishedType()).getTypeName());
 
         var packedResult = support.resolveSubscriptType(
                 GdPackedNumericArrayType.PACKED_INT32_ARRAY,
@@ -45,11 +46,11 @@ class FrontendSubscriptSemanticSupportTest {
                 "subscript expression"
         );
         assertEquals(FrontendExpressionTypeStatus.RESOLVED, packedResult.status());
-        assertEquals("int", packedResult.publishedType().getTypeName());
+        assertEquals("int", Objects.requireNonNull(packedResult.publishedType()).getTypeName());
     }
 
     @Test
-    void resolveSubscriptTypePublishesDynamicVariantAndRejectsBadKeys() {
+    void resolveSubscriptTypePublishesDynamicVariantAndAcceptsSharedVariantBoundary() {
         var support = new FrontendSubscriptSemanticSupport(newRegistry(List.of()));
 
         var dynamicResult = support.resolveSubscriptType(
@@ -60,13 +61,34 @@ class FrontendSubscriptSemanticSupportTest {
         assertEquals(FrontendExpressionTypeStatus.DYNAMIC, dynamicResult.status());
         assertEquals(GdVariantType.VARIANT, dynamicResult.publishedType());
 
+        var plainDictionaryResult = support.resolveSubscriptType(
+                new GdDictionaryType(GdVariantType.VARIANT, GdVariantType.VARIANT),
+                List.of(GdStringType.STRING),
+                "subscript expression"
+        );
+        assertEquals(FrontendExpressionTypeStatus.RESOLVED, plainDictionaryResult.status());
+        assertEquals(GdVariantType.VARIANT, plainDictionaryResult.publishedType());
+
+        var variantKeyResult = support.resolveSubscriptType(
+                new GdDictionaryType(GdStringType.STRING, GdIntType.INT),
+                List.of(GdVariantType.VARIANT),
+                "subscript expression"
+        );
+        assertEquals(FrontendExpressionTypeStatus.RESOLVED, variantKeyResult.status());
+        assertEquals("int", Objects.requireNonNull(variantKeyResult.publishedType()).getTypeName());
+    }
+
+    @Test
+    void resolveSubscriptTypeRejectsBadKeysOutsideSharedVariantBoundary() {
+        var support = new FrontendSubscriptSemanticSupport(newRegistry(List.of()));
+
         var badKeyResult = support.resolveSubscriptType(
                 new GdArrayType(GdIntType.INT),
                 List.of(GdStringType.STRING),
                 "subscript expression"
         );
         assertEquals(FrontendExpressionTypeStatus.FAILED, badKeyResult.status());
-        assertTrue(badKeyResult.detailReason().contains("not assignable"));
+        assertTrue(Objects.requireNonNull(badKeyResult.detailReason()).contains("not frontend-boundary compatible"));
     }
 
     @Test
@@ -79,7 +101,7 @@ class FrontendSubscriptSemanticSupportTest {
                 "subscript expression"
         );
         assertEquals(FrontendExpressionTypeStatus.UNSUPPORTED, keyedBuiltinResult.status());
-        assertTrue(keyedBuiltinResult.detailReason().contains("keyed access metadata"));
+        assertTrue(Objects.requireNonNull(keyedBuiltinResult.detailReason()).contains("keyed access metadata"));
 
         var scalarResult = support.resolveSubscriptType(
                 GdIntType.INT,
@@ -87,7 +109,7 @@ class FrontendSubscriptSemanticSupportTest {
                 "subscript expression"
         );
         assertEquals(FrontendExpressionTypeStatus.FAILED, scalarResult.status());
-        assertTrue(scalarResult.detailReason().contains("does not support"));
+        assertTrue(Objects.requireNonNull(scalarResult.detailReason()).contains("does not support"));
 
         var multiArgumentResult = support.resolveSubscriptType(
                 new GdDictionaryType(GdStringType.STRING, GdIntType.INT),
@@ -95,7 +117,7 @@ class FrontendSubscriptSemanticSupportTest {
                 "subscript expression"
         );
         assertEquals(FrontendExpressionTypeStatus.UNSUPPORTED, multiArgumentResult.status());
-        assertTrue(multiArgumentResult.detailReason().contains("exactly one key/index argument"));
+        assertTrue(Objects.requireNonNull(multiArgumentResult.detailReason()).contains("exactly one key/index argument"));
     }
 
     private static @NotNull ClassRegistry newRegistry(@NotNull List<ExtensionBuiltinClass> builtins) {

--- a/src/test/test_suite/unit_test/script/collection/dictionary_mutation_and_lookup.gd
+++ b/src/test/test_suite/unit_test/script/collection/dictionary_mutation_and_lookup.gd
@@ -5,14 +5,11 @@ func summarize() -> int:
     var scores: Dictionary = Dictionary()
     var alpha_flag := 0
     var gamma_flag := 0
-    var alpha_key: Variant = "alpha"
-    var beta_key: Variant = "beta"
-    var gamma_key: Variant = "gamma"
-    scores[alpha_key] = 2
-    scores[beta_key] = 5
-    scores[alpha_key] = int(scores[alpha_key]) + 4
-    if scores.has(alpha_key):
+    scores["alpha"] = 2
+    scores["beta"] = 5
+    scores["alpha"] = int(scores["alpha"]) + 4
+    if scores.has("alpha"):
         alpha_flag = 1
-    if scores.has(gamma_key):
+    if scores.has("gamma"):
         gamma_flag = 1
-    return scores.size() * 1000 + int(scores[alpha_key]) * 100 + int(scores[beta_key]) * 10 + alpha_flag * 2 + gamma_flag
+    return scores.size() * 1000 + int(scores["alpha"]) * 100 + int(scores["beta"]) * 10 + alpha_flag * 2 + gamma_flag


### PR DESCRIPTION
## Summary
- align container subscript key/index typing with `FrontendVariantBoundaryCompatibility`
- restore natural plain `Dictionary` string-key usage in the collection test-suite script
- add semantic and lowering regressions, and sync the frontend/test-suite fact-source docs

## Why
Plain `Dictionary` is represented as `Dictionary[Variant, Variant]`, but subscript typing was still using strict `ClassRegistry.checkAssignable(...)` for key/index validation. That rejected common routes such as `scores["alpha"]`, even though the shared frontend boundary helper, lowering, and backend codegen already support materializing stable keys into `Variant`.

## Affected Packages
- `dev.superice.gdcc.frontend.sema.analyzer.support`
- `dev.superice.gdcc.frontend.lowering`
- `doc/module_impl/frontend`
- `doc/test_error`
- `src/test/test_suite/unit_test/script/collection`

## Tests
- `powershell -ExecutionPolicy Bypass -File script/run-gradle-targeted-tests.ps1 -Tests FrontendSubscriptSemanticSupportTest,FrontendLoweringBodyInsnPassTest.runChoosesIndexedNamedAndKeyedSubscriptInstructionsFromPublishedKeyTypes,FrontendLoweringBodyInsnPassTest.runAllowsPlainDictionaryStringKeysThroughSharedVariantBoundary,GdScriptUnitTestCompileRunnerTest.compilesAndValidatesCollectionScripts`