### PR TITLE
ci(github): add build and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+env:
+  ZIG_VERSION: 0.16.0
+  GODOT_VERSION: 4.5.1
+  GODOT_STATUS: stable
+
+jobs:
+  test:
+    name: Ubuntu Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Cache tool downloads
+        uses: actions/cache@v5
+        with:
+          path: |
+            .tools
+            src/launcher/zig/.zig-cache
+            ~/.cache/zig
+          key: ci-tools-${{ runner.os }}-zig-${{ env.ZIG_VERSION }}-godot-${{ env.GODOT_VERSION }}-${{ hashFiles('src/launcher/zig/build.zig', 'src/launcher/zig/build.zig.zon') }}
+          restore-keys: |
+            ci-tools-${{ runner.os }}-zig-${{ env.ZIG_VERSION }}-godot-${{ env.GODOT_VERSION }}-
+
+      - name: Install Zig
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          zig_archive="zig-x86_64-linux-${ZIG_VERSION}.tar.xz"
+          zig_url="https://zigmirror.com/${zig_archive}"
+          zig_root="${GITHUB_WORKSPACE}/.tools/zig/${ZIG_VERSION}"
+          zig_bin="${zig_root}/bin"
+
+          if [[ ! -x "${zig_bin}/zig" ]]; then
+            rm -rf "${zig_root}"
+            mkdir -p "${zig_root}" "${GITHUB_WORKSPACE}/.tools/downloads"
+            curl -fL --retry 3 --connect-timeout 20 --output "${GITHUB_WORKSPACE}/.tools/downloads/${zig_archive}" "${zig_url}"
+            tar -xJf "${GITHUB_WORKSPACE}/.tools/downloads/${zig_archive}" -C "${zig_root}" --strip-components=1
+            mkdir -p "${zig_bin}"
+            ln -sf "${zig_root}/zig" "${zig_bin}/zig"
+          fi
+
+          "${zig_bin}/zig" version
+          echo "${zig_bin}" >> "${GITHUB_PATH}"
+          echo "ZIG=${zig_bin}/zig" >> "${GITHUB_ENV}"
+
+      - name: Install Godot
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          godot_file="Godot_v${GODOT_VERSION}-${GODOT_STATUS}_linux.x86_64"
+          godot_archive="${godot_file}.zip"
+          godot_url="https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-${GODOT_STATUS}/${godot_archive}"
+          godot_dir="${GITHUB_WORKSPACE}/.tools/godot/${GODOT_VERSION}-${GODOT_STATUS}"
+          godot_bin="${godot_dir}/${godot_file}"
+
+          if [[ ! -x "${godot_bin}" ]]; then
+            rm -rf "${godot_dir}"
+            mkdir -p "${godot_dir}" "${GITHUB_WORKSPACE}/.tools/downloads"
+            curl -fL --retry 3 --connect-timeout 20 --output "${GITHUB_WORKSPACE}/.tools/downloads/${godot_archive}" "${godot_url}"
+            unzip -q "${GITHUB_WORKSPACE}/.tools/downloads/${godot_archive}" -d "${godot_dir}"
+            chmod +x "${godot_bin}"
+          fi
+
+          "${godot_bin}" --version
+          echo "GODOT_BIN=${godot_bin}" >> "${GITHUB_ENV}"
+
+      - name: Run unit tests
+        shell: bash
+        run: ./gradlew test jar --no-daemon --info --console=plain
+
+      - name: Package jar and runtime libraries
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="$(grep -E '^[[:space:]]*version[[:space:]]*=[[:space:]]*"[^"]+"' build.gradle.kts | head -n 1 | sed -E 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+          if [[ -z "${version}" ]]; then
+            echo "Failed to extract project version from build.gradle.kts" >&2
+            exit 1
+          fi
+
+          if [[ ! -s "build/libs/gdcc-${version}.jar" ]]; then
+            echo "Missing gdcc jar: build/libs/gdcc-${version}.jar" >&2
+            exit 1
+          fi
+
+          if [[ ! -d build/libs/lib ]]; then
+            echo "Missing runtime library directory: build/libs/lib" >&2
+            exit 1
+          fi
+
+          rm -f "build/libs/gdcc-${version}-libs.zip"
+          (
+            cd build/libs
+            zip -qr "gdcc-${version}-libs.zip" lib
+          )
+          java -jar "build/libs/gdcc-${version}.jar" --version
+
+      - name: Upload jar and runtime libraries
+        uses: actions/upload-artifact@v7
+        with:
+          name: gdcc-jar-and-libs
+          path: |
+            build/libs/gdcc-*.jar
+            build/libs/gdcc-*-libs.zip
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,172 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  ZIG_VERSION: 0.16.0
+
+jobs:
+  release:
+    name: Build And Publish Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Cache release downloads
+        uses: actions/cache@v5
+        with:
+          path: |
+            .tools
+            tmp/zig-downloads
+            tmp/temurin-jre-downloads
+            src/launcher/zig/.zig-cache
+            ~/.cache/zig
+          key: release-tools-${{ runner.os }}-zig-${{ env.ZIG_VERSION }}-${{ hashFiles('src/launcher/zig/build.zig', 'src/launcher/zig/build.zig.zon', 'build-script/package-full-distributions.sh') }}
+          restore-keys: |
+            release-tools-${{ runner.os }}-zig-${{ env.ZIG_VERSION }}-
+
+      - name: Extract project version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="$(grep -E '^[[:space:]]*version[[:space:]]*=[[:space:]]*"[^"]+"' build.gradle.kts | head -n 1 | sed -E 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+          if [[ -z "${version}" ]]; then
+            echo "Failed to extract project version from build.gradle.kts" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "VERSION=${version}" >> "${GITHUB_ENV}"
+          echo "TAG=v${version}" >> "${GITHUB_ENV}"
+
+      - name: Install Zig
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          zig_archive="zig-x86_64-linux-${ZIG_VERSION}.tar.xz"
+          zig_url="https://zigmirror.com/${zig_archive}"
+          zig_root="${GITHUB_WORKSPACE}/.tools/zig/${ZIG_VERSION}"
+          zig_bin="${zig_root}/bin"
+
+          if [[ ! -x "${zig_bin}/zig" ]]; then
+            rm -rf "${zig_root}"
+            mkdir -p "${zig_root}" "${GITHUB_WORKSPACE}/.tools/downloads"
+            curl -fL --retry 3 --connect-timeout 20 --output "${GITHUB_WORKSPACE}/.tools/downloads/${zig_archive}" "${zig_url}"
+            tar -xJf "${GITHUB_WORKSPACE}/.tools/downloads/${zig_archive}" -C "${zig_root}" --strip-components=1
+            mkdir -p "${zig_bin}"
+            ln -sf "${zig_root}/zig" "${zig_bin}/zig"
+          fi
+
+          "${zig_bin}/zig" version
+          echo "${zig_bin}" >> "${GITHUB_PATH}"
+          echo "ZIG=${zig_bin}/zig" >> "${GITHUB_ENV}"
+
+      - name: Build platform distributions
+        shell: bash
+        run: ./gradlew packageDistribution jar --no-daemon --info --console=plain
+
+      - name: Build full distributions
+        shell: bash
+        run: bash build-script/package-full-distributions.sh
+
+      - name: Package jar and runtime libraries
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! -s "build/libs/gdcc-${VERSION}.jar" ]]; then
+            echo "Missing gdcc jar: build/libs/gdcc-${VERSION}.jar" >&2
+            exit 1
+          fi
+
+          if [[ ! -d build/libs/lib ]]; then
+            echo "Missing runtime library directory: build/libs/lib" >&2
+            exit 1
+          fi
+
+          java -jar "build/libs/gdcc-${VERSION}.jar" --version
+
+          cp "build/libs/gdcc-${VERSION}.jar" "build/distributions/gdcc-${VERSION}.jar"
+          rm -f "build/distributions/gdcc-${VERSION}-libs.zip"
+          (
+            cd build/libs
+            zip -qr "../distributions/gdcc-${VERSION}-libs.zip" lib
+          )
+
+      - name: Validate release files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_files=(
+            "build/distributions/gdcc-${VERSION}-linux-x86_64.zip"
+            "build/distributions/gdcc-${VERSION}-windows-x86_64.zip"
+            "build/distributions/gdcc-${VERSION}-linux-aarch64.zip"
+            "build/distributions/gdcc-${VERSION}-linux-x86_64-full.zip"
+            "build/distributions/gdcc-${VERSION}-windows-x86_64-full.zip"
+            "build/distributions/gdcc-${VERSION}-linux-aarch64-full.zip"
+            "build/distributions/gdcc-${VERSION}.jar"
+            "build/distributions/gdcc-${VERSION}-libs.zip"
+          )
+
+          for release_file in "${release_files[@]}"; do
+            if [[ ! -s "${release_file}" ]]; then
+              echo "Missing release file: ${release_file}" >&2
+              exit 1
+            fi
+          done
+
+          printf '%s\n' "${release_files[@]}" > build/distributions/release-files.txt
+          sha256sum "${release_files[@]}"
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: gdcc-${{ steps.version.outputs.version }}-release-files
+          path: |
+            build/distributions/gdcc-${{ steps.version.outputs.version }}-linux-x86_64.zip
+            build/distributions/gdcc-${{ steps.version.outputs.version }}-windows-x86_64.zip
+            build/distributions/gdcc-${{ steps.version.outputs.version }}-linux-aarch64.zip
+            build/distributions/gdcc-${{ steps.version.outputs.version }}-linux-x86_64-full.zip
+            build/distributions/gdcc-${{ steps.version.outputs.version }}-windows-x86_64-full.zip
+            build/distributions/gdcc-${{ steps.version.outputs.version }}-linux-aarch64-full.zip
+            build/distributions/gdcc-${{ steps.version.outputs.version }}.jar
+            build/distributions/gdcc-${{ steps.version.outputs.version }}-libs.zip
+          if-no-files-found: error
+
+      - name: Publish GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t release_files < build/distributions/release-files.txt
+
+          if gh release view "${TAG}" > /dev/null 2>&1; then
+            echo "Release ${TAG} already exists" >&2
+            exit 1
+          fi
+
+          gh release create "${TAG}" "${release_files[@]}" \
+            --target "${GITHUB_SHA}" \
+            --title "gdcc ${VERSION}" \
+            --notes "Automated gdcc ${VERSION} release with platform distributions, full distributions, the gdcc jar, and runtime libraries."

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,10 @@ bin/
 ### Mac OS ###
 .DS_Store
 /.idea/
