### PR TITLE
fix(ci): stabilize test report artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          report_dir="build/reports/test/test"
+          report_dir="build/reports/tests/test"
           report_zip="build/reports/gdcc-test-report.zip"
 
           if [[ ! -d "${report_dir}" ]]; then
@@ -147,7 +147,7 @@ jobs:
 
           rm -f "${report_zip}"
           (
-            cd build/reports/test
+            cd build/reports/tests
             zip -qr ../gdcc-test-report.zip test
           )
 

--- a/src/test/java/gd/script/gdcc/test_suite/GdScriptUnitTestCompileRunnerTest.java
+++ b/src/test/java/gd/script/gdcc/test_suite/GdScriptUnitTestCompileRunnerTest.java
@@ -1,5 +1,6 @@
 package gd.script.gdcc.test_suite;
 
+import gd.script.gdcc.backend.c.build.GodotGdextensionTestRunner;
 import gd.script.gdcc.backend.c.build.ZigUtil;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DynamicTest;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,6 +91,10 @@ public class GdScriptUnitTestCompileRunnerTest {
     private static final List<String> SCENE_SCRIPT_PATHS = scriptPathsWithPrefix("scene/");
     private static final List<String> SMOKE_SCRIPT_PATHS = scriptPathsWithPrefix("smoke/");
     private static final List<String> SUBSCRIPT_SCRIPT_PATHS = scriptPathsWithPrefix("subscript/");
+    private static final int PHYSICS_FRAME_QUIT_AFTER_FRAMES = 60;
+    private static final Set<String> PHYSICS_FRAME_SCRIPT_PATHS = Set.of(
+            "runtime/virtual/physics_process_called_and_delta_valid.gd"
+    );
 
     @Test
     void listsExpectedBundledUnitScripts() throws Exception {
@@ -208,8 +214,19 @@ public class GdScriptUnitTestCompileRunnerTest {
         return scriptPaths.stream()
                 .map(scriptResourcePath -> DynamicTest.dynamicTest(
                         scriptResourcePath,
-                        () -> new GdScriptUnitTestCompileRunner().compileAndValidate(scriptResourcePath)
+                        () -> new GdScriptUnitTestCompileRunner().compileAndValidate(
+                                scriptResourcePath,
+                                runOptionsFor(scriptResourcePath)
+                        )
                 ));
+    }
+
+    private static GodotGdextensionTestRunner.RunOptions runOptionsFor(String scriptResourcePath) {
+        var runOptions = GodotGdextensionTestRunner.defaultRunOptions(true);
+        if (PHYSICS_FRAME_SCRIPT_PATHS.contains(scriptResourcePath)) {
+            return runOptions.withQuitAfterFrames(PHYSICS_FRAME_QUIT_AFTER_FRAMES);
+        }
+        return runOptions;
     }
 
     private static List<String> scriptPathsWithPrefix(String prefix) {


### PR DESCRIPTION
## Summary
Fix CI-only failures around test report artifact packaging and the physics-frame runtime fixture. The workflow now packages Gradle's actual HTML test report directory, and the resource compile-run suite gives physics-frame cases enough Godot frames to finish validation.

## What changed
- Updated `.github/workflows/ci.yml` to package `build/reports/tests/test` instead of the non-existent `build/reports/test/test`.
- Updated `GdScriptUnitTestCompileRunnerTest` to run physics-frame resource cases with a 60-frame Godot budget.
- Kept non-physics resource cases on the default runner options.

## Why
- Gradle writes HTML test reports to `build/reports/tests/test`, but the CI packaging step was checking and zipping `build/reports/test/test`.
- The `_physics_process` validation waits for physics frames, while Godot `--quit-after` counts idle frames; GitHub Actions can stop after 10 idle frames before the validation observes enough physics frames.

## Affected packages/files
- `.github/workflows/ci.yml`
- `src/test/java/gd/script/gdcc/test_suite/GdScriptUnitTestCompileRunnerTest.java`

## Validation
- `./gradlew test --tests GdScriptUnitTestCompileRunnerTest --no-daemon --info --console=plain`
- `./gradlew test --tests GdScriptEngineVirtualOverrideRuntimeTest --no-daemon --info --console=plain`

Result: `BUILD SUCCESSFUL`

## Risks / Notes
- The physics-frame budget increase is limited to explicitly listed physics-frame resource cases.
- No compiler semantics, ownership lifecycle, type compatibility, or codegen behavior is changed.

## Diff stats (Optional)
- 2 files changed, 20 insertions, 3 deletions.

## Breaking changes (Optional)
- None