### PR TITLE
fix(backend): emit class struct definitions and ClassDB registration in inheritance topological order

### DIFF
--- a/doc/module_impl/backend/explicit_c_inheritance_layout_contract.md
+++ b/doc/module_impl/backend/explicit_c_inheritance_layout_contract.md
@@ -10,7 +10,7 @@
   - `src/main/java/gd/script/gdcc/backend/c/**`
   - `src/main/c/codegen/**`
   - `src/test/java/gd/script/gdcc/backend/c/**`
-- 更新时间：2026-04-27
+- 更新时间：2026-09-06
 - 上游对齐基线：
   - Godot ClassDB 继承关系决定 source-visible / runtime-visible 继承层级
   - GDExtension extension instance 回调会把同一个实例指针传给 GDCC 父类/子类方法路径
@@ -29,6 +29,10 @@
 - per-class object pointer helper 与 create/bind 链路：
   - `src/main/c/codegen/template_451/entry.c.ftl`
   - `src/main/c/codegen/include_451/gdcc/gdcc_helper.h`
+- 模块类 base-before-derived 拓扑顺序（struct 定义与 ClassDB 注册共用）：
+  - `src/main/java/gd/script/gdcc/backend/c/gen/CCodegen.java`
+    - `computeInheritanceClassOrder(...)`
+    - `computeStaticInitClassOrder(...)`
 - 最近 native ancestor 解析与 helper 符号渲染：
   - `src/main/java/gd/script/gdcc/backend/c/gen/CGenHelper.java`
     - `resolveNearestNativeAncestorName(...)`
@@ -54,6 +58,7 @@
 - `godot_object_set_instance(...)` 与 `godot_object_set_instance_binding(...)` 只在最派生 GDCC 创建路径执行一次。
 - GDCC->GDCC 转换只允许可证明的上行转换，生成 `_super` 链表达式；不可证明路径必须 fail-fast。
 - `CALL_METHOD` 在 GDCC 子类 receiver 调用 GDCC 父类 owner 方法时，必须复用上述安全上行路径，不能退回裸 C cast。
+- `entry.h` 的 wrapper struct 定义与 `entry.c` 的 ClassDB 注册都按模块继承拓扑 base-before-derived 生成（`inheritanceOrderedClassDefs`），不直接使用原始 `module.classDefs` 顺序；module 顺序由源文件顺序决定，可以是 derived-first。
 
 ## 长期合同
 
@@ -132,6 +137,18 @@
   - 旧式通用 `_object` 宏
   - 假设所有 GDCC wrapper 物理形状相同的临时转换
 
+### 7. 模块类拓扑顺序合同
+
+- `CCodegen.computeInheritanceClassOrder()` 产出模块全部类的 base-before-derived 拓扑序：
+  - 类绝不先于其模块内父类出现（唯一顺序合同）。
+  - 父类在模块外（engine/native 根）不构成约束。
+  - 每轮按 module（`LirModule.classDefs`）顺序发出所有父类已就位的类，同一输入产出唯一确定结果；但被父链阻塞的类可能晚于 module 中位于其后且无继承关系的类，不保证无关类保持 module 相对序。
+  - frontend 已在 lowering 前拒绝继承环；backend 遇到环必须 fail-fast，不得静默输出无序 C。
+- 以下两处消费该顺序，禁止改回原始 module 顺序：
+  - `entry.h.ftl` 的 wrapper struct 定义循环：非根 wrapper 以值嵌入父 wrapper（`Parent _super`），父 struct 定义必须先完整，否则 C 编译报 incomplete type 字段错误。
+  - `entry.c.ftl` 的 ClassDB 注册循环：Godot 在 `_register_extension_class_internal` 中要求父 extension class 已注册（否则报 `non-existing parent class` 并放弃注册），并在注册时绑定父/子 extension 指针对。
+- static init 两段式全局初始化（见 `frontend_static_var_implementation.md` §5.2）复用同一拓扑序过滤含 static var 的类，不再维护独立排序实现。
+
 ## 与 Godot 的对齐点
 
 ### 1. ClassDB 继承关系不是 C struct 布局
@@ -144,12 +161,18 @@ C struct 布局只决定 backend 自己传入 extension method callback 的实�
 - ClassDB 注册继续发布正确的 `class_name` / `parent_class_name`
 - GDCC wrapper 的 C-level 前缀布局能支撑父类方法读取父 wrapper 字段
 
-### 2. extension instance 指针在父/子路径间共享
+### 2. ClassDB 注册顺序与 struct 定义顺序是同一个拓扑约束
+
+- Godot 侧：`_register_extension_class_internal` 要求父 extension class 已经注册（`extension_classes.has(parent_class_name)`），否则报 `Attempt to register an extension class ... using non-existing parent class ...` 并放弃注册；注册成功时还会把子类挂到父类的 `children` 列表。
+- C 侧：子类 wrapper 以值嵌入父 wrapper，父 struct 定义必须先完整。
+- 两者由同一个 `inheritanceOrderedClassDefs`（base-before-derived）满足；frontend 保证无环，backend 对环 fail-fast。
+
+### 3. extension instance 指针在父/子路径间共享
 
 GDCC 子类对象调用父类方法时，Godot 仍会把同一个 extension instance 交给 callback。  
 如果父类方法把该指针解释为父 wrapper，而子类 wrapper 不以前缀形式嵌入父 wrapper，就会重新打开布局未定义行为风险。
 