-/.github/
+/.github/*
+!/.github/pull_request_template.md
+!/.github/workflows/
+!/.github/workflows/*.yml
 /todo.md
 /.kilocode/
 /.clinerules/

--- a/build-script/package-full-distributions.sh
+++ b/build-script/package-full-distributions.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ZIG_VERSION="0.16.0"
+ZIG_MIRROR_URL="${ZIG_MIRROR_URL:-https://zigmirror.com}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1; pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1; pwd)"
+DIST_DIR="$REPO_ROOT/build/distributions"
+TMP_ROOT="$REPO_ROOT/tmp/full-distribution"
+DOWNLOAD_DIR="$REPO_ROOT/tmp/zig-downloads/$ZIG_VERSION"
+EXTRACT_ROOT="$TMP_ROOT/extract"
+ZIP_WORK_ROOT="$TMP_ROOT/zip-work"
+
+PLATFORMS=(
+    "linux-x86_64"
+    "windows-x86_64"
+    "linux-aarch64"
+)
+
+require_tool() {
+    local tool="$1"
+
+    if command -v "$tool" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    printf 'error: required tool not found: %s\n' "$tool" >&2
+    exit 1
+}
+
+zig_archive_name() {
+    local platform="$1"
+
+    case "$platform" in
+        linux-x86_64)
+            printf 'zig-x86_64-linux-%s.tar.xz\n' "$ZIG_VERSION"
+            ;;
+        windows-x86_64)
+            printf 'zig-x86_64-windows-%s.zip\n' "$ZIG_VERSION"
+            ;;
+        linux-aarch64)
+            printf 'zig-aarch64-linux-%s.tar.xz\n' "$ZIG_VERSION"
+            ;;
+        *)
+            printf 'error: unsupported platform: %s\n' "$platform" >&2
+            exit 1
+            ;;
+    esac
+}
+
+zig_executable_name() {
+    local platform="$1"
+
+    case "$platform" in
+        windows-*)
+            printf 'zig.exe\n'
+            ;;
+        *)
+            printf 'zig\n'
+            ;;
+    esac
+}
+
+find_distribution_zip() {
+    local platform="$1"
+    local -a matches=()
+
+    if [[ ! -d "$DIST_DIR" ]]; then
+        printf 'error: distribution directory does not exist: %s\n' "$DIST_DIR" >&2
+        exit 1
+    fi
+
+    while IFS= read -r path; do
+        matches+=("$path")
+    done < <(find "$DIST_DIR" -maxdepth 1 -type f -name "gdcc-*-$platform.zip" ! -name "*-full.zip" | sort)
+
+    if [[ "${#matches[@]}" -eq 0 ]]; then
+        printf 'error: no distribution zip found for platform %s in %s\n' "$platform" "$DIST_DIR" >&2
+        exit 1
+    fi
+
+    if [[ "${#matches[@]}" -gt 1 ]]; then
+        printf 'error: multiple distribution zips found for platform %s:\n' "$platform" >&2
+        printf '  %s\n' "${matches[@]}" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "${matches[0]}"
+}
+
+download_zig_archive() {
+    local platform="$1"
+    local archive_name
+    local archive_path
+    local part_path
+    local url
+
+    archive_name="$(zig_archive_name "$platform")"
+    archive_path="$DOWNLOAD_DIR/$archive_name"
+    part_path="$archive_path.part"
+    url="$ZIG_MIRROR_URL/$archive_name"
+
+    mkdir -p "$DOWNLOAD_DIR"
+
+    if [[ -s "$archive_path" ]]; then
+        printf 'Using cached Zig archive: %s\n' "$archive_path" >&2
+        printf '%s\n' "$archive_path"
+        return 0
+    fi
+
+    printf 'Downloading %s\n' "$url" >&2
+    rm -f "$part_path"
+    curl -fL --retry 3 --connect-timeout 20 --output "$part_path" "$url"
+    mv "$part_path" "$archive_path"
+
+    printf '%s\n' "$archive_path"
+}
+
+extract_zig_archive() {
+    local platform="$1"
+    local archive_path="$2"
+    local extract_dir="$EXTRACT_ROOT/$platform"
+    local zig_dir="$ZIP_WORK_ROOT/$platform/zig"
+    local executable_name
+    local -a roots=()
+
+    executable_name="$(zig_executable_name "$platform")"
+
+    rm -rf "$extract_dir"
+    rm -rf "$zig_dir"
+    mkdir -p "$extract_dir"
+    mkdir -p "$zig_dir"
+
+    case "$archive_path" in
+        *.zip)
+            unzip -q "$archive_path" -d "$extract_dir"
+            ;;
+        *.tar.xz)
+            tar -xJf "$archive_path" -C "$extract_dir"
+            ;;
+        *)
+            printf 'error: unsupported Zig archive format: %s\n' "$archive_path" >&2
+            exit 1
+            ;;
+    esac
+
+    while IFS= read -r path; do
+        roots+=("$path")
+    done < <(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d | sort)
+
+    if [[ "${#roots[@]}" -ne 1 ]]; then
+        printf 'error: expected exactly one top-level directory in Zig archive for %s, found %s\n' "$platform" "${#roots[@]}" >&2
+        exit 1
+    fi
+
+    cp -R "${roots[0]}"/. "$zig_dir/"
+
+    if [[ ! -f "$zig_dir/$executable_name" ]]; then
+        printf 'error: expected Zig executable missing after extraction: %s\n' "$zig_dir/$executable_name" >&2
+        exit 1
+    fi
+
+    chmod +x "$zig_dir/$executable_name"
+    printf '%s\n' "$zig_dir"
+}
+
+add_zig_to_distribution() {
+    local platform="$1"
+    local input_zip="$2"
+    local zig_dir="$3"
+    local output_zip="${input_zip%.zip}-full.zip"
+    local zip_work_dir
+
+    zip_work_dir="$(dirname "$zig_dir")"
+
+    rm -f "$output_zip"
+    cp "$input_zip" "$output_zip"
+
+    (
+        cd "$zip_work_dir"
+        zip -qr "$output_zip" zig
+    )
+
+    printf 'Wrote %s\n' "$output_zip"
+}
+
+main() {
+    require_tool curl
+    require_tool find
+    require_tool sort
+    require_tool tar
+    require_tool unzip
+    require_tool zip
+
+    mkdir -p "$TMP_ROOT"
+    mkdir -p "$ZIP_WORK_ROOT"
+
+    for platform in "${PLATFORMS[@]}"; do
+        printf 'Packaging full distribution for %s\n' "$platform"
+
+        local input_zip
+        local archive_path
+        local zig_dir
+
+        input_zip="$(find_distribution_zip "$platform")"
+        archive_path="$(download_zig_archive "$platform")"
+        zig_dir="$(extract_zig_archive "$platform" "$archive_path")"
+        add_zig_to_distribution "$platform" "$input_zip" "$zig_dir"
+    done
+}
+
+main "$@"

--- a/build-script/package-full-distributions.sh
+++ b/build-script/package-full-distributions.sh
@@ -2,13 +2,16 @@
 set -euo pipefail
 
 ZIG_VERSION="0.16.0"
+TEMURIN_FEATURE_VERSION="25"
 ZIG_MIRROR_URL="${ZIG_MIRROR_URL:-https://zigmirror.com}"
+ADOPTIUM_API_URL="${ADOPTIUM_API_URL:-https://api.adoptium.net/v3/binary/latest}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1; pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1; pwd)"
 DIST_DIR="$REPO_ROOT/build/distributions"
 TMP_ROOT="$REPO_ROOT/tmp/full-distribution"
-DOWNLOAD_DIR="$REPO_ROOT/tmp/zig-downloads/$ZIG_VERSION"
+ZIG_DOWNLOAD_DIR="$REPO_ROOT/tmp/zig-downloads/$ZIG_VERSION"
+JRE_DOWNLOAD_DIR="$REPO_ROOT/tmp/temurin-jre-downloads/$TEMURIN_FEATURE_VERSION"
 EXTRACT_ROOT="$TMP_ROOT/extract"
 ZIP_WORK_ROOT="$TMP_ROOT/zip-work"
 
@@ -62,6 +65,70 @@ zig_executable_name() {
     esac
 }
 
+temurin_os() {
+    local platform="$1"
+
+    case "$platform" in
+        linux-*)
+            printf 'linux\n'
+            ;;
+        windows-*)
+            printf 'windows\n'
+            ;;
+        *)
+            printf 'error: unsupported platform: %s\n' "$platform" >&2
+            exit 1
+            ;;
+    esac
+}
+
+temurin_arch() {
+    local platform="$1"
+
+    case "$platform" in
+        linux-x86_64 | windows-x86_64)
+            printf 'x64\n'
+            ;;
+        linux-aarch64)
+            printf 'aarch64\n'
+            ;;
+        *)
+            printf 'error: unsupported platform: %s\n' "$platform" >&2
+            exit 1
+            ;;
+    esac
+}
+
+jre_archive_name() {
+    local platform="$1"
+
+    case "$platform" in
+        linux-*)
+            printf 'temurin-%s-jre-%s.tar.gz\n' "$TEMURIN_FEATURE_VERSION" "$platform"
+            ;;
+        windows-*)
+            printf 'temurin-%s-jre-%s.zip\n' "$TEMURIN_FEATURE_VERSION" "$platform"
+            ;;
+        *)
+            printf 'error: unsupported platform: %s\n' "$platform" >&2
+            exit 1
+            ;;
+    esac
+}
+
+java_executable_name() {
+    local platform="$1"
+
+    case "$platform" in
+        windows-*)
+            printf 'java.exe\n'
+            ;;
+        *)
+            printf 'java\n'
+            ;;
+    esac
+}
+
 find_distribution_zip() {
     local platform="$1"
     local -a matches=()
@@ -97,14 +164,46 @@ download_zig_archive() {
     local url
 
     archive_name="$(zig_archive_name "$platform")"
-    archive_path="$DOWNLOAD_DIR/$archive_name"
+    archive_path="$ZIG_DOWNLOAD_DIR/$archive_name"
     part_path="$archive_path.part"
     url="$ZIG_MIRROR_URL/$archive_name"
 
-    mkdir -p "$DOWNLOAD_DIR"
+    mkdir -p "$ZIG_DOWNLOAD_DIR"
 
     if [[ -s "$archive_path" ]]; then
         printf 'Using cached Zig archive: %s\n' "$archive_path" >&2
+        printf '%s\n' "$archive_path"
+        return 0
+    fi
+
+    printf 'Downloading %s\n' "$url" >&2
+    rm -f "$part_path"
+    curl -fL --retry 3 --connect-timeout 20 --output "$part_path" "$url"
+    mv "$part_path" "$archive_path"
+
+    printf '%s\n' "$archive_path"
+}
+
+download_jre_archive() {
+    local platform="$1"
+    local os
+    local arch
+    local archive_name
+    local archive_path
+    local part_path
+    local url
+
+    os="$(temurin_os "$platform")"
+    arch="$(temurin_arch "$platform")"
+    archive_name="$(jre_archive_name "$platform")"
+    archive_path="$JRE_DOWNLOAD_DIR/$archive_name"
+    part_path="$archive_path.part"
+    url="$ADOPTIUM_API_URL/$TEMURIN_FEATURE_VERSION/ga/$os/$arch/jre/hotspot/normal/eclipse"
+
+    mkdir -p "$JRE_DOWNLOAD_DIR"
+
+    if [[ -s "$archive_path" ]]; then
+        printf 'Using cached Temurin JRE archive: %s\n' "$archive_path" >&2
         printf '%s\n' "$archive_path"
         return 0
     fi
@@ -165,21 +264,65 @@ extract_zig_archive() {
     printf '%s\n' "$zig_dir"
 }
 
-add_zig_to_distribution() {
+extract_jre_archive() {
     local platform="$1"
-    local input_zip="$2"
-    local zig_dir="$3"
-    local output_zip="${input_zip%.zip}-full.zip"
-    local zip_work_dir
+    local archive_path="$2"
+    local extract_dir="$EXTRACT_ROOT/$platform-jre"
+    local jre_dir="$ZIP_WORK_ROOT/$platform/jre"
+    local executable_name
+    local -a roots=()
 
-    zip_work_dir="$(dirname "$zig_dir")"
+    executable_name="$(java_executable_name "$platform")"
+
+    rm -rf "$extract_dir"
+    rm -rf "$jre_dir"
+    mkdir -p "$extract_dir"
+    mkdir -p "$jre_dir"
+
+    case "$archive_path" in
+        *.zip)
+            unzip -q "$archive_path" -d "$extract_dir"
+            ;;
+        *.tar.gz)
+            tar -xzf "$archive_path" -C "$extract_dir"
+            ;;
+        *)
+            printf 'error: unsupported Temurin JRE archive format: %s\n' "$archive_path" >&2
+            exit 1
+            ;;
+    esac
+
+    while IFS= read -r path; do
+        roots+=("$path")
+    done < <(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d | sort)
+
+    if [[ "${#roots[@]}" -ne 1 ]]; then
+        printf 'error: expected exactly one top-level directory in Temurin JRE archive for %s, found %s\n' "$platform" "${#roots[@]}" >&2
+        exit 1
+    fi
+
+    cp -R "${roots[0]}"/. "$jre_dir/"
+
+    if [[ ! -f "$jre_dir/bin/$executable_name" ]]; then
+        printf 'error: expected Java executable missing after extraction: %s\n' "$jre_dir/bin/$executable_name" >&2
+        exit 1
+    fi
+
+    chmod +x "$jre_dir/bin/$executable_name"
+    printf '%s\n' "$jre_dir"
+}
+
+write_full_distribution() {
+    local input_zip="$1"
+    local content_root="$2"
+    local output_zip="${input_zip%.zip}-full.zip"
 
     rm -f "$output_zip"
     cp "$input_zip" "$output_zip"
 
     (
-        cd "$zip_work_dir"
-        zip -qr "$output_zip" zig
+        cd "$content_root"
+        zip -qr "$output_zip" zig jre
     )
 
     printf 'Wrote %s\n' "$output_zip"
@@ -200,13 +343,25 @@ main() {
         printf 'Packaging full distribution for %s\n' "$platform"
 
         local input_zip
-        local archive_path
+        local zig_archive_path
+        local jre_archive_path
         local zig_dir
+        local jre_dir
+        local content_root
 
         input_zip="$(find_distribution_zip "$platform")"
-        archive_path="$(download_zig_archive "$platform")"
-        zig_dir="$(extract_zig_archive "$platform" "$archive_path")"
-        add_zig_to_distribution "$platform" "$input_zip" "$zig_dir"
+        zig_archive_path="$(download_zig_archive "$platform")"
+        jre_archive_path="$(download_jre_archive "$platform")"
+        zig_dir="$(extract_zig_archive "$platform" "$zig_archive_path")"
+        jre_dir="$(extract_jre_archive "$platform" "$jre_archive_path")"
+        content_root="$(dirname "$zig_dir")"
+
+        if [[ "$(dirname "$jre_dir")" != "$content_root" ]]; then
+            printf 'error: internal package work directories differ for platform %s\n' "$platform" >&2
+            exit 1
+        fi
+
+        write_full_distribution "$input_zip" "$content_root"
     done
 }
 


### PR DESCRIPTION
## Summary
Add GitHub Actions coverage for regular CI and manual release publishing. The release path also adds full platform distribution archives that bundle Zig 0.16.0 and Temurin JRE 25 next to the launcher.

## What changed
- Add a push-triggered Ubuntu CI workflow that installs Java 25, Zig, and Godot 4.5.1, then runs Gradle tests and uploads the gdcc jar plus `libs.zip`.
- Add a manual release workflow that extracts the project version from `build.gradle.kts`, builds three platform distributions, creates three full distributions, and publishes the gdcc jar plus `libs.zip`.
- Add `build-script/package-full-distributions.sh` to derive `*-full.zip` archives from Gradle distributions while flattening bundled `zig/` and `jre/` directories at the archive root.
- Allow `.github/workflows/*.yml` through the existing `.github` ignore rule.

## Why
- Contributors need a reproducible CI path that exercises the Java compiler tests with the same native tools used by integration tests.
- Releases need self-contained platform packages so launchers can find `./zig/zig` or `./zig/zig.exe` and `./jre/bin/java` or `./jre/bin/java.exe` without relying on host installs.
- Publishing the plain gdcc jar and a separate `libs.zip` keeps dependency layout explicit and matches the jar manifest `Class-Path` contract.

## Affected packages/files
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`
- `build-script/package-full-distributions.sh`
- `.gitignore`

## Validation
- `python3 - <<'PY' ... PY` to parse both workflow YAML files and run `bash -n` against every workflow `run:` shell snippet.

Result: `workflow shell snippets ok`

- `bash -n build-script/package-full-distributions.sh`

Result: command completed successfully.

- IntelliJ `get_file_problems(errorsOnly=true)` for `.github/workflows/ci.yml` and `.github/workflows/release.yml`.

Result: no errors reported.

- `unzip -Z1 build/libs/gdcc-0.0.1-libs.zip | head -n 10`

Result: confirmed `libs.zip` keeps `lib/` as the archive root, including runtime dependency jars.

## Risks / Notes
- Full Gradle CI/release execution is expected to run in GitHub Actions where Java 25, Zig, and Godot are installed by the workflow.
- The manual release workflow fails if the `v<version>` release already exists, to avoid overwriting an existing published release.
- The full archive script requires exactly one base distribution zip per supported platform before adding bundled Zig and JRE payloads.

## Key behaviors covered (Optional)
- Full distribution root layout keeps the launcher, gdcc jar, `lib/`, `zig/`, and `jre/` as siblings.
- Release artifacts include three base zips, three full zips, the plain gdcc jar, and `gdcc-<version>-libs.zip`.

## Diff stats (Optional)
- 4 files changed, 671 insertions, 1 deletion.

## Breaking changes (Optional)
- None

## Related docs (Optional)
- `doc/module_impl/cli/cli_implementation.md`
- `doc/test_suite.md`