### PR TITLE
feat(api): add analyze-only entrypoint and isolate per-run lowering state

### DIFF
--- a/doc/module_impl/api/rpc_api_implementation.md
+++ b/doc/module_impl/api/rpc_api_implementation.md
@@ -7,7 +7,7 @@
 ## Document Status
 
 - Status: fact source maintained
-- Updated: 2026-04-25
+- Updated: 2026-09-06
 - Scope:
   - `src/main/java/gd/script/gdcc/api/**`
   - `src/test/java/gd/script/gdcc/api/**`
@@ -25,6 +25,10 @@
   - `src/main/java/gd/script/gdcc/api/CompileOptions.java`
   - `src/main/java/gd/script/gdcc/api/CompileResult.java`
   - `src/main/java/gd/script/gdcc/api/CompileTaskSnapshot.java`
+  - `src/main/java/gd/script/gdcc/api/AnalyzeOptions.java`
+  - `src/main/java/gd/script/gdcc/api/AnalysisResult.java`
+  - `src/main/java/gd/script/gdcc/api/AnalysisRunner.java`
+  - `src/main/java/gd/script/gdcc/api/DiagnosticSourcePathRemapper.java`
   - `src/main/java/gd/script/gdcc/api/VfsEntrySnapshot.java`
   - `src/main/java/gd/script/gdcc/api/task/CompileTaskRunner.java`
 - Explicit non-goals:
@@ -42,7 +46,9 @@
 
 `API` is an in-memory facade for controlling the compiler from a remote process through an adapter.
 It owns module state, virtual files, compile configuration, compile task tracking, and publication of
-local build outputs back into module VFS as links.
+local build outputs back into module VFS as links. It also exposes a synchronous analyze-only
+entrypoint so editor-plugin integrations can collect frontend warnings and errors, and optionally
+verify lowering readiness, without running a full compile.
 
 The facade deliberately remains transport-neutral:
 
@@ -82,6 +88,9 @@ The intended layering is:
   - VFS link whose target is another path inside the same module VFS.
 - **Compile task**
   - One asynchronous compile attempt started by `compile(moduleId)`.
+- **Analysis request**
+  - One synchronous analyze-only pass started by `analyze(moduleId, analyzeOptions)`. It reports
+    frontend diagnostics and optional lowering verification without producing artifacts.
 - **Output mount root**
   - VFS directory where successful compile outputs are published as local links.
 
@@ -168,6 +177,26 @@ snapshots and their event logs are retained for a TTL, then removed by a backgro
 
 `recordCurrentCompileTaskEvent(...)` only records into the compile task bound to the current thread.
 Calls outside an API-managed compile thread return `false`.
+
+### 3.6 Module Analysis
+
+- `analyze(moduleId)`
+- `analyze(moduleId, analyzeOptions)`
+
+`analyze(...)` is the synchronous analyze-only entrypoint for editor-plugin style integrations. It
+runs the parser plus the shared semantic pipeline over the module's frozen sources and returns an
+`AnalysisResult` with frontend diagnostics. It never requires `projectPath`, never generates C
+code, never starts a native build, and never touches the module's last compile result.
+
+When `AnalyzeOptions.includeLowering()` is `true`, the pass continues into
+`FrontendLoweringPassManager.lower(...)` after parsing so the caller can verify whether the module
+can currently lower to LIR; the C backend still never runs. Lowering reruns semantic analysis
+through the compile-only gate, so this mode can additionally surface `sema.compile_check`
+diagnostics that plain analysis intentionally skips.
+
+The analysis result surface is deliberately independent from the compile surface: `AnalysisResult`
+and `AnalyzeOptions` are separate DTOs and must not reuse `CompileResult`, compile task snapshots,
+or compile outcomes.
 
 ---
 
@@ -305,6 +334,45 @@ Progress fields:
 
 Parsing progress is counted by source unit. Native build progress is intentionally coarse.
 
+### 4.8 Analyze Options
+
+`AnalyzeOptions` contains:
+
+- `boolean includeLowering`
+
+Defaults: `includeLowering == false`, so `analyze(moduleId)` runs the shared semantic pipeline
+only.
+
+### 4.9 Analysis Result
+
+`AnalysisResult` freezes the observable outcome of one synchronous analysis attempt:
+
+- `outcome`
+- `analyzeOptions`
+- `godotVersion` taken from the module's `CompileOptions`; extension metadata is only loaded once
+  source collection and parsing have succeeded
+- top-level canonical name map
+- source paths using display paths
+- diagnostics snapshot
+- failure message
+- `loweringStatus`
+
+Current outcomes:
+
+- `COMPLETED`: the parse/analyze pipeline (and lowering, when requested) ran to completion.
+  Diagnostics may still contain errors; `COMPLETED` describes the pipeline, not code health.
+- `SOURCE_COLLECTION_FAILED`: module VFS source collection failed before parsing, for example on
+  broken or cyclic virtual links, or the module has no `.gd` sources.
+- `INTERNAL_FAILED`: required compiler metadata such as the Godot extension API could not be
+  loaded.
+
+Lowering status:
+
+- `NOT_REQUESTED`: `includeLowering` was `false`; no lowering answer is available.
+- `SUCCEEDED`: lowering was requested, published a `LirModule`, and diagnostics contain no errors.
+- `FAILED`: lowering was requested but the module cannot currently lower, either because
+  diagnostics contain errors or because the pipeline stopped before LIR publication.
+
 ---
 
 ## 5. Virtual Path Contract
@@ -409,6 +477,34 @@ The result boundary is intentional:
   `generatedFiles`, because only the project builder knows which `GeneratedFile` instances were
   written for the current invocation.
 
+### 7.1 Analysis Pipeline Boundary
+
+One analysis request performs:
+
+1. Freeze compile options, class-name map, and VFS source snapshots through the same module-state
+   freeze used by compile tasks.
+2. Collect `.gd` files from the whole module VFS, with identical link and dedup rules.
+3. Parse each source with `GdScriptParserService.parseUnit(...)`.
+4. Stop after parsing when parse diagnostics contain errors, because semantic phases require a
+   well-formed AST.
+5. Load extension metadata for the module's `CompileOptions.godotVersion` and create
+   `ClassRegistry`.
+6. Run `FrontendSemanticAnalyzer.analyze(...)`, the shared semantic pipeline without the
+   compile-only gate, unless lowering was requested.
+7. When `AnalyzeOptions.includeLowering()` is `true`, run
+   `FrontendLoweringPassManager.lower(...)` instead, which reruns analysis through
+   `analyzeForCompile(...)` and emits a `LirModule` when no errors exist.
+
+The analysis boundary ends before `CCodegen.prepare(...)`: analysis never instantiates C codegen,
+never writes generated files, never invokes a native compiler, and never publishes output links.
+Only `CompileOptions.godotVersion` influences analysis; build-directory, optimization, platform,
+and output-mount settings are compile-only inputs.
+
+Semantic analyzers and lowering passes keep per-run state (for example lambda name counters and
+scope reverse indexes), so each analysis request constructs fresh `FrontendSemanticAnalyzer` /
+`FrontendLoweringPassManager` instances. Analysis never borrows the compile path's long-lived
+lowering pass manager.
+
 ---
 
 ## 8. Concurrency Contract
@@ -419,6 +515,8 @@ Per module:
 
 - VFS reads and writes, link operations, compile options, class-name mapping, snapshots, and
   last-result queries serialize through one module gate.
+- `analyze(moduleId, ...)` is synchronous and also serializes through the module gate, so it waits
+  for a queued or active compile of the same module to finish before its inputs are frozen.
 - `compile(moduleId)` reserves the module's compile slot before returning a task ID.
 - A queued compile prevents later same-module operations from overtaking it before input freeze.
 - Once a compile task becomes active, it holds the module gate until result writeback and output
@@ -574,6 +672,7 @@ Focused API tests currently anchor the contract:
 - compile configuration: `ApiCompileOptionsTest`, `ApiCanonicalNameMapTest`
 - compile pipeline and diagnostics: `ApiCompilePipelineTest`, `ApiCompileDiagnosticsTest`,
   `ApiMappedClassCompileTest`
+- analyze-only surface: `ApiAnalyzeTest`
 - task lifecycle, progress, events, retention: `ApiCompileTaskTest`,
   `ApiCompileTaskProgressTest`, `ApiCompileTaskFailureStageTest`, `ApiCompileTaskEventTest`,
   `ApiCompileTaskTtlTest`

--- a/doc/module_impl/api/rpc_api_implementation.md
+++ b/doc/module_impl/api/rpc_api_implementation.md
@@ -502,8 +502,8 @@ and output-mount settings are compile-only inputs.
 
 Semantic analyzers and lowering passes keep per-run state (for example lambda name counters and
 scope reverse indexes), so each analysis request constructs fresh `FrontendSemanticAnalyzer` /
-`FrontendLoweringPassManager` instances. Analysis never borrows the compile path's long-lived
-lowering pass manager.
+`FrontendLoweringPassManager` instances. Analysis never shares a lowering pass manager with compile
+tasks; both paths construct a fresh instance per request or task.
 
 ---
 
@@ -673,6 +673,7 @@ Focused API tests currently anchor the contract:
 - compile pipeline and diagnostics: `ApiCompilePipelineTest`, `ApiCompileDiagnosticsTest`,
   `ApiMappedClassCompileTest`
 - analyze-only surface: `ApiAnalyzeTest`