-### 3. Godot object pointer 是 wrapper 内部事实，不是通用字段名合同
+### 4. Godot object pointer 是 wrapper 内部事实，不是通用字段名合同
 
 `_object` 只存在于根 GDCC wrapper 层。  
 非根 wrapper 通过 `_super` 链间接持有同一个 Godot object pointer，因此所有 Godot object pointer 访问都必须走生成 helper。
@@ -162,6 +185,9 @@ GDCC 子类对象调用父类方法时，Godot 仍会把同一个 extension inst
   - `create_instance` 构造最近 native ancestor
   - 多级 GDCC 继承链仍稳定构造同一个 native ancestor
   - extension instance / binding 在最派生 create path 中各绑定一次
+  - derived-first module 输入下 struct 定义与 ClassDB 注册仍为 base-before-derived；同 pass 就绪的无关类保持 module 相对序（被父链阻塞的类不在此列）
+  - static init 序为全类拓扑序的 static 子序列：经无 static 中间类的传递祖先仍约束顺序，无关 static 类不保证保持 module 相对序
+  - 模块内继承环 fail-fast
 - `src/test/java/gd/script/gdcc/backend/c/gen/CBodyBuilderPhaseCTest.java`
   - GDCC 多级上行转换生成 `_super` 链
   - 非上行或不可证明转换 fail-fast
@@ -175,6 +201,10 @@ GDCC 子类对象调用父类方法时，Godot 仍会把同一个 extension inst
   - GDCC 子类调用父类静态 owner 方法
   - 动态 receiver 通过 generated helper 转成 Godot raw pointer
   - Godot runtime 侧 `child is Base` / `ClassDB.is_parent_class(...)` 可见性
+- `src/test/java/gd/script/gdcc/backend/c/build/FrontendLoweringToCProjectBuilderIntegrationTest.java`
+  - 跨文件 extends 且子类源文件先于父类的模块：zig 编译通过（struct 定义拓扑序），ClassDB 注册 base-before-derived
+  - 引擎侧实例化跨文件子类、`is` / `is_class` / `ClassDB.is_parent_class(...)` 行为
+  - 继承方法分派（子类实例调父类 owner 方法、base 类型参数接收派生实例的安全上行分派）
 
 依赖 Zig / Godot 运行环境的集成测试必须保持环境不可用时跳过，不得误报失败。
 

--- a/doc/module_impl/backend/object_value_fat_pointer_implementation.md
+++ b/doc/module_impl/backend/object_value_fat_pointer_implementation.md
@@ -268,7 +268,10 @@ C lowering 合同：
 1. Godot/runtime includes 和 `class_library`。
 2. GDCC wrapper struct forward declarations。
 3. 所有 generated fat pointer typedef（由独立头文件 `object_fat_ptr_types.h` 承载）。
-4. GDCC wrapper struct definitions；object fields 使用 fat pointer。
+4. GDCC wrapper struct definitions；object fields 使用 fat pointer。定义按模块继承拓扑
+   base-before-derived（`inheritanceOrderedClassDefs`）：非根 wrapper 以值嵌入父 wrapper
+   `Parent _super`，父 struct 定义必须先完整，详见
+   `explicit_c_inheritance_layout_contract.md` §7。
 5. `<Class>_object_ptr(...)` 等 raw layout helper declarations。
 6. per-type fat pointer helper declarations/definitions。
 7. `engine_method_binds.h`。

--- a/doc/module_impl/frontend/frontend_static_var_implementation.md
+++ b/doc/module_impl/frontend/frontend_static_var_implementation.md
@@ -218,7 +218,14 @@
 1. 先按类间顺序调用所有 `gdcc_static_defaults_*`
 2. 再按同一顺序调用所有 `gdcc_static_initializers_*`
 
-类间顺序固定为 base-before-derived（按继承拓扑；无继承关系时按 module class 顺序）。初始化级别为 `GDEXTENSION_INITIALIZATION_SCENE`。
+类间顺序固定为 base-before-derived（按继承拓扑，含经无 static 中间类传递的祖先）。初始化级别为 `GDEXTENSION_INITIALIZATION_SCENE`。
+
+该拓扑序由 backend `CCodegen.computeInheritanceClassOrder()` 统一产出，与 `entry.h` wrapper
+struct 定义顺序、`entry.c` ClassDB 注册顺序共用同一份实现（见
+`explicit_c_inheritance_layout_contract.md` §7）；static init 只是在完整拓扑序上过滤含
+static var 的类，不再维护独立排序。全类图拓扑下，被父链阻塞的类可能晚于 module 中位于
+其后但无继承关系的类，因此过滤结果只保证 base-before-derived 与确定性，不保证无关
+static 类保持 module 相对序（本节原本就不保证跨类 initializer 的相对先后）。
 
 分段理由：static initializer 可以通过 `ClassName.name` 读其他类的 static var。若默认值与 initializer 混在同一个 per-class 函数里，module 词法序可能让早初始化的类读到尚未物化的 managed 默认值。分段后任何 initializer 读到的至少是类型默认值。
 