+- informational pipeline throughput (no perf thresholds): `ApiCompileThroughputTest`
 - task lifecycle, progress, events, retention: `ApiCompileTaskTest`,
   `ApiCompileTaskProgressTest`, `ApiCompileTaskFailureStageTest`, `ApiCompileTaskEventTest`,
   `ApiCompileTaskTtlTest`

--- a/src/main/java/gd/script/gdcc/api/API.java
+++ b/src/main/java/gd/script/gdcc/api/API.java
@@ -11,7 +11,6 @@ import gd.script.gdcc.exception.ApiModuleAlreadyExistsException;
 import gd.script.gdcc.exception.ApiModuleBusyException;
 import gd.script.gdcc.exception.ApiModuleNotFoundException;
 import gd.script.gdcc.frontend.diagnostic.DiagnosticSnapshot;
-import gd.script.gdcc.frontend.lowering.FrontendLoweringPassManager;
 import gd.script.gdcc.frontend.parse.GdScriptParserService;
 import gd.script.gdcc.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
@@ -40,7 +39,6 @@ public final class API {
 
     private final @NotNull Clock clock;
     private final @NotNull GdScriptParserService parserService;
-    private final @NotNull FrontendLoweringPassManager loweringPassManager;
     private final @NotNull CProjectBuilder projectBuilder;
     private final @NotNull AnalysisRunner analysisRunner;
     private final @NotNull CompileTaskHooks compileTaskHooks;
@@ -53,7 +51,6 @@ public final class API {
         this(
                 Clock.systemUTC(),
                 new GdScriptParserService(),
-                new FrontendLoweringPassManager(),
                 new CProjectBuilder(),
                 CompileTaskHooks.none(),
                 DEFAULT_COMPLETED_COMPILE_TASK_TTL,
@@ -65,7 +62,6 @@ public final class API {
         this(
                 clock,
                 new GdScriptParserService(),
-                new FrontendLoweringPassManager(),
                 new CProjectBuilder(),
                 CompileTaskHooks.none(),
                 DEFAULT_COMPLETED_COMPILE_TASK_TTL,
@@ -76,7 +72,6 @@ public final class API {
     API(
             @NotNull Clock clock,
             @NotNull GdScriptParserService parserService,
-            @NotNull FrontendLoweringPassManager loweringPassManager,
             @NotNull CProjectBuilder projectBuilder,
             @NotNull CompileTaskHooks compileTaskHooks,
             @NotNull Duration completedCompileTaskTtl,
@@ -84,7 +79,6 @@ public final class API {
     ) {
         this.clock = Objects.requireNonNull(clock, "clock must not be null");
         this.parserService = Objects.requireNonNull(parserService, "parserService must not be null");
-        this.loweringPassManager = Objects.requireNonNull(loweringPassManager, "loweringPassManager must not be null");
         this.projectBuilder = Objects.requireNonNull(projectBuilder, "projectBuilder must not be null");
         this.compileTaskHooks = Objects.requireNonNull(compileTaskHooks, "compileTaskHooks must not be null");
         analysisRunner = new AnalysisRunner(parserService);
@@ -313,7 +307,6 @@ public final class API {
                     .unstarted(new CompileTaskRunner(
                             clock,
                             parserService,
-                            loweringPassManager,
                             projectBuilder,
                             taskState,
                             () -> managedModule.awaitCompileTurn(normalizedModuleId, taskId),

--- a/src/main/java/gd/script/gdcc/api/API.java
+++ b/src/main/java/gd/script/gdcc/api/API.java
@@ -42,6 +42,7 @@ public final class API {
     private final @NotNull GdScriptParserService parserService;
     private final @NotNull FrontendLoweringPassManager loweringPassManager;
     private final @NotNull CProjectBuilder projectBuilder;
+    private final @NotNull AnalysisRunner analysisRunner;
     private final @NotNull CompileTaskHooks compileTaskHooks;
     private final @NotNull ConcurrentHashMap<String, ManagedModule> modules = new ConcurrentHashMap<>();
     private final @NotNull ConcurrentHashMap<Long, CompileTaskState> compileTasks = new ConcurrentHashMap<>();
@@ -86,6 +87,7 @@ public final class API {
         this.loweringPassManager = Objects.requireNonNull(loweringPassManager, "loweringPassManager must not be null");
         this.projectBuilder = Objects.requireNonNull(projectBuilder, "projectBuilder must not be null");
         this.compileTaskHooks = Objects.requireNonNull(compileTaskHooks, "compileTaskHooks must not be null");
+        analysisRunner = new AnalysisRunner(parserService);
         compileTaskCleaner = new CompileTaskCleaner(
                 clock,
                 compileTasks,
@@ -263,6 +265,28 @@ public final class API {
     public @Nullable CompileResult getLastCompileResult(@NotNull String moduleId) {
         var normalizedModuleId = normalizeModuleId(moduleId);
         return requireManagedModule(normalizedModuleId).runExclusive(normalizedModuleId, ModuleState::getLastCompileResult);
+    }
+
+    /// Runs one synchronous analyze-only pass over the module's current sources and returns the
+    /// collected frontend diagnostics without producing artifacts. Editor-style callers use this to
+    /// surface warnings and errors without configuring a build directory or polling an asynchronous
+    /// compile task.
+    public @NotNull AnalysisResult analyze(@NotNull String moduleId) {
+        return analyze(moduleId, AnalyzeOptions.defaults());
+    }
+
+    /// When `AnalyzeOptions.includeLowering()` is set, the analysis pass continues into frontend
+    /// lowering to verify whether the module can currently lower to LIR; the C backend still never
+    /// runs. The call serializes through the module gate like any other operation, so it waits for
+    /// a queued or active compile of the same module to finish first, and it never touches the
+    /// module's last compile result.
+    public @NotNull AnalysisResult analyze(@NotNull String moduleId, @NotNull AnalyzeOptions analyzeOptions) {
+        var normalizedModuleId = normalizeModuleId(moduleId);
+        var managedModule = requireManagedModule(normalizedModuleId);
+        var options = Objects.requireNonNull(analyzeOptions, "analyzeOptions must not be null");
+        return managedModule.runExclusive(normalizedModuleId, state ->
+                analysisRunner.analyze(state.freezeCompileRequest(), options)
+        );
     }
 
     /// Publishes one queued compile task immediately, then lets a fresh virtual thread wait for the

--- a/src/main/java/gd/script/gdcc/api/AnalysisResult.java
+++ b/src/main/java/gd/script/gdcc/api/AnalysisResult.java
@@ -1,0 +1,113 @@
+package gd.script.gdcc.api;
+
+import gd.script.gdcc.enums.GodotVersion;
+import gd.script.gdcc.frontend.diagnostic.DiagnosticSnapshot;
+import gd.script.gdcc.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/// Frozen result of one synchronous module analysis attempt.
+///
+/// The result mirrors the transport-friendly shape of `CompileResult` but stays independent from
+/// the compile surface: analysis has no build log, generated files, artifacts, or output links.
+/// `outcome` reports whether the analysis pipeline itself ran to completion; code health is
+/// reported separately through `diagnostics`, which may contain errors even when the outcome is
+/// `COMPLETED`.
+public record AnalysisResult(
+        @NotNull Outcome outcome,
+        @NotNull AnalyzeOptions analyzeOptions,
+        @NotNull GodotVersion godotVersion,
+        @NotNull Map<String, String> topLevelCanonicalNameMap,
+        @NotNull List<String> sourcePaths,
+        @NotNull DiagnosticSnapshot diagnostics,
+        @Nullable String failureMessage,
+        @NotNull LoweringStatus loweringStatus
+) {
+    public AnalysisResult {
+        Objects.requireNonNull(outcome, "outcome must not be null");
+        Objects.requireNonNull(analyzeOptions, "analyzeOptions must not be null");
+        Objects.requireNonNull(godotVersion, "godotVersion must not be null");
+        topLevelCanonicalNameMap = Collections.unmodifiableMap(new LinkedHashMap<>(Objects.requireNonNull(
+                topLevelCanonicalNameMap,
+                "topLevelCanonicalNameMap must not be null"
+        )));
+        sourcePaths = freezeSourcePaths(sourcePaths);
+        Objects.requireNonNull(diagnostics, "diagnostics must not be null");
+        failureMessage = validateFailureMessage(outcome, failureMessage);
+        validateLoweringStatus(outcome, analyzeOptions, loweringStatus);
+    }
+
+    /// Returns whether the analysis pipeline ran to completion. This is intentionally not a
+    /// code-health answer: a completed analysis can still report errors through `diagnostics`.
+    public boolean completed() {
+        return outcome == Outcome.COMPLETED;
+    }
+
+    /// Returns whether the collected diagnostics already contain an error.
+    public boolean hasErrors() {
+        return diagnostics.hasErrors();
+    }
+
+    public enum Outcome {
+        /// The parse/analyze pipeline (and lowering, when requested) ran to completion.
+        COMPLETED,
+        /// Module VFS source collection failed before parsing, for example on broken virtual links.
+        SOURCE_COLLECTION_FAILED,
+        /// Required compiler metadata such as the Godot extension API could not be loaded.
+        INTERNAL_FAILED
+    }
+
+    /// Answers whether the module can currently lower to LIR. Only meaningful when the request
+    /// opted in through `AnalyzeOptions.includeLowering()`; `SUCCEEDED` requires a published LIR
+    /// module and diagnostics without errors.
+    public enum LoweringStatus {
+        NOT_REQUESTED,
+        SUCCEEDED,
+        FAILED
+    }
+
+    private static @NotNull List<String> freezeSourcePaths(@NotNull List<String> sourcePaths) {
+        var frozen = List.copyOf(Objects.requireNonNull(sourcePaths, "sourcePaths must not be null"));
+        for (var sourcePath : frozen) {
+            StringUtil.requireTrimmedNonBlank(sourcePath, "sourcePaths element");
+        }
+        return frozen;
+    }
+
+    private static @Nullable String validateFailureMessage(
+            @NotNull Outcome outcome,
+            @Nullable String failureMessage
+    ) {
+        if (outcome == Outcome.COMPLETED) {
+            if (failureMessage != null) {
+                throw new IllegalArgumentException("failureMessage must be null when outcome is COMPLETED");
+            }
+            return null;
+        }
+        return StringUtil.requireTrimmedNonBlank(failureMessage, "failureMessage");
+    }
+
+    private static @NotNull LoweringStatus validateLoweringStatus(
+            @NotNull Outcome outcome,
+            @NotNull AnalyzeOptions analyzeOptions,
+            @NotNull LoweringStatus loweringStatus
+    ) {
+        Objects.requireNonNull(loweringStatus, "loweringStatus must not be null");
+        if (!analyzeOptions.includeLowering() && loweringStatus != LoweringStatus.NOT_REQUESTED) {
+            throw new IllegalArgumentException("loweringStatus must be NOT_REQUESTED when includeLowering is false");
+        }
+        if (analyzeOptions.includeLowering() && loweringStatus == LoweringStatus.NOT_REQUESTED) {
+            throw new IllegalArgumentException("loweringStatus must not be NOT_REQUESTED when includeLowering is true");
+        }
+        if (outcome != Outcome.COMPLETED && loweringStatus == LoweringStatus.SUCCEEDED) {
+            throw new IllegalArgumentException("loweringStatus cannot be SUCCEEDED when analysis did not complete");
+        }
+        return loweringStatus;
+    }
+}

--- a/src/main/java/gd/script/gdcc/api/AnalysisRunner.java
+++ b/src/main/java/gd/script/gdcc/api/AnalysisRunner.java
@@ -25,8 +25,8 @@ import java.util.stream.Collectors;
 /// matching editor-plugin flows that show warnings and errors without producing artifacts.
 ///
 /// Semantic analyzers and lowering passes keep per-run state (for example lambda name counters and
-/// scope reverse indexes), so every request constructs fresh pipeline instances instead of sharing
-/// the compile path's long-lived `FrontendLoweringPassManager`.
+/// scope reverse indexes), so every request constructs fresh pipeline instances and never shares a
+/// `FrontendLoweringPassManager` with compile tasks, which also construct their own per task.
 final class AnalysisRunner {
     private static final @NotNull DiagnosticSnapshot EMPTY_DIAGNOSTICS = new DiagnosticSnapshot(List.of());
 

--- a/src/main/java/gd/script/gdcc/api/AnalysisRunner.java
+++ b/src/main/java/gd/script/gdcc/api/AnalysisRunner.java
@@ -1,0 +1,194 @@
+package gd.script.gdcc.api;
+
+import gd.script.gdcc.frontend.diagnostic.DiagnosticManager;
+import gd.script.gdcc.frontend.diagnostic.DiagnosticSnapshot;
+import gd.script.gdcc.frontend.lowering.FrontendLoweringPassManager;
+import gd.script.gdcc.frontend.parse.FrontendModule;
+import gd.script.gdcc.frontend.parse.FrontendSourceUnit;
+import gd.script.gdcc.frontend.parse.GdScriptParserService;
+import gd.script.gdcc.frontend.sema.analyzer.FrontendSemanticAnalyzer;
+import gd.script.gdcc.gdextension.ExtensionApiLoader;
+import gd.script.gdcc.scope.ClassRegistry;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/// Executes one synchronous analyze-only request against a frozen module snapshot.
+///
+/// The runner reuses the compiler's parser, shared semantic pipeline, and (on request) the
+/// lowering pipeline, but never enters the C backend: no C code is generated and no native build
+/// starts. Parse and semantic problems surface as diagnostics instead of aborting the request,
+/// matching editor-plugin flows that show warnings and errors without producing artifacts.
+///
+/// Semantic analyzers and lowering passes keep per-run state (for example lambda name counters and
+/// scope reverse indexes), so every request constructs fresh pipeline instances instead of sharing
+/// the compile path's long-lived `FrontendLoweringPassManager`.
+final class AnalysisRunner {
+    private static final @NotNull DiagnosticSnapshot EMPTY_DIAGNOSTICS = new DiagnosticSnapshot(List.of());
+
+    private final @NotNull GdScriptParserService parserService;
+
+    AnalysisRunner(@NotNull GdScriptParserService parserService) {
+        this.parserService = Objects.requireNonNull(parserService, "parserService must not be null");
+    }
+
+    @NotNull AnalysisResult analyze(
+            @NotNull ModuleState.CompileRequest request,
+            @NotNull AnalyzeOptions analyzeOptions
+    ) {
+        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(analyzeOptions, "analyzeOptions must not be null");
+        var sourcePaths = request.sourceSnapshots().stream()
+                .map(ModuleState.SourceSnapshot::displayPath)
+                .toList();
+        if (request.failure() != null) {
+            // Frozen source collection only fails on broken or cyclic virtual links.
+            return failureResult(
+                    AnalysisResult.Outcome.SOURCE_COLLECTION_FAILED,
+                    request,
+                    analyzeOptions,
+                    sourcePaths,
+                    EMPTY_DIAGNOSTICS,
+                    request.failure().message()
+            );
+        }
+        if (request.sourceSnapshots().isEmpty()) {
+            return failureResult(
+                    AnalysisResult.Outcome.SOURCE_COLLECTION_FAILED,
+                    request,
+                    analyzeOptions,
+                    sourcePaths,
+                    EMPTY_DIAGNOSTICS,
+                    "Module '" + request.moduleId() + "' has no .gd source files to analyze"
+            );
+        }
+
+        var diagnostics = new DiagnosticManager();
+        var units = new ArrayList<FrontendSourceUnit>(request.sourceSnapshots().size());
+        for (var sourceSnapshot : request.sourceSnapshots()) {
+            units.add(parserService.parseUnit(
+                    sourceSnapshot.logicalPath(),
+                    sourceSnapshot.source(),
+                    diagnostics
+            ));
+        }
+        var parseDiagnostics = remapDiagnosticSourcePaths(request, diagnostics.snapshot());
+        if (parseDiagnostics.hasErrors()) {
+            // Semantic phases require a well-formed AST, so parse errors end the pipeline with the
+            // diagnostics collected so far instead of failing the whole request.
+            return completedResult(
+                    request,
+                    analyzeOptions,
+                    sourcePaths,
+                    parseDiagnostics,
+                    unverifiedLoweringStatus(analyzeOptions)
+            );
+        }
+
+        final ClassRegistry classRegistry;
+        try {
+            classRegistry = new ClassRegistry(ExtensionApiLoader.loadVersion(request.compileOptions().godotVersion()));
+        } catch (IOException exception) {
+            return failureResult(
+                    AnalysisResult.Outcome.INTERNAL_FAILED,
+                    request,
+                    analyzeOptions,
+                    sourcePaths,
+                    parseDiagnostics,
+                    "Godot extension metadata for "
+                            + request.compileOptions().godotVersion()
+                            + " could not be loaded: "
+                            + exception.getMessage()
+            );
+        }
+        var frontendModule = new FrontendModule(
+                request.moduleName(),
+                units,
+                request.topLevelCanonicalNameMap()
+        );
+        if (!analyzeOptions.includeLowering()) {
+            // The shared semantic entrypoint reports warnings and errors without the compile-only
+            // gate, so editor callers never see `sema.compile_check` diagnostics from this path.
+            new FrontendSemanticAnalyzer().analyze(frontendModule, classRegistry, diagnostics);
+            return completedResult(
+                    request,
+                    analyzeOptions,
+                    sourcePaths,
+                    remapDiagnosticSourcePaths(request, diagnostics.snapshot()),
+                    AnalysisResult.LoweringStatus.NOT_REQUESTED
+            );
+        }
+
+        // Lowering reruns semantic analysis through the compile-ready gate and stops on the first
+        // error, so a published LirModule plus clean diagnostics proves the module can lower. A
+        // fresh pass manager keeps its per-run analyzer state isolated from concurrent compile tasks.
+        var lowered = new FrontendLoweringPassManager().lower(frontendModule, classRegistry, diagnostics);
+        var loweringDiagnostics = remapDiagnosticSourcePaths(request, diagnostics.snapshot());
+        var loweringStatus = lowered != null && !loweringDiagnostics.hasErrors()
+                ? AnalysisResult.LoweringStatus.SUCCEEDED
+                : AnalysisResult.LoweringStatus.FAILED;
+        return completedResult(request, analyzeOptions, sourcePaths, loweringDiagnostics, loweringStatus);
+    }
+
+    private static @NotNull AnalysisResult.LoweringStatus unverifiedLoweringStatus(@NotNull AnalyzeOptions analyzeOptions) {
+        return analyzeOptions.includeLowering()
+                ? AnalysisResult.LoweringStatus.FAILED
+                : AnalysisResult.LoweringStatus.NOT_REQUESTED;
+    }
+
+    private static @NotNull AnalysisResult completedResult(
+            @NotNull ModuleState.CompileRequest request,
+            @NotNull AnalyzeOptions analyzeOptions,
+            @NotNull List<String> sourcePaths,
+            @NotNull DiagnosticSnapshot diagnostics,
+            @NotNull AnalysisResult.LoweringStatus loweringStatus
+    ) {
+        return new AnalysisResult(
+                AnalysisResult.Outcome.COMPLETED,
+                analyzeOptions,
+                request.compileOptions().godotVersion(),
+                request.topLevelCanonicalNameMap(),
+                sourcePaths,
+                diagnostics,
+                null,
+                loweringStatus
+        );
+    }
+
+    private static @NotNull AnalysisResult failureResult(
+            @NotNull AnalysisResult.Outcome outcome,
+            @NotNull ModuleState.CompileRequest request,
+            @NotNull AnalyzeOptions analyzeOptions,
+            @NotNull List<String> sourcePaths,
+            @NotNull DiagnosticSnapshot diagnostics,
+            @NotNull String failureMessage
+    ) {
+        return new AnalysisResult(
+                outcome,
+                analyzeOptions,
+                request.compileOptions().godotVersion(),
+                request.topLevelCanonicalNameMap(),
+                sourcePaths,
+                diagnostics,
+                failureMessage,
+                unverifiedLoweringStatus(analyzeOptions)
+        );
+    }
+
+    private static @NotNull DiagnosticSnapshot remapDiagnosticSourcePaths(
+            @NotNull ModuleState.CompileRequest request,
+            @NotNull DiagnosticSnapshot diagnostics
+    ) {
+        var displayPathsByLogicalPath = request.sourceSnapshots().stream()
+                .collect(Collectors.toMap(
+                        sourceSnapshot -> DiagnosticSourcePathRemapper.logicalPathKey(sourceSnapshot.logicalPath()),
+                        ModuleState.SourceSnapshot::displayPath,
+                        (first, _) -> first
+                ));
+        return DiagnosticSourcePathRemapper.remap(displayPathsByLogicalPath, diagnostics);
+    }
+}

--- a/src/main/java/gd/script/gdcc/api/AnalyzeOptions.java
+++ b/src/main/java/gd/script/gdcc/api/AnalyzeOptions.java
@@ -1,0 +1,18 @@
+package gd.script.gdcc.api;
+
+import org.jetbrains.annotations.NotNull;
+
+/// Per-request settings for `API.analyze(...)`.
+///
+/// @param includeLowering When `true`, the analysis pass runs frontend lowering after parsing —
+/// instead of stopping at the shared semantic entrypoint — so callers can verify whether the
+///                        module can currently lower to LIR. Lowering reruns semantic analysis
+///                        through the compile-only gate. The C backend never runs: no C code is
+///                        generated and no native build starts, regardless of this flag.
+public record AnalyzeOptions(boolean includeLowering) {
+    /// Default analysis runs the shared semantic pipeline only, which matches the editor
+    /// warning/error flow without paying for lowering verification.
+    public static @NotNull AnalyzeOptions defaults() {
+        return new AnalyzeOptions(false);
+    }
+}

--- a/src/main/java/gd/script/gdcc/api/DiagnosticSourcePathRemapper.java
+++ b/src/main/java/gd/script/gdcc/api/DiagnosticSourcePathRemapper.java
@@ -1,0 +1,64 @@
+package gd.script.gdcc.api;
+
+import gd.script.gdcc.frontend.diagnostic.DiagnosticSnapshot;
+import gd.script.gdcc.frontend.diagnostic.FrontendDiagnostic;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+
+/// Shared API-layer remapping from compiler-facing logical source paths to caller-facing display
+/// paths.
+///
+/// Frontend internals still track host-usable logical paths, but API callers care about the
+/// original caller-facing labels such as `res://player.gd`. Compile and analysis results therefore
+/// remap matching frontend diagnostic source paths back to each frozen source snapshot's
+/// `displayPath`. The type is public only because the compile task runner lives in a sub-package;
+/// it is not part of the RPC-facing facade surface.
+public final class DiagnosticSourcePathRemapper {
+    private DiagnosticSourcePathRemapper() {
+    }
+
+    /// The remapping key for one logical path matches the normalized text form frontend
+    /// diagnostics carry, so callers can key their display-path lookup with it directly.
+    public static @NotNull String logicalPathKey(@NotNull Path logicalPath) {
+        return FrontendDiagnostic.sourcePathText(logicalPath);
+    }
+
+    public static @NotNull DiagnosticSnapshot remap(
+            @NotNull Map<String, String> displayPathsByLogicalPath,
+            @NotNull DiagnosticSnapshot diagnostics
+    ) {
+        Objects.requireNonNull(displayPathsByLogicalPath, "displayPathsByLogicalPath must not be null");
+        Objects.requireNonNull(diagnostics, "diagnostics must not be null");
+        if (diagnostics.isEmpty()) {
+            return diagnostics;
+        }
+        var remappedDiagnostics = diagnostics.asList().stream()
+                .map(diagnostic -> remapDiagnostic(diagnostic, displayPathsByLogicalPath))
+                .toList();
+        return new DiagnosticSnapshot(remappedDiagnostics);
+    }
+
+    private static @NotNull FrontendDiagnostic remapDiagnostic(
+            @NotNull FrontendDiagnostic diagnostic,
+            @NotNull Map<String, String> displayPathsByLogicalPath
+    ) {
+        var sourcePath = diagnostic.sourcePath();
+        if (sourcePath == null) {
+            return diagnostic;
+        }
+        var displayPath = displayPathsByLogicalPath.get(sourcePath);
+        if (displayPath == null || Objects.equals(sourcePath, displayPath)) {
+            return diagnostic;
+        }
+        return new FrontendDiagnostic(
+                diagnostic.severity(),
+                diagnostic.category(),
+                diagnostic.message(),
+                displayPath,
+                diagnostic.range()
+        );
+    }
+}

--- a/src/main/java/gd/script/gdcc/api/task/CompileTaskRunner.java
+++ b/src/main/java/gd/script/gdcc/api/task/CompileTaskRunner.java
@@ -3,6 +3,7 @@ package gd.script.gdcc.api.task;
 import gd.script.gdcc.api.CompileOptions;
 import gd.script.gdcc.api.CompileResult;
 import gd.script.gdcc.api.CompileTaskSnapshot;
+import gd.script.gdcc.api.DiagnosticSourcePathRemapper;
 import gd.script.gdcc.api.VfsEntrySnapshot;
 import gd.script.gdcc.backend.CodegenContext;
 import gd.script.gdcc.backend.c.build.CProjectBuilder;
@@ -11,7 +12,6 @@ import gd.script.gdcc.backend.c.gen.CCodegen;
 import gd.script.gdcc.exception.ApiEntryTypeMismatchException;
 import gd.script.gdcc.frontend.diagnostic.DiagnosticManager;
 import gd.script.gdcc.frontend.diagnostic.DiagnosticSnapshot;
-import gd.script.gdcc.frontend.diagnostic.FrontendDiagnostic;
 import gd.script.gdcc.frontend.lowering.FrontendLoweringPassManager;
 import gd.script.gdcc.frontend.parse.FrontendModule;
 import gd.script.gdcc.frontend.parse.FrontendSourceUnit;
@@ -434,40 +434,13 @@ public final class CompileTaskRunner implements Runnable {
             @NotNull Request request,
             @NotNull DiagnosticSnapshot diagnostics
     ) {
-        if (diagnostics.isEmpty()) {
-            return diagnostics;
-        }
         var displayPathsByLogicalPath = request.sourceSnapshots().stream()
                 .collect(Collectors.toMap(
-                        sourceSnapshot -> FrontendDiagnostic.sourcePathText(sourceSnapshot.logicalPath()),
+                        sourceSnapshot -> DiagnosticSourcePathRemapper.logicalPathKey(sourceSnapshot.logicalPath()),
                         SourceSnapshot::displayPath,
                         (first, _) -> first
                 ));
-        var remappedDiagnostics = diagnostics.asList().stream()
-                .map(diagnostic -> remapDiagnosticSourcePath(diagnostic, displayPathsByLogicalPath))
-                .toList();
-        return new DiagnosticSnapshot(remappedDiagnostics);
-    }
-
-    private @NotNull FrontendDiagnostic remapDiagnosticSourcePath(
-            @NotNull FrontendDiagnostic diagnostic,
-            @NotNull Map<String, String> displayPathsByLogicalPath
-    ) {
-        var sourcePath = diagnostic.sourcePath();
-        if (sourcePath == null) {
-            return diagnostic;
-        }
-        var displayPath = displayPathsByLogicalPath.get(sourcePath);
-        if (Objects.equals(sourcePath, displayPath) || displayPath == null) {
-            return diagnostic;
-        }
-        return new FrontendDiagnostic(
-                diagnostic.severity(),
-                diagnostic.category(),
-                diagnostic.message(),
-                displayPath,
-                diagnostic.range()
-        );
+        return DiagnosticSourcePathRemapper.remap(displayPathsByLogicalPath, diagnostics);
     }
 
     private @NotNull CompileResult unexpectedTaskFailure(

--- a/src/main/java/gd/script/gdcc/api/task/CompileTaskRunner.java
+++ b/src/main/java/gd/script/gdcc/api/task/CompileTaskRunner.java
@@ -44,7 +44,6 @@ public final class CompileTaskRunner implements Runnable {
 
     private final @NotNull Clock clock;
     private final @NotNull GdScriptParserService parserService;
-    private final @NotNull FrontendLoweringPassManager loweringPassManager;
     private final @NotNull CProjectBuilder projectBuilder;
     private final @NotNull CompileTaskState taskState;
     private final @NotNull Runnable executionStarter;
@@ -54,7 +53,6 @@ public final class CompileTaskRunner implements Runnable {
     public CompileTaskRunner(
             @NotNull Clock clock,
             @NotNull GdScriptParserService parserService,
-            @NotNull FrontendLoweringPassManager loweringPassManager,
             @NotNull CProjectBuilder projectBuilder,
             @NotNull CompileTaskState taskState,
             @NotNull Runnable executionStarter,
@@ -63,7 +61,6 @@ public final class CompileTaskRunner implements Runnable {
     ) {
         this.clock = Objects.requireNonNull(clock, "clock must not be null");
         this.parserService = Objects.requireNonNull(parserService, "parserService must not be null");
-        this.loweringPassManager = Objects.requireNonNull(loweringPassManager, "loweringPassManager must not be null");
         this.projectBuilder = Objects.requireNonNull(projectBuilder, "projectBuilder must not be null");
         this.taskState = Objects.requireNonNull(taskState, "taskState must not be null");
         this.executionStarter = Objects.requireNonNull(executionStarter, "executionStarter must not be null");
@@ -268,7 +265,10 @@ public final class CompileTaskRunner implements Runnable {
                     request.sourceSnapshots().size(),
                     null
             );
-            var lowered = loweringPassManager.lower(frontendModule, classRegistry, diagnostics);
+            // Each task lowers through a fresh pass manager because semantic analyzers and
+            // lowering passes keep per-run state (lambda name counters, scope reverse indexes)
+            // that must never leak into another module's compile.
+            var lowered = new FrontendLoweringPassManager().lower(frontendModule, classRegistry, diagnostics);
             throwIfCancellationRequested();
             var frontendDiagnostics = remapDiagnosticSourcePaths(request, diagnostics.snapshot());
             if (lowered == null || frontendDiagnostics.hasErrors()) {

--- a/src/test/java/gd/script/gdcc/api/ApiAnalyzeTest.java
+++ b/src/test/java/gd/script/gdcc/api/ApiAnalyzeTest.java
@@ -1,0 +1,423 @@
+package gd.script.gdcc.api;
+
+import gd.script.gdcc.exception.ApiModuleNotFoundException;
+import gd.script.gdcc.frontend.diagnostic.FrontendDiagnosticSeverity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Focused tests for the synchronous analyze-only API surface (`API.analyze(...)`), which serves
+/// editor-plugin warning/error flows without entering the C backend.
+class ApiAnalyzeTest {
+    @Test
+    void analyzeRejectsUnknownModule() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        assertThrows(ApiModuleNotFoundException.class, () -> api.analyze("missing"));
+    }
+
+    @Test
+    void analyzeRejectsModulesWithoutAnySourceFiles() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("demo", "No Source Demo");
+        api.putFile("demo", "/notes/readme.txt", "hello");
+
+        var result = api.analyze("demo");
+
+        assertEquals(AnalysisResult.Outcome.SOURCE_COLLECTION_FAILED, result.outcome());
+        assertFalse(result.completed());
+        assertEquals("Module 'demo' has no .gd source files to analyze", result.failureMessage());
+        assertTrue(result.sourcePaths().isEmpty());
+        assertTrue(result.diagnostics().isEmpty());
+        assertEquals(AnalysisResult.LoweringStatus.NOT_REQUESTED, result.loweringStatus());
+    }
+
+    @Test
+    void analyzeReportsBrokenVirtualLinksDuringSourceCollection() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("demo", "Broken Link Demo");
+        api.createLink("demo", "/src", VfsEntrySnapshot.LinkKind.VIRTUAL, "/missing");
+
+        var result = api.analyze("demo", new AnalyzeOptions(true));
+
+        assertEquals(AnalysisResult.Outcome.SOURCE_COLLECTION_FAILED, result.outcome());
+        assertEquals(
+                "Virtual link '/src' in module 'demo' points to missing path '/missing'",
+                result.failureMessage()
+        );
+        assertTrue(result.diagnostics().isEmpty());
+        assertEquals(AnalysisResult.LoweringStatus.FAILED, result.loweringStatus());
+    }
+
+    @Test
+    void analyzeSucceedsWithoutProjectPathAndSkipsNativeCompiler() {
+        var compiler = ApiCompileTestSupport.RecordingCompiler.succeeding();
+        var api = ApiCompileTestSupport.newApi(compiler);
+
+        api.createModule("demo", "Editor Demo");
+        // Intentionally no setCompileOptions(...): analysis must not require a build directory.
+        api.putFile("demo", "/src/valid.gd", validSource("AnalyzeSmoke"));
+
+        var result = api.analyze("demo");
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertTrue(result.completed());
+        assertNull(result.failureMessage());
+        assertFalse(result.hasErrors());
+        assertEquals(List.of("/src/valid.gd"), result.sourcePaths());
+        assertEquals(AnalysisResult.LoweringStatus.NOT_REQUESTED, result.loweringStatus());
+        assertEquals(0, compiler.invocationCount());
+        assertNull(api.getLastCompileResult("demo"));
+    }
+
+    @Test
+    void analyzeReportsWarningsWithoutFailing() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("demo", "Warning Demo");
+        api.putFile("demo", "/src/warn.gd", """
+                class_name AnalyzeWarning
+                extends Node
+                
+                func user():
+                    var result = await plain()
+                
+                func plain() -> String:
+                    return "x"
+                """);
+
+        var result = api.analyze("demo");
+        var warning = result.diagnostics().asList().stream()
+                .filter(diagnostic -> diagnostic.category().equals("sema.redundant_await"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertFalse(result.hasErrors());
+        assertEquals(FrontendDiagnosticSeverity.WARNING, warning.severity());
+    }
+
+    @Test
+    void analyzeReportsSemanticErrorsAsCompletedDiagnostics() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("demo", "Cycle Demo");
+        api.putFile("demo", "/src/a.gd", """
+                class_name AnalyzeCycleA
+                extends AnalyzeCycleB
+                """);
+        api.putFile("demo", "/src/b.gd", """
+                class_name AnalyzeCycleB
+                extends AnalyzeCycleA
+                """);
+
+        var result = api.analyze("demo");
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertTrue(result.completed());
+        assertTrue(result.hasErrors());
+        assertTrue(result.diagnostics().asList().stream()
+                .anyMatch(diagnostic -> diagnostic.category().equals("sema.inheritance_cycle")));
+        assertEquals(List.of("/src/a.gd", "/src/b.gd"), result.sourcePaths());
+    }
+
+    @Test
+    void analyzeReportsParseErrorsAsCompletedDiagnosticsWithDisplayPaths() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("demo", "Broken Parse Demo");
+        api.putFile("demo", "/src/broken.gd", """
+                class_name AnalyzeBroken
+                extends Node
+                
+                func _ready(
+                    pass
+                """, "res://shown/broken.gd");
+
+        var result = api.analyze("demo");
+        var parseDiagnostic = result.diagnostics().asList().stream()
+                .filter(diagnostic -> diagnostic.category().equals("parse.lowering"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertTrue(result.hasErrors());
+        assertEquals("res://shown/broken.gd", parseDiagnostic.sourcePath());
+        assertEquals(List.of("res://shown/broken.gd"), result.sourcePaths());
+    }
+
+    @Test
+    void analyzeWithoutLoweringSkipsCompileOnlyGate() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("demo", "Compile Gate Demo");
+        api.putFile("demo", "/src/blocked.gd", """
+                class_name AnalyzeLoweringBlockedGetNode
+                extends Node
+                
+                var camera = $Camera3D
+                """);
+
+        // The get-node property initializer is only rejected by the compile-only gate, so plain
+        // analysis completes cleanly and never emits `sema.compile_check` diagnostics.
+        var result = api.analyze("demo");
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertFalse(result.hasErrors());
+        assertTrue(result.diagnostics().asList().stream()
+                .noneMatch(diagnostic -> diagnostic.category().equals("sema.compile_check")));
+        assertEquals(AnalysisResult.LoweringStatus.NOT_REQUESTED, result.loweringStatus());
+    }
+
+    @Test
+    void analyzeWithLoweringVerifiesLowerableModuleWithoutNativeBuild() {
+        var compiler = ApiCompileTestSupport.RecordingCompiler.succeeding();
+        var api = ApiCompileTestSupport.newApi(compiler);
+
+        api.createModule("demo", "Lowering Demo");
+        api.putFile("demo", "/src/valid.gd", validSource("AnalyzeLoweringSmoke"));
+
+        var result = api.analyze("demo", new AnalyzeOptions(true));
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertFalse(result.hasErrors());
+        assertEquals(AnalysisResult.LoweringStatus.SUCCEEDED, result.loweringStatus());
+        assertEquals(0, compiler.invocationCount());
+        assertNull(api.getLastCompileResult("demo"));
+        assertTrue(api.listDirectory("demo", "/").isEmpty()
+                || api.listDirectory("demo", "/").stream()
+                        .noneMatch(entry -> entry.name().equals("__build__")));
+    }
+
+    @Test
+    void analyzeWithLoweringReportsUnlowerableModule() {
+        var compiler = ApiCompileTestSupport.RecordingCompiler.succeeding();
+        var api = ApiCompileTestSupport.newApi(compiler);
+
+        api.createModule("demo", "Lowering Blocked Demo");
+        api.putFile("demo", "/src/blocked.gd", """
+                class_name AnalyzeUnlowerableGetNode
+                extends Node
+                
+                var camera = $Camera3D
+                """);
+
+        var result = api.analyze("demo", new AnalyzeOptions(true));
+        var compileDiagnostic = result.diagnostics().asList().stream()
+                .filter(diagnostic -> diagnostic.category().equals("sema.compile_check"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertTrue(result.hasErrors());
+        assertTrue(compileDiagnostic.message().contains("Get-node expression"));
+        assertEquals(AnalysisResult.LoweringStatus.FAILED, result.loweringStatus());
+        assertEquals(0, compiler.invocationCount());
+    }
+
+    @Test
+    void analyzeWithLoweringMarksParseErrorsAsLoweringFailure() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("demo", "Parse Lowering Demo");
+        api.putFile("demo", "/src/broken.gd", """
+                class_name AnalyzeParseLowering
+                extends Node
+                
+                func _ready(
+                    pass
+                """);
+
+        // Parse errors end the pipeline before lowering can run, so the lowering answer is FAILED
+        // while the analysis outcome stays COMPLETED with the parse diagnostics attached.
+        var result = api.analyze("demo", new AnalyzeOptions(true));
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertTrue(result.hasErrors());
+        assertTrue(result.diagnostics().asList().stream()
+                .anyMatch(diagnostic -> diagnostic.category().equals("parse.lowering")));
+        assertEquals(AnalysisResult.LoweringStatus.FAILED, result.loweringStatus());
+    }
+
+    @Test
+    void analyzeAfterSuccessfulCompileKeepsLastCompileResult(@TempDir Path tempDir) {
+        var compiler = ApiCompileTestSupport.RecordingCompiler.succeeding();
+        var api = ApiCompileTestSupport.newApi(compiler);
+
+        api.createModule("demo", "Compile Then Analyze Demo");
+        api.setCompileOptions("demo", ApiCompileTestSupport.compileOptions(tempDir.resolve("compile-then-analyze-project")));
+        api.putFile("demo", "/src/valid.gd", validSource("AnalyzeAfterCompileSmoke"));
+
+        var compileResult = ApiCompileTestSupport.awaitResult(api, api.compile("demo"));
+        assertEquals(CompileResult.Outcome.SUCCESS, compileResult.outcome());
+
+        var analysisResult = api.analyze("demo", new AnalyzeOptions(true));
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, analysisResult.outcome());
+        assertEquals(AnalysisResult.LoweringStatus.SUCCEEDED, analysisResult.loweringStatus());
+        assertSame(compileResult, api.getLastCompileResult("demo"));
+        assertEquals(1, compiler.invocationCount());
+    }
+
+    @Test
+    void analyzeRunsConcurrentlyAcrossIndependentModules() throws InterruptedException {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("first", "First Concurrent Demo");
+        api.putFile("first", "/src/first.gd", lambdaSource("AnalyzeConcurrentFirst"));
+        api.createModule("second", "Second Concurrent Demo");
+        api.putFile("second", "/src/second.gd", lambdaSource("AnalyzeConcurrentSecond"));
+
+        // Module gates are independent, so both analyses really can overlap; each request must
+        // still observe its own fresh semantic analyzer state.
+        var startGate = new CountDownLatch(1);
+        var firstResult = new AtomicReference<AnalysisResult>();
+        var secondResult = new AtomicReference<AnalysisResult>();
+        var firstFailure = new AtomicReference<Throwable>();
+        var secondFailure = new AtomicReference<Throwable>();
+        var firstThread = Thread.ofVirtual().start(() -> {
+            await(startGate);
+            try {
+                firstResult.set(api.analyze("first", new AnalyzeOptions(true)));
+            } catch (Throwable throwable) {
+                firstFailure.set(throwable);
+            }
+        });
+        var secondThread = Thread.ofVirtual().start(() -> {
+            await(startGate);
+            try {
+                secondResult.set(api.analyze("second", new AnalyzeOptions(true)));
+            } catch (Throwable throwable) {
+                secondFailure.set(throwable);
+            }
+        });
+        startGate.countDown();
+        firstThread.join(TimeUnit.SECONDS.toMillis(30));
+        secondThread.join(TimeUnit.SECONDS.toMillis(30));
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+        assertNull(firstFailure.get());
+        assertNull(secondFailure.get());
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, Objects.requireNonNull(firstResult.get()).outcome());
+        assertFalse(firstResult.get().hasErrors());
+        assertEquals(AnalysisResult.LoweringStatus.SUCCEEDED, firstResult.get().loweringStatus());
+        assertEquals(List.of("/src/first.gd"), firstResult.get().sourcePaths());
+        assertEquals(AnalysisResult.Outcome.COMPLETED, Objects.requireNonNull(secondResult.get()).outcome());
+        assertFalse(secondResult.get().hasErrors());
+        assertEquals(AnalysisResult.LoweringStatus.SUCCEEDED, secondResult.get().loweringStatus());
+        assertEquals(List.of("/src/second.gd"), secondResult.get().sourcePaths());
+    }
+
+    @Test
+    void analyzeSequentiallyReusesApiAcrossLambdaModules() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("first", "First Lambda Demo");
+        api.putFile("first", "/src/first.gd", lambdaSource("AnalyzeLambdaFirst"));
+        api.createModule("second", "Second Lambda Demo");
+        api.putFile("second", "/src/second.gd", lambdaSource("AnalyzeLambdaSecond"));
+
+        // FrontendSuiteResolver keeps per-run lambda state, so the second analysis on the same API
+        // instance must observe a fresh resolver instead of stale scope/counter state from the first.
+        var firstResult = api.analyze("first");
+        var secondResult = api.analyze("second");
+
+        assertEquals(AnalysisResult.Outcome.COMPLETED, firstResult.outcome());
+        assertFalse(firstResult.hasErrors());
+        assertEquals(AnalysisResult.Outcome.COMPLETED, secondResult.outcome());
+        assertFalse(secondResult.hasErrors());
+    }
+
+    @Test
+    void analyzeSequentiallyReusesApiAcrossLambdaModulesWithLowering() {
+        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("first", "First Lambda Lowering Demo");
+        api.putFile("first", "/src/first.gd", lambdaSource("AnalyzeLambdaLoweringFirst"));
+        api.createModule("second", "Second Lambda Lowering Demo");
+        api.putFile("second", "/src/second.gd", lambdaSource("AnalyzeLambdaLoweringSecond"));
+
+        // Same per-run state isolation requirement as the analyze-only path, but through the
+        // lowering pipeline's own compile-ready analysis pass.
+        var firstResult = api.analyze("first", new AnalyzeOptions(true));
+        var secondResult = api.analyze("second", new AnalyzeOptions(true));
+
+        assertEquals(AnalysisResult.LoweringStatus.SUCCEEDED, firstResult.loweringStatus());
+        assertEquals(AnalysisResult.LoweringStatus.SUCCEEDED, secondResult.loweringStatus());
+        assertEquals(List.of("/src/first.gd"), firstResult.sourcePaths());
+        assertEquals(List.of("/src/second.gd"), secondResult.sourcePaths());
+    }
+
+    @Test
+    void analyzeWaitsForModuleGateBehindOtherOperations() throws InterruptedException {        var api = ApiCompileTestSupport.newApi(ApiCompileTestSupport.RecordingCompiler.succeeding());
+
+        api.createModule("demo", "Gate Demo");
+        api.putFile("demo", "/src/valid.gd", validSource("AnalyzeGateSmoke"));
+
+        var blocker = ApiCompileTestSupport.blockModuleOperation(api, "demo");
+        assertTrue(blocker.awaitEntered());
+        var resultRef = new AtomicReference<AnalysisResult>();
+        var analyzeThread = Thread.ofVirtual()
+                .name("gdcc-api-test-analyze-gate")
+                .start(() -> resultRef.set(api.analyze("demo")));
+        try {
+            ApiCompileTestSupport.sleepForProgressPolling();
+            assertNull(resultRef.get());
+        } finally {
+            blocker.close();
+        }
+        analyzeThread.join(TimeUnit.SECONDS.toMillis(30));
+        assertFalse(analyzeThread.isAlive());
+
+        var result = Objects.requireNonNull(resultRef.get());
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertFalse(result.hasErrors());
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for test start gate", exception);
+        }
+    }
+
+    private static String lambdaSource(String className) {
+        return """
+                class_name %s
+                extends RefCounted
+                
+                func make() -> Callable:
+                    var add := func(a: int, b: int) -> int:
+                        return a + b
+                    return add
+                """.formatted(className);
+    }
+
+    private static String validSource(String className) {
+        return """
+                class_name %s
+                extends RefCounted
+                
+                func value() -> int:
+                    return 1
+                """.formatted(className);
+    }
+}

--- a/src/test/java/gd/script/gdcc/api/ApiCompilePipelineTest.java
+++ b/src/test/java/gd/script/gdcc/api/ApiCompilePipelineTest.java
@@ -173,4 +173,45 @@ class ApiCompilePipelineTest {
         var bindHeader = Files.readString(projectPath.resolve("engine_method_binds.h"));
         assertTrue(bindHeader.contains("static inline godot_int godot_Probe_READY(void)"), bindHeader);
     }
+
+    @Test
+    void sequentialCompilesReuseApiAcrossLambdaModules(@TempDir Path tempDir) {
+        var compiler = ApiCompileTestSupport.RecordingCompiler.succeeding();
+        var api = ApiCompileTestSupport.newApi(compiler);
+
+        // Both modules deliberately reuse the same class name so a stale per-run resolver would
+        // collide on the lambda name counter as well as the scope reverse index.
+        api.createModule("first", "First Lambda Compile Demo");
+        api.setCompileOptions("first", ApiCompileTestSupport.compileOptions(tempDir.resolve("first-lambda-project")));
+        api.putFile("first", "/src/first.gd", lambdaSource("CompileLambdaShared"));
+        api.createModule("second", "Second Lambda Compile Demo");
+        api.setCompileOptions("second", ApiCompileTestSupport.compileOptions(tempDir.resolve("second-lambda-project")));
+        api.putFile("second", "/src/second.gd", lambdaSource("CompileLambdaShared"));
+
+        // FrontendSuiteResolver keeps per-run lambda state, so the second compile on the same API
+        // instance must observe a fresh lowering pipeline instead of stale scope/counter state
+        // left behind by the first compile.
+        var firstResult = ApiCompileTestSupport.awaitResult(api, api.compile("first"));
+        var secondResult = ApiCompileTestSupport.awaitResult(api, api.compile("second"));
+
+        assertEquals(CompileResult.Outcome.SUCCESS, firstResult.outcome());
+        assertFalse(firstResult.diagnostics().hasErrors());
+        assertEquals(List.of("/src/first.gd"), firstResult.sourcePaths());
+        assertEquals(CompileResult.Outcome.SUCCESS, secondResult.outcome());
+        assertFalse(secondResult.diagnostics().hasErrors());
+        assertEquals(List.of("/src/second.gd"), secondResult.sourcePaths());
+        assertEquals(2, compiler.invocationCount());
+    }
+
+    private static String lambdaSource(String className) {
+        return """
+                class_name %s
+                extends RefCounted
+                
+                func make() -> Callable:
+                    var add := func(a: int, b: int) -> int:
+                        return a + b
+                    return add
+                """.formatted(className);
+    }
 }

--- a/src/test/java/gd/script/gdcc/api/ApiCompileTestSupport.java
+++ b/src/test/java/gd/script/gdcc/api/ApiCompileTestSupport.java
@@ -7,7 +7,6 @@ import gd.script.gdcc.backend.c.build.COptimizationLevel;
 import gd.script.gdcc.backend.c.build.CProjectBuilder;
 import gd.script.gdcc.backend.c.build.TargetPlatform;
 import gd.script.gdcc.enums.GodotVersion;
-import gd.script.gdcc.frontend.lowering.FrontendLoweringPassManager;
 import gd.script.gdcc.frontend.parse.GdScriptParserService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -103,7 +102,6 @@ final class ApiCompileTestSupport {
         return new API(
                 clock,
                 new GdScriptParserService(),
-                new FrontendLoweringPassManager(),
                 projectBuilder,
                 compileTaskHooks,
                 completedCompileTaskTtl,

--- a/src/test/java/gd/script/gdcc/api/ApiCompileThroughputTest.java
+++ b/src/test/java/gd/script/gdcc/api/ApiCompileThroughputTest.java
@@ -1,0 +1,182 @@
+package gd.script.gdcc.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Informational throughput measurements for the common API use cases: one module holding a single
+/// script and one project-style module holding several cross-referencing scripts. The native
+/// compiler is a recording stub, so the numbers cover the API freeze/parse/analyze/lowering/codegen
+/// pipeline only. Results are printed as `[gdcc-api-throughput]` lines for humans; the test asserts
+/// correctness of every run but intentionally sets no performance threshold, keeping it stable
+/// across machines.
+class ApiCompileThroughputTest {
+    private static final int WARMUP_ITERATIONS = 20;
+    private static final int MEASURED_ITERATIONS = 50;
+
+    @Test
+    void reportsSingleScriptCompileThroughput(@TempDir Path tempDir) {
+        var compiler = ApiCompileTestSupport.RecordingCompiler.succeeding();
+        var api = ApiCompileTestSupport.newApi(compiler);
+        api.createModule("demo", "Single Script Compile Throughput");
+        api.setCompileOptions("demo", ApiCompileTestSupport.compileOptions(tempDir.resolve("single-compile-project")));
+        api.putFile("demo", "/src/player.gd", singleScriptSource());
+
+        measureCompileRuns(api, "demo", "compile/single-script", 1);
+    }
+
+    @Test
+    void reportsMultiScriptProjectCompileThroughput(@TempDir Path tempDir) {
+        var compiler = ApiCompileTestSupport.RecordingCompiler.succeeding();
+        var api = ApiCompileTestSupport.newApi(compiler);
+        api.createModule("demo", "Multi Script Compile Throughput");
+        api.setCompileOptions("demo", ApiCompileTestSupport.compileOptions(tempDir.resolve("multi-compile-project")));
+        putProjectScripts(api);
+
+        measureCompileRuns(api, "demo", "compile/multi-script-project", 4);
+    }
+
+    @Test
+    void reportsSingleScriptAnalyzeThroughput(@TempDir Path tempDir) {
+        var compiler = ApiCompileTestSupport.RecordingCompiler.succeeding();
+        var api = ApiCompileTestSupport.newApi(compiler);
+        api.createModule("demo", "Single Script Analyze Throughput");
+        api.setCompileOptions("demo", ApiCompileTestSupport.compileOptions(tempDir.resolve("single-analyze-project")));
+        api.putFile("demo", "/src/player.gd", singleScriptSource());
+
+        measureAnalyzeRuns(api, "demo", "analyze/single-script", 1);
+    }
+
+    @Test
+    void reportsMultiScriptProjectAnalyzeThroughput(@TempDir Path tempDir) {
+        var compiler = ApiCompileTestSupport.RecordingCompiler.succeeding();
+        var api = ApiCompileTestSupport.newApi(compiler);
+        api.createModule("demo", "Multi Script Analyze Throughput");
+        api.setCompileOptions("demo", ApiCompileTestSupport.compileOptions(tempDir.resolve("multi-analyze-project")));
+        putProjectScripts(api);
+
+        measureAnalyzeRuns(api, "demo", "analyze/multi-script-project", 4);
+    }
+
+    private static void measureCompileRuns(API api, String moduleId, String scenario, int scriptsPerRun) {
+        for (var warmup = 0; warmup < WARMUP_ITERATIONS; warmup++) {
+            assertCompileSucceeded(api, moduleId);
+        }
+        var startedNanos = System.nanoTime();
+        for (var iteration = 0; iteration < MEASURED_ITERATIONS; iteration++) {
+            assertCompileSucceeded(api, moduleId);
+        }
+        report(scenario, scriptsPerRun, System.nanoTime() - startedNanos);
+    }
+
+    private static void measureAnalyzeRuns(API api, String moduleId, String scenario, int scriptsPerRun) {
+        for (var warmup = 0; warmup < WARMUP_ITERATIONS; warmup++) {
+            assertAnalyzeSucceeded(api, moduleId);
+        }
+        var startedNanos = System.nanoTime();
+        for (var iteration = 0; iteration < MEASURED_ITERATIONS; iteration++) {
+            assertAnalyzeSucceeded(api, moduleId);
+        }
+        report(scenario, scriptsPerRun, System.nanoTime() - startedNanos);
+    }
+
+    private static void assertCompileSucceeded(API api, String moduleId) {
+        var result = ApiCompileTestSupport.awaitResult(api, api.compile(moduleId));
+        assertEquals(CompileResult.Outcome.SUCCESS, result.outcome());
+        assertTrue(result.diagnostics().isEmpty(), () -> result.diagnostics().toString());
+    }
+
+    private static void assertAnalyzeSucceeded(API api, String moduleId) {
+        var result = api.analyze(moduleId, new AnalyzeOptions(true));
+        assertEquals(AnalysisResult.Outcome.COMPLETED, result.outcome());
+        assertEquals(AnalysisResult.LoweringStatus.SUCCEEDED, result.loweringStatus());
+        assertTrue(result.diagnostics().isEmpty(), () -> result.diagnostics().toString());
+    }
+
+    private static void report(String scenario, int scriptsPerRun, long totalNanos) {
+        var totalMillis = totalNanos / 1_000_000.0;
+        var runsPerSecond = MEASURED_ITERATIONS * 1_000_000_000.0 / totalNanos;
+        System.out.printf(
+                Locale.ROOT,
+                "[gdcc-api-throughput] scenario=%s runs=%d scripts/run=%d total=%.1fms avg=%.2fms/run runs/s=%.2f scripts/s=%.2f%n",
+                scenario,
+                MEASURED_ITERATIONS,
+                scriptsPerRun,
+                totalMillis,
+                totalMillis / MEASURED_ITERATIONS,
+                runsPerSecond,
+                runsPerSecond * scriptsPerRun
+        );
+    }
+
+    /// A small player-style script mixing the constructs typical projects use most: typed state,
+    /// `_ready`, a while loop, and cross-method calls.
+    private static String singleScriptSource() {
+        return """
+                class_name ThroughputPlayer
+                extends Node
+                
+                var speed: int = 4
+                var _position: int = 0
+                
+                func _ready() -> void:
+                    _position = advance(speed)
+                
+                func advance(steps: int) -> int:
+                    var total := 0
+                    var step := 0
+                    while step < steps:
+                        total = total + step
+                        step = step + 1
+                    return _position + total
+                """;
+    }
+
+    /// One project-style module with four cross-referencing scripts: a utility, a worker using it,
+    /// a coordinator using the worker, and a node entry script using the coordinator.
+    private static void putProjectScripts(API api) {
+        api.putFile("demo", "/src/math_util.gd", """
+                class_name ThroughputMathUtil
+                extends RefCounted
+                
+                func scale(value: int, factor: int) -> int:
+                    return value * factor
+                """);
+        api.putFile("demo", "/src/worker.gd", """
+                class_name ThroughputWorker
+                extends RefCounted
+                
+                func work(amount: int) -> int:
+                    var util := ThroughputMathUtil.new()
+                    var total := 0
+                    var index := 0
+                    while index < amount:
+                        total = total + util.scale(index, 2)
+                        index = index + 1
+                    return total
+                """);
+        api.putFile("demo", "/src/coordinator.gd", """
+                class_name ThroughputCoordinator
+                extends RefCounted
+                
+                func run() -> int:
+                    var worker := ThroughputWorker.new()
+                    return worker.work(8)
+                """);
+        api.putFile("demo", "/src/main.gd", """
+                class_name ThroughputMain
+                extends Node
+                
+                var score: int = 0
+                
+                func _ready() -> void:
+                    var coordinator := ThroughputCoordinator.new()
+                    score = coordinator.run()
+                """);
+    }
+}

--- a/src/test/java/gd/script/gdcc/cli/CliCompileTestSupport.java
+++ b/src/test/java/gd/script/gdcc/cli/CliCompileTestSupport.java
@@ -9,7 +9,6 @@ import gd.script.gdcc.backend.c.build.CCompiler;
 import gd.script.gdcc.backend.c.build.COptimizationLevel;
 import gd.script.gdcc.backend.c.build.CProjectBuilder;
 import gd.script.gdcc.backend.c.build.TargetPlatform;
-import gd.script.gdcc.frontend.lowering.FrontendLoweringPassManager;
 import gd.script.gdcc.frontend.parse.GdScriptParserService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -50,7 +49,6 @@ final class CliCompileTestSupport {
             var constructor = API.class.getDeclaredConstructor(
                     Clock.class,
                     GdScriptParserService.class,
-                    FrontendLoweringPassManager.class,
                     CProjectBuilder.class,
                     CompileTaskHooks.class,
                     Duration.class,
@@ -60,7 +58,6 @@ final class CliCompileTestSupport {
             return constructor.newInstance(
                     Clock.systemUTC(),
                     new GdScriptParserService(),
-                    new FrontendLoweringPassManager(),
                     projectBuilder,
                     hooks,
                     COMPLETED_TASK_TTL,


### PR DESCRIPTION
## Summary

Adds a synchronous analyze-only entrypoint to the compiler control API (`gd.script.gdcc.api`) so editor-plugin integrations can collect frontend warnings/errors and optionally verify lowering readiness without a full compile. Also fixes a latent compile-path bug where tasks shared per-run lowering state across modules.

## What changed

- New RPC-facing DTOs: `AnalyzeOptions` (`includeLowering`) and `AnalysisResult` (`Outcome`: `COMPLETED`/`SOURCE_COLLECTION_FAILED`/`INTERNAL_FAILED`; `LoweringStatus`: `NOT_REQUESTED`/`SUCCEEDED`/`FAILED`), kept independent from `CompileResult` and the compile task surface.
- New synchronous `API.analyze(moduleId[, analyzeOptions])`, serialized through the per-module gate and running against frozen source snapshots; it never requires `projectPath`, never generates C code, never starts a native build, and never touches the module's last compile result.
- New package-private `AnalysisRunner`: parse → shared `FrontendSemanticAnalyzer.analyze(...)` (no compile-only gate); with `includeLowering`, runs a fresh `FrontendLoweringPassManager.lower(...)` instead, so `sema.compile_check` readiness is reported through `LoweringStatus`.
- Extracted `DiagnosticSourcePathRemapper`, now shared by analysis and compile for logical-path → display-path remapping (compile behavior unchanged).
- `CompileTaskRunner` constructs a fresh `FrontendLoweringPassManager` per task; `API` no longer holds a shared lowering pass manager (constructor injection seam removed, test supports updated).
- Tests: new `ApiAnalyzeTest` (editor diagnostics, warnings, optional lowering, gate serialization, sequential/concurrent module reuse), compile regression `ApiCompilePipelineTest.sequentialCompilesReuseApiAcrossLambdaModules`, and informational `ApiCompileThroughputTest` (single-script and multi-script project throughput for compile and analyze, printed as `[gdcc-api-throughput]` lines, no performance thresholds).
- Documentation: `rpc_api_implementation.md` gains the analysis surface (§3.6), data model (§4.8/§4.9), pipeline boundary (§7.1), concurrency note, and test anchors.

## Why

- The compile API could only run end-to-end compilation, so an editor plugin had no way to show warnings/errors without configuring a build directory and waiting for a native build. This mirrors Godot's editor validation model (`GDScriptParser` + `GDScriptAnalyzer` only, no compiler), mapped onto gdcc's existing analyze / analyzeForCompile / lowering layering.
- Root cause of the bundled fix: `FrontendSuiteResolver` keeps per-run state (`cachedScopeToAstIndex`, `lambdaNameCountersByOwningClass`) that is never reset and whose contract assumes a per-run instance. A shared analyzer/manager reused across runs made the second lambda-bearing run on the same `API` instance fail (stale scope identity cache → `IllegalStateException`, wrapped as `BUILD_FAILED`) — reproduced by the new regression tests before the fix, green after. Per-request/per-task construction was chosen over adding reset hooks because it cannot forget a state field again.

## Affected packages/files

- `gd.script.gdcc.api`: `API`, `AnalyzeOptions`, `AnalysisResult`, `AnalysisRunner`, `DiagnosticSourcePathRemapper`
- `gd.script.gdcc.api.task`: `CompileTaskRunner`
- Tests: `ApiAnalyzeTest`, `ApiCompilePipelineTest`, `ApiCompileThroughputTest`, `ApiCompileTestSupport`, `CliCompileTestSupport`
- `doc/module_impl/api/rpc_api_implementation.md`

## Validation

- `script/run-gradle-targeted-tests.sh --tests ApiAnalyzeTest`
- `script/run-gradle-targeted-tests.sh --tests ApiCompileThroughputTest`
- `script/run-gradle-targeted-tests.sh --tests "gd.script.gdcc.api.*,gd.script.gdcc.cli.*"`
- `./gradlew classes --no-daemon --info --console=plain`

Result: `BUILD SUCCESSFUL`

## Risks / Notes

- `analyze(...)` is synchronous and serializes through the module gate, so it waits behind a queued or active compile of the same module; async task-based analysis is a deliberate non-goal for now.
- `INTERNAL_FAILED` currently only covers Godot extension-metadata load failures; unexpected runtime exceptions propagate to the caller/adapter.
- Test-suite harness runners (`GdScriptUnitTestCompileRunner`, `GdScriptBenchmarkRunner`) still reuse one lowering pass manager across scripts — a pre-existing test-infrastructure concern outside the API compile path; follow-up candidate if lambda scripts enter those suites.
- No IR validation, ownership lifecycle, type compatibility, or codegen semantics changes; `CompileResult` and the compile task contract are untouched.

## Key behaviors covered (Optional)

- `COMPLETED` reports pipeline completion, not code health; errors/warnings stay in `diagnostics` even when analysis completes.
- Plain analysis never emits `sema.compile_check`; `includeLowering=true` reruns analysis through the compile-ready gate and reports the answer as `LoweringStatus`.
- Both analysis requests and compile tasks get fully isolated per-run lowering/analyzer state (sequential and concurrent lambda-module coverage).

## Diff stats (Optional)

- 12 files changed, 1168 insertions(+), 48 deletions(-)

## Breaking changes (Optional)

- None. The public surface only gains methods/DTOs; the removed constructor parameter lived on a package-private constructor.

## Related docs (Optional)

- `doc/module_impl/api/rpc_api_implementation.md`
- `doc/pr_message_guideline.md`