--- a/src/main/c/codegen/template_451/entry.c.ftl
+++ b/src/main/c/codegen/template_451/entry.c.ftl
@@ -2,6 +2,7 @@
 <#-- @ftlvariable name="helper" type="gd.script.gdcc.backend.c.gen.CGenHelper" -->
 <#-- @ftlvariable name="bodyRender" type="gd.script.gdcc.backend.c.gen.binding.GenerateRenderFacade" -->
 <#-- @ftlvariable name="staticInitClassDefs" type="java.util.List<gd.script.gdcc.lir.LirClassDef>" -->
+<#-- @ftlvariable name="inheritanceOrderedClassDefs" type="java.util.List<gd.script.gdcc.lir.LirClassDef>" -->
 <#include "func.ftl">
 <#include "trim.ftl">
 
@@ -57,7 +58,10 @@ void initialize(void* userdata, const GDExtensionInitializationLevel p_level) {
     <#-- Register user classes.-->
     <#-- Registration, bind-owner lookup, and instance attach intentionally all reuse the-->
     <#-- same canonical class name directly. There is no backend-only Godot alias layer here.-->
-    <#list module.classDefs as classDef>
+    <#-- Registration iterates the base-before-derived inheritance order (never raw module -->
+    <#-- order): Godot rejects registering an extension class whose parent extension class is -->
+    <#-- not registered yet, and binds the parent/child extension pair at registration time. -->
+    <#list inheritanceOrderedClassDefs as classDef>
     {
         GDExtensionClassCreationInfo5 creation_info = {};
         creation_info.is_abstract = ${classDef.abstract?c};

--- a/src/main/c/codegen/template_451/entry.h.ftl
+++ b/src/main/c/codegen/template_451/entry.h.ftl
@@ -1,5 +1,6 @@
 <#-- @ftlvariable name="module" type="gd.script.gdcc.lir.LirModule" -->
 <#-- @ftlvariable name="helper" type="gd.script.gdcc.backend.c.gen.CGenHelper" -->
+<#-- @ftlvariable name="inheritanceOrderedClassDefs" type="java.util.List<gd.script.gdcc.lir.LirClassDef>" -->
 <#include "trim.ftl">
 <#include "func.ftl">
 #ifndef GDEXTENSION_${module.moduleName?upper_case}_ENTRY_H
@@ -23,13 +24,16 @@ void deinitialize(void* userdata, GDExtensionInitializationLevel p_level);
 
 // Class declarations
 
-<#list module.classDefs as classDef>
+<#list inheritanceOrderedClassDefs as classDef>
 typedef struct ${classDef.name} ${classDef.name};
 </#list>
 
 #include "object_fat_ptr_types.h"
 
-<#list module.classDefs as classDef>
+<#-- Struct definitions iterate the base-before-derived inheritance order (never raw module -->
+<#-- order): a non-root wrapper embeds its parent BY VALUE as the first field (`Parent _super`), -->
+<#-- which is only legal once the parent struct definition is complete. -->
+<#list inheritanceOrderedClassDefs as classDef>
 // Class definition for ${classDef.name}
 
 struct ${classDef.name} {

--- a/src/main/java/gd/script/gdcc/backend/c/gen/CCodegen.java
+++ b/src/main/java/gd/script/gdcc/backend/c/gen/CCodegen.java
@@ -35,8 +35,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class CCodegen implements Codegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(CCodegen.class);
@@ -778,41 +776,42 @@ public class CCodegen implements Codegen {
         return body.toString();
     }
 
-    /// Classes that declare at least one static property, ordered base-before-derived along the
-    /// module's inheritance topology for the global two-phase static initialization. Classes whose
-    /// superclass chain leaves the module (engine/native roots) have no static-init dependencies.
-    /// Unrelated classes keep module (`LirModule.classDefs`) order so generated C stays
-    /// deterministic.
-    private @NotNull List<LirClassDef> computeStaticInitClassOrder() {
+    /// All module classes ordered base-before-derived along the module's inheritance topology:
+    /// a class never precedes its in-module superclass. Two consumers depend on this order —
+    /// `entry.h` struct definitions embed the parent wrapper by value (`Parent _super`), so the
+    /// parent type must be complete first, and Godot refuses to register an extension class whose
+    /// parent extension class is not registered yet. Superclasses outside the module (engine or
+    /// native roots) impose no constraint. Each pass emits, in module (`LirModule.classDefs`)
+    /// order, every class whose in-module superclass is already emitted, so the result is
+    /// deterministic for identical input; a class blocked behind its superclass chain can still
+    /// land after unrelated classes that follow it in module order, so only the
+    /// base-before-derived guarantee is contractual.
+    private @NotNull List<LirClassDef> computeInheritanceClassOrder() {
         var classByName = new HashMap<String, LirClassDef>();
         for (var classDef : module.getClassDefs()) {
             classByName.put(classDef.getName(), classDef);
         }
-        var staticClassNames = new HashSet<String>();
-        for (var classDef : module.getClassDefs()) {
-            if (classDef.getProperties().stream().anyMatch(LirPropertyDef::isStatic)) {
-                staticClassNames.add(classDef.getName());
-            }
-        }
-        var remaining = module.getClassDefs().stream()
-                .filter(classDef -> staticClassNames.contains(classDef.getName()))
-                .collect(Collectors.toCollection(ArrayList::new));
+        var remaining = new ArrayList<>(module.getClassDefs());
         var ordered = new ArrayList<LirClassDef>(remaining.size());
         var emittedNames = new HashSet<String>();
         while (!remaining.isEmpty()) {
             var progressed = false;
             for (var iterator = remaining.iterator(); iterator.hasNext(); ) {
                 var candidate = iterator.next();
-                if (staticAncestorNames(candidate, classByName, staticClassNames).allMatch(emittedNames::contains)) {
+                var superDef = classByName.get(candidate.getSuperName());
+                if (superDef == null || emittedNames.contains(superDef.getName())) {
                     ordered.add(candidate);
                     emittedNames.add(candidate.getName());
                     iterator.remove();
                     progressed = true;
                 }
             }
+            // The frontend rejects inheritance cycles before lowering, so a stall here means a
+            // hand-built or corrupted module reached the backend; fail fast instead of emitting
+            // silently unordered output.
             if (!progressed) {
                 throw new IllegalStateException(
-                        "Inheritance cycle among classes with static properties: "
+                        "Inheritance cycle among module classes: "
                                 + remaining.stream().map(LirClassDef::getName).toList()
                 );
             }
@@ -820,24 +819,17 @@ public class CCodegen implements Codegen {
         return List.copyOf(ordered);
     }
 
-    /// Streams the names of all module ancestors of `classDef` that themselves declare static
-    /// properties (walks the full superclass chain, not just the direct parent, so transitive
-    /// dependencies like `A -> B -> C` order `A` after `C` even when `B` declares no statics).
-    private @NotNull Stream<String> staticAncestorNames(
-            @NotNull LirClassDef classDef,
-            @NotNull Map<String, LirClassDef> classByName,
-            @NotNull Set<String> staticClassNames
-    ) {
-        var ancestorNames = new ArrayList<String>();
-        var visited = new HashSet<String>();
-        var current = classByName.get(classDef.getSuperName());
-        while (current != null && visited.add(current.getName())) {
-            if (staticClassNames.contains(current.getName())) {
-                ancestorNames.add(current.getName());
-            }
-            current = classByName.get(current.getSuperName());
-        }
-        return ancestorNames.stream();
+    /// Classes that declare at least one static property, filtered from the module-wide
+    /// base-before-derived inheritance order for the global two-phase static initialization.
+    /// The only contractual guarantee is base-before-derived, including transitive ancestors
+    /// reached through non-static intermediates (`A -> B -> C` orders `A` after `C` even when
+    /// `B` declares no statics); static classes unrelated by inheritance are NOT guaranteed to
+    /// keep their module-order relative positions, but the filtered result stays deterministic
+    /// for identical input.
+    private @NotNull List<LirClassDef> computeStaticInitClassOrder(@NotNull List<LirClassDef> inheritanceOrderedClassDefs) {
+        return inheritanceOrderedClassDefs.stream()
+                .filter(classDef -> classDef.getProperties().stream().anyMatch(LirPropertyDef::isStatic))
+                .toList();
     }
 
     /// Module-wide C file-scope symbol conflict validation. Collects the
@@ -930,7 +922,8 @@ public class CCodegen implements Codegen {
                 lifecycleValidator.validateFunction(ctx, function);
             }
         }
-        var staticInitClassDefs = computeStaticInitClassOrder();
+        var inheritanceOrderedClassDefs = computeInheritanceClassOrder();
+        var staticInitClassDefs = computeStaticInitClassOrder(inheritanceOrderedClassDefs);
         try {
             var usageSession = GodotBindingUsageSession.forRegistry(ctx.classRegistry());
             // Template-visible registrations are committed only after `entry.c` renders successfully.
@@ -947,7 +940,8 @@ public class CCodegen implements Codegen {
                     "module", module,
                     "helper", helper,
                     "bodyRender", bodyRender,
-                    "staticInitClassDefs", staticInitClassDefs
+                    "staticInitClassDefs", staticInitClassDefs,
+                    "inheritanceOrderedClassDefs", inheritanceOrderedClassDefs
             );
             var cSrc = TemplateLoader.renderFromClasspath("template_451/entry.c.ftl", cTplCtx);
             usageSession.commit(templateUsageBuffer);
@@ -983,7 +977,8 @@ public class CCodegen implements Codegen {
             );
             var hTplCtx = Map.of(
                     "module", module,
-                    "helper", helper
+                    "helper", helper,
+                    "inheritanceOrderedClassDefs", inheritanceOrderedClassDefs
             );
             var hSrc = TemplateLoader.renderFromClasspath("template_451/entry.h.ftl", hTplCtx);
             cSrc = CCodeFormatter.format(cSrc);

--- a/src/test/java/gd/script/gdcc/backend/c/build/FrontendLoweringToCProjectBuilderIntegrationTest.java
+++ b/src/test/java/gd/script/gdcc/backend/c/build/FrontendLoweringToCProjectBuilderIntegrationTest.java
@@ -2203,6 +2203,184 @@ public class FrontendLoweringToCProjectBuilderIntegrationTest {
         );
     }
 
+    @Test
+    void lowerFrontendCrossFileInheritanceBuildsNativeLibraryAndRunInGodot() throws Exception {
+        if (ZigUtil.findZig() == null) {
+            Assumptions.abort("Zig not found; skipping cross-file inheritance frontend integration test");
+            return;
+        }
+
+        var tempDir = Path.of("tmp/test/frontend_cross_file_inheritance_runtime");
+        Files.createDirectories(tempDir);
+
+        // The child source is listed before its base on purpose: module class order follows
+        // source order, so this fixture forces the derived-first hazard that requires the
+        // backend to emit base-before-derived struct definitions and ClassDB registration.
+        var childSource = """
+                class_name CrossFileChild
+                extends CrossFileBase
+
+                func child_value() -> int:
+                    return base_value() + 1
+                """;
+        var baseSource = """
+                class_name CrossFileBase
+                extends RefCounted
+
+                func base_value() -> int:
+                    return 41
+                """;
+        var hostSource = """
+                class_name CrossFileInheritanceHost
+                extends Node
+
+                func make_child_sum() -> int:
+                    var child: CrossFileChild = CrossFileChild.new()
+                    return child.base_value() + child.child_value()
+
+                func dispatch_via_base(base_ref: CrossFileBase) -> int:
+                    return base_ref.base_value()
+                """;
+        var module = parseModule(
+                "frontend_cross_file_inheritance_runtime_module",
+                List.of(
+                        new SourceFileSpec(tempDir.resolve("cross_file_child.gd"), childSource),
+                        new SourceFileSpec(tempDir.resolve("cross_file_base.gd"), baseSource),
+                        new SourceFileSpec(tempDir.resolve("cross_file_inheritance_host.gd"), hostSource)
+                ),
+                Map.of(
+                        "CrossFileChild", "RuntimeCrossFileChild",
+                        "CrossFileBase", "RuntimeCrossFileBase",
+                        "CrossFileInheritanceHost", "RuntimeCrossFileInheritanceHost"
+                )
+        );
+        var diagnostics = new DiagnosticManager();
+        var classRegistry = new ClassRegistry(ExtensionApiLoader.loadVersion(GodotVersion.V451));
+        var lowered = new FrontendLoweringPassManager().lower(module, classRegistry, diagnostics);
+
+        assertNotNull(lowered, () -> "Lowering returned null with diagnostics: " + diagnostics.snapshot());
+        assertFalse(diagnostics.hasErrors(), () -> "Unexpected frontend diagnostics: " + diagnostics.snapshot());
+        assertEquals(3, lowered.getClassDefs().size());
+        // Pin the hazard setup: the module stays derived-first, so the C assertions below
+        // actually observe the backend reorder instead of a lucky input order.
+        assertEquals("RuntimeCrossFileChild", lowered.getClassDefs().getFirst().getName());
+
+        var projectDir = tempDir.resolve("project");
+        Files.createDirectories(projectDir);
+        var projectInfo = new CProjectInfo(
+                "frontend_cross_file_inheritance_runtime",
+                GodotVersion.V451,
+                projectDir,
+                COptimizationLevel.DEBUG,
+                TargetPlatform.getNativePlatform()
+        );
+        var codegen = new CCodegen();
+        codegen.prepare(new CodegenContext(projectInfo, classRegistry), lowered);
+
+        var buildResult = new CProjectBuilder().buildProject(projectInfo, codegen);
+        var entrySource = Files.readString(projectDir.resolve("entry.c"));
+        var headerSource = Files.readString(projectDir.resolve("entry.h"));
+
+        assertTrue(buildResult.success(), () -> "Native build should succeed. Build log:\n" + buildResult.buildLog());
+        // The child wrapper embeds `RuntimeCrossFileBase _super` by value as its first field,
+        // so the base struct definition must be complete first (C has no by-value incomplete
+        // fields); raw module order would fail the C compile here.
+        var baseStructIndex = headerSource.indexOf("struct RuntimeCrossFileBase {");
+        var childStructIndex = headerSource.indexOf("struct RuntimeCrossFileChild {");
+        assertTrue(baseStructIndex >= 0 && childStructIndex > baseStructIndex, headerSource);
+        assertTrue(headerSource.contains("RuntimeCrossFileBase _super;"), headerSource);
+        // Godot rejects registering an extension class whose parent extension class is not
+        // registered yet, so ClassDB registration follows the same base-before-derived order.
+        // The `();` anchor matches only the call sites inside initialize(), never the later
+        // `void <Class>_class_bind_methods() {` definitions.
+        var baseRegistrationIndex = entrySource.indexOf("RuntimeCrossFileBase_class_bind_methods();");
+        var childRegistrationIndex = entrySource.indexOf("RuntimeCrossFileChild_class_bind_methods();");
+        assertTrue(baseRegistrationIndex >= 0 && childRegistrationIndex > baseRegistrationIndex, entrySource);
+
+        var runner = new GodotGdextensionTestRunner(Path.of("test_project"));
+        runner.prepareProject(new GodotGdextensionTestRunner.ProjectSetup(
+                buildResult.artifacts(),
+                List.of(new GodotGdextensionTestRunner.SceneNodeSpec(
+                        "CrossFileInheritanceHostNode",
+                        "RuntimeCrossFileInheritanceHost",
+                        ".",
+                        Map.of()
+                )),
+                new GodotGdextensionTestRunner.TestScriptSpec(crossFileInheritanceTestScript())
+        ));
+
+        var runResult = runner.run(true);
+        var combinedOutput = runResult.combinedOutput();
+
+        assertTrue(
+                runResult.stopSignalSeen(),
+                () -> "Godot run should emit \"" + GodotGdextensionTestRunner.TEST_STOP_SIGNAL + "\".\nOutput:\n" + combinedOutput
+        );
+        assertTrue(
+                combinedOutput.contains("frontend cross-file inheritance instantiate dispatch check passed."),
+                () -> "Cross-file instantiation and method dispatch check should pass.\nOutput:\n" + combinedOutput
+        );
+        assertTrue(
+                combinedOutput.contains("frontend cross-file inheritance upcast dispatch check passed."),
+                () -> "Base-typed upcast dispatch check should pass.\nOutput:\n" + combinedOutput
+        );
+        assertTrue(
+                combinedOutput.contains("frontend cross-file inheritance is_class check passed."),
+                () -> "Cross-file is/is_class check should pass.\nOutput:\n" + combinedOutput
+        );
+        assertFalse(
+                combinedOutput.contains("frontend cross-file inheritance instantiate dispatch check failed."),
+                () -> "Cross-file instantiation and method dispatch check should not fail.\nOutput:\n" + combinedOutput
+        );
+        assertFalse(
+                combinedOutput.contains("frontend cross-file inheritance upcast dispatch check failed."),
+                () -> "Base-typed upcast dispatch check should not fail.\nOutput:\n" + combinedOutput
+        );
+        assertFalse(
+                combinedOutput.contains("frontend cross-file inheritance is_class check failed."),
+                () -> "Cross-file is/is_class check should not fail.\nOutput:\n" + combinedOutput
+        );
+    }
+
+    private static @NotNull String crossFileInheritanceTestScript() {
+        return """
+                extends Node
+
+                const TARGET_NODE_NAME = "CrossFileInheritanceHostNode"
+
+                func _ready() -> void:
+                    var target = get_parent().get_node_or_null(TARGET_NODE_NAME)
+                    if target == null:
+                        push_error("Target node missing.")
+                        return
+
+                    # Engine-side instantiation of a class that extends another file's class,
+                    # plus inherited/own method dispatch on the gdcc-compiled host.
+                    var child = RuntimeCrossFileChild.new()
+                    var sum = int(target.call("make_child_sum"))
+                    if sum == 83 and int(child.base_value()) == 41 and int(child.child_value()) == 42:
+                        print("frontend cross-file inheritance instantiate dispatch check passed.")
+                    else:
+                        push_error("frontend cross-file inheritance instantiate dispatch check failed.")
+
+                    # A derived instance passed through the base-typed parameter boundary must
+                    # still dispatch to the base owner method via the safe upcast path.
+                    var via_base = int(target.call("dispatch_via_base", child))
+                    if via_base == 41:
+                        print("frontend cross-file inheritance upcast dispatch check passed.")
+                    else:
+                        push_error("frontend cross-file inheritance upcast dispatch check failed.")
+
+                    var is_ok = child is RuntimeCrossFileBase
+                    var classdb_ok = ClassDB.is_parent_class("RuntimeCrossFileChild", "RuntimeCrossFileBase")
+                    var is_class_ok = child.is_class("RuntimeCrossFileChild") and child.is_class("RuntimeCrossFileBase") and child.is_class("RefCounted") and not child.is_class("CrossFileChild") and not child.is_class("CrossFileBase")
+                    if is_ok and classdb_ok and is_class_ok:
+                        print("frontend cross-file inheritance is_class check passed.")
+                    else:
+                        push_error("frontend cross-file inheritance is_class check failed.")
+                """;
+    }
+
     private static @NotNull FrontendModule parseModule(
             @NotNull Path sourcePath,
             @NotNull String source,

--- a/src/test/java/gd/script/gdcc/backend/c/gen/CCodegenTest.java
+++ b/src/test/java/gd/script/gdcc/backend/c/gen/CCodegenTest.java
@@ -3049,6 +3049,93 @@ public class CCodegenTest {
     }
 
     @Test
+    void generateEmitsStructDefinitionsAndClassRegistrationInBaseBeforeDerivedOrder() {
+        // Module order is deliberately derived-first to prove the inheritance topology reorder;
+        // the unrelated solo class pins that classes ready in the same pass keep their
+        // module-relative order (Solo precedes Root in module order and neither blocks the other).
+        var leafClass = new LirClassDef("GdTopoLeaf", "GdTopoMid");
+        var midClass = new LirClassDef("GdTopoMid", "GdTopoRoot");
+        var soloClass = new LirClassDef("GdTopoSolo", "RefCounted");
+        var rootClass = new LirClassDef("GdTopoRoot", "RefCounted");
+        var module = new LirModule("topo_order_module", List.of(leafClass, midClass, soloClass, rootClass));
+        var codegen = new CCodegen();
+        codegen.prepare(newStaticTestContext(), module);
+
+        var files = codegen.generate();
+        var cCode = generatedFileText(files, "entry.c");
+        var hCode = generatedFileText(files, "entry.h");
+
+        // A non-root wrapper embeds its parent BY VALUE as the first field, so the parent struct
+        // definition must be complete before the child one (C has no by-value incomplete fields).
+        assertOrdered(hCode,
+                "struct GdTopoSolo {",
+                "struct GdTopoRoot {",
+                "struct GdTopoMid {",
+                "struct GdTopoLeaf {");
+        assertOrdered(hCode,
+                "struct GdTopoRoot {",
+                "GdTopoRoot _super;",
+                "GdTopoMid _super;");
+
+        // Godot rejects registering an extension class whose parent extension class is not
+        // registered yet, so ClassDB registration must follow the same base-before-derived order.
+        // The `();` anchor matches only the call sites inside initialize(), never the later
+        // `void <Class>_class_bind_methods() {` definitions.
+        assertOrdered(cCode,
+                "GdTopoSolo_class_bind_methods();",
+                "GdTopoRoot_class_bind_methods();",
+                "GdTopoMid_class_bind_methods();",
+                "GdTopoLeaf_class_bind_methods();");
+    }
+
+    @Test
+    void generateEmitsStaticInitAsFilteredInheritanceOrder() {
+        // Locks the filtered-order semantics of the shared topology: transitive static
+        // dependencies order through non-static intermediates (GdStaticD before GdStaticA via
+        // GdNonStaticB), and a class blocked behind its chain may land after unrelated static
+        // classes that follow it in module order (GdStaticC before GdStaticA). Only
+        // base-before-derived is contractual; the exact sequence pins determinism.
+        var classA = new LirClassDef("GdStaticA", "GdNonStaticB");
+        classA.addProperty(staticProperty("a_title", GdStringType.STRING));
+        var classC = new LirClassDef("GdStaticC", "RefCounted");
+        classC.addProperty(staticProperty("c_title", GdStringType.STRING));
+        var classB = new LirClassDef("GdNonStaticB", "GdStaticD");
+        var classD = new LirClassDef("GdStaticD", "RefCounted");
+        classD.addProperty(staticProperty("d_title", GdStringType.STRING));
+        var module = new LirModule("static_filtered_order_module", List.of(classA, classC, classB, classD));
+        var codegen = new CCodegen();
+        codegen.prepare(newStaticTestContext(), module);
+
+        var cCode = generatedFileText(codegen.generate(), "entry.c");
+
+        assertOrdered(cCode,
+                "gdcc_static_defaults_GdStaticC();",
+                "gdcc_static_defaults_GdStaticD();",
+                "gdcc_static_defaults_GdStaticA();");
+        assertOrdered(cCode,
+                "gdcc_static_initializers_GdStaticC();",
+                "gdcc_static_initializers_GdStaticD();",
+                "gdcc_static_initializers_GdStaticA();");
+    }
+
+    @Test
+    void generateFailsFastOnModuleInheritanceCycle() {
+        // The frontend rejects inheritance cycles before lowering; the backend still fails fast
+        // on hand-built cyclic modules instead of emitting silently unordered C.
+        var classA = new LirClassDef("GdCycleA", "GdCycleB");
+        var classB = new LirClassDef("GdCycleB", "GdCycleA");
+        var module = new LirModule("topo_cycle_module", List.of(classA, classB));
+        var codegen = new CCodegen();
+        codegen.prepare(newStaticTestContext(), module);
+
+        var exception = assertThrows(IllegalStateException.class, codegen::generate);
+        assertTrue(
+                exception.getMessage().contains("Inheritance cycle among module classes"),
+                exception.getMessage()
+        );
+    }
+
+    @Test
     void generateRoutesStaticInitializerThroughOverwriteSemantics() {
         var workerClass = new LirClassDef("Worker", "RefCounted");
         var titleProperty = new LirPropertyDef("title", GdStringType.STRING, true, "_field_init_title", null, null, Map.of());

--- a/src/test/java/gd/script/gdcc/backend/c/gen/FuncHeaderCaptureTemplateTest.java
+++ b/src/test/java/gd/script/gdcc/backend/c/gen/FuncHeaderCaptureTemplateTest.java
@@ -89,7 +89,9 @@ class FuncHeaderCaptureTemplateTest {
         );
         return TemplateLoader.renderFromClasspath(
                 "template_451/entry.h.ftl",
-                Map.of("module", module, "helper", helper)
+                // Single-class module: module order already satisfies the base-before-derived
+                // inheritance order entry.h.ftl now requires.
+                Map.of("module", module, "helper", helper, "inheritanceOrderedClassDefs", module.getClassDefs())
         );
     }
 


### PR DESCRIPTION
## Summary
Fix the backend (C codegen) emitting module classes in raw source order: wrapper struct definitions in `entry.h` and ClassDB registration in `entry.c` now follow a single base-before-derived inheritance topology, so derived-first modules compile under Zig and register correctly in Godot. The same topology is reused for the two-phase static initialization order instead of a separate static-subgraph sort.

## What changed
- **`CCodegen`**: new `computeInheritanceClassOrder()` producing a deterministic base-before-derived order over all module classes (direct-superclass constraint, in-module ancestors only, fail-fast `IllegalStateException` on cycles); `computeStaticInitClassOrder()` is now a filter over that shared order (the standalone static-ancestor chain walk is removed); both template models gain `inheritanceOrderedClassDefs`.
- **`entry.h.ftl`**: typedef and wrapper struct definition loops iterate `inheritanceOrderedClassDefs`; template comment documents the by-value `Parent _super;` completeness requirement.
- **`entry.c.ftl`**: the `initialize()` ClassDB registration loop iterates `inheritanceOrderedClassDefs`; comment documents Godot's parent-registered-first requirement.
- **Tests**: `CCodegenTest` gains derived-first struct-definition/registration ordering assertions (with an unrelated class pinning same-pass module-order stability), a module inheritance-cycle fail-fast test, and a filtered static-order locking test covering transitive static dependencies through a non-static intermediate; `FrontendLoweringToCProjectBuilderIntegrationTest` gains a cross-file `extends` end-to-end test (child source deliberately listed before its base) that builds with Zig and runs in Godot, covering engine-side instantiation, `is` / `is_class` / `ClassDB.is_parent_class`, inherited-method dispatch, and base-typed parameter upcast dispatch; `FuncHeaderCaptureTemplateTest` supplies the new template variable for its direct `entry.h.ftl` render.
- **Docs**: `explicit_c_inheritance_layout_contract.md` adds §7 (module class topological-order contract) plus a Godot alignment note and new regression anchors; `object_value_fat_pointer_implementation.md` §4.4 and `frontend_static_var_implementation.md` §5.2 cross-reference the shared topology and state the exact ordering guarantees.

## Why
- `module.classDefs` order follows source file order (the API layer sorts sources by virtual path), so a module can be derived-first; two consumers silently depended on that order:
  - Non-root wrapper structs embed the parent wrapper **by value** as the first field (`Parent _super;`), which is only legal once the parent struct definition is complete — derived-first output fails the C compile with an incomplete-type field.
  - Godot's `_register_extension_class_internal` requires the parent extension class to be already registered (`extension_classes.has(parent_class_name)`), otherwise registration fails with `non-existing parent class` and the class is never registered — derived-first output breaks at runtime even if it compiled.
- One shared topological order (rather than a third per-consumer sort) keeps struct layout, ClassDB registration, and static initialization from drifting apart.
- Design trade-off accepted deliberately: the static-init order is now the static-holding subsequence of the full-class topology. Only base-before-derived (including transitive ancestors through non-static intermediates) is contractual; static classes blocked behind their chain may land after unrelated static classes that follow them in module order. Output stays deterministic, and the static-var contract never guaranteed cross-class initializer order.

## Affected packages/files
- `gd.script.gdcc.backend.c.gen` — `CCodegen.java`
- `src/main/c/codegen/template_451/entry.h.ftl`, `entry.c.ftl`
- `src/test/java/gd/script/gdcc/backend/c/gen/CCodegenTest.java`, `FuncHeaderCaptureTemplateTest.java`
- `src/test/java/gd/script/gdcc/backend/c/build/FrontendLoweringToCProjectBuilderIntegrationTest.java`
- `doc/module_impl/backend/explicit_c_inheritance_layout_contract.md`, `object_value_fat_pointer_implementation.md`, `doc/module_impl/frontend/frontend_static_var_implementation.md`

## Validation
- `script/run-gradle-targeted-tests.sh --tests CCodegenTest` — 72 tests, 0 failures (includes the three new ordering/cycle tests)
- `script/run-gradle-targeted-tests.sh --tests "FrontendLoweringToCProjectBuilderIntegrationTest.lowerFrontendCrossFileInheritanceBuildsNativeLibraryAndRunInGodot"` — Zig build + Godot run pass
- `script/run-gradle-targeted-tests.sh --tests "gd.script.gdcc.backend.c.gen.*"`
- `script/run-gradle-targeted-tests.sh --tests "gd.script.gdcc.backend.c.build.*"`
- `./gradlew clean build --no-daemon --console=plain`

Result: `BUILD SUCCESSFUL` (full suite, including all Zig/Godot integration tests)

## Risks / Notes
- Behavior-contract note: the filtered static-init order no longer guarantees module-relative order for unrelated static classes when one is blocked behind its superclass chain (deterministic per input; base-before-derived still guaranteed). This is documented in `frontend_static_var_implementation.md` §5.2 and locked by `generateEmitsStaticInitAsFilteredInheritanceOrder`.
- Cycle handling stays defensive: the frontend rejects inheritance cycles before lowering; the backend now fails fast with `IllegalStateException` instead of emitting silently unordered C.
- Order-insensitive per-class loops (static backing storage, default-argument userdata, bind-method definitions, object-pointer helpers, constructors/destructors, coroutine state classes) intentionally keep module order to minimize diff.
- Non-goals: multi-module/cross-module `extends` (rejected by the frontend by design); virtual-dispatch semantics for overridden methods (unchanged, static dispatch).

## Key behaviors covered (Optional)
- Derived-first module input: `struct Base` definition precedes `struct Child { Base _super; ... }`; ClassDB registers base before derived.
- Cross-file `extends` (single module): engine-side `Child.new()`, `child is Base`, `child.is_class(...)`, `ClassDB.is_parent_class(...)`, inherited-method dispatch on a child receiver, and base-typed parameter receiving a derived instance through the safe `_super` upcast path.
- Static two-phase init keeps base-before-derived across non-static intermediates (`A -> B -> C` orders `A` after `C` even when `B` declares no statics).

## Diff stats (Optional)
- 9 files changed, 359 insertions(+), 49 deletions(-)

## Breaking changes (Optional)
- None

## Related docs (Optional)
- `doc/module_impl/backend/explicit_c_inheritance_layout_contract.md`
- `doc/module_impl/backend/object_value_fat_pointer_implementation.md`
- `doc/module_impl/frontend/frontend_static_var_implementation.md